### PR TITLE
替换滚动视图

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -988,7 +988,7 @@
       <Version>7.1.0-rc2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.7.0-prerelease.210827001</Version>
+      <Version>2.7.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>
@@ -997,7 +997,7 @@
       <Version>5.1.0</Version>
     </PackageReference>
     <PackageReference Include="Richasy.ExpanderEx.UWP">
-      <Version>1.0.2</Version>
+      <Version>1.0.3</Version>
     </PackageReference>
     <PackageReference Include="Richasy.FluentIcon.Regular.UWP">
       <Version>1.1.135</Version>

--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -978,11 +978,14 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.12</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Toolkit.Uwp.UI">
+      <Version>7.1.0-rc2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Animations">
-      <Version>7.0.2</Version>
+      <Version>7.1.0-rc2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
-      <Version>7.0.2</Version>
+      <Version>7.1.0-rc2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.7.0-prerelease.210827001</Version>
@@ -998,9 +1001,6 @@
     </PackageReference>
     <PackageReference Include="Richasy.FluentIcon.Regular.UWP">
       <Version>1.1.135</Version>
-    </PackageReference>
-    <PackageReference Include="Richasy.Shadow.UWP">
-      <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>

--- a/src/App/Controls/App/QuestionPanel.xaml
+++ b/src/App/Controls/App/QuestionPanel.xaml
@@ -44,7 +44,7 @@
                         <muxc:NavigationViewItem Content="{x:Bind Name}" Tag="{x:Bind Id}" />
                     </DataTemplate>
                 </muxc:NavigationView.MenuItemTemplate>
-                <muxc:ScrollView
+                <ScrollViewer
                     x:Name="QuestionScrollView"
                     HorizontalScrollMode="Disabled"
                     VerticalScrollBarVisibility="Hidden">
@@ -83,7 +83,7 @@
                             <muxc:StackLayout Spacing="8" />
                         </muxc:ItemsRepeater.Layout>
                     </muxc:ItemsRepeater>
-                </muxc:ScrollView>
+                </ScrollViewer>
             </muxc:NavigationView>
         </Grid>
     </local:CardPanel>

--- a/src/App/Controls/CardPanel/CardPanel.cs
+++ b/src/App/Controls/CardPanel/CardPanel.cs
@@ -2,8 +2,8 @@
 
 using System;
 using System.Numerics;
+using Microsoft.Toolkit.Uwp.UI;
 using Microsoft.Toolkit.Uwp.UI.Animations;
-using Richasy.Shadow.Uwp;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation.Peers;
@@ -70,11 +70,11 @@ namespace Richasy.Bili.App.Controls
                 return;
             }
 
-            var attachedShadow = Shadows.GetAttachedShadow(instance._rootContainer);
+            var attachedShadow = Effects.GetShadow(instance._rootContainer);
             var isEnabled = Convert.ToBoolean(e.NewValue);
             if (isEnabled && attachedShadow != null)
             {
-                instance._rootContainer.ClearValue(Shadows.AttachedShadowProperty);
+                instance._rootContainer.ClearValue(Effects.ShadowProperty);
                 instance.DestroyShadow();
             }
             else
@@ -113,10 +113,10 @@ namespace Richasy.Bili.App.Controls
                 return;
             }
 
-            var attachedShadow = Shadows.GetAttachedShadow(this._rootContainer);
+            var attachedShadow = Effects.GetShadow(this._rootContainer);
             if (!this.IsEnableShadow && attachedShadow != null)
             {
-                this._rootContainer.ClearValue(Shadows.AttachedShadowProperty);
+                this._rootContainer.ClearValue(Effects.ShadowProperty);
                 return;
             }
 
@@ -163,7 +163,7 @@ namespace Richasy.Bili.App.Controls
                 return;
             }
 
-            var shadowContext = Shadows.GetAttachedShadow(this._rootContainer)?.GetElementContext(this._rootContainer);
+            var shadowContext = Effects.GetShadow(this._rootContainer)?.GetElementContext(this._rootContainer);
 
             if (shadowContext?.SpriteVisual != null)
             {
@@ -210,7 +210,7 @@ namespace Richasy.Bili.App.Controls
                 return;
             }
 
-            var shadowContext = Shadows.GetAttachedShadow(this._rootContainer)?.GetElementContext(this._rootContainer);
+            var shadowContext = Effects.GetShadow(this._rootContainer)?.GetElementContext(this._rootContainer);
 
             if (shadowContext?.SpriteVisual != null)
             {
@@ -278,7 +278,7 @@ namespace Richasy.Bili.App.Controls
                     break;
             }
 
-            var shadowContext = Shadows.GetAttachedShadow(this._rootContainer)?.GetElementContext(this._rootContainer);
+            var shadowContext = Effects.GetShadow(this._rootContainer)?.GetElementContext(this._rootContainer);
 
             if (shadowContext?.Shadow != null)
             {
@@ -314,7 +314,7 @@ namespace Richasy.Bili.App.Controls
                 batch.Dispose();
             }
 
-            var shadowContext = Shadows.GetAttachedShadow(this._rootContainer)?.GetElementContext(this._rootContainer);
+            var shadowContext = Effects.GetShadow(this._rootContainer)?.GetElementContext(this._rootContainer);
 
             // Set SpriteVisible.IsVisible to false when the hide animation is complete to make sure it doesn't use GPU resources.
             if (!this.IsPointerOver && this._shadowCreated && shadowContext?.SpriteVisual != null)

--- a/src/App/Controls/CardPanel/CardPanel.xaml
+++ b/src/App/Controls/CardPanel/CardPanel.xaml
@@ -2,8 +2,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Richasy.Bili.App.Controls"
-    xmlns:shadow="using:Richasy.Shadow.Uwp">
-    <shadow:RoundedCornerAttachedShadow
+    xmlns:shadow="using:Microsoft.Toolkit.Uwp.UI">
+    <shadow:AttachedDropShadow
         x:Key="DefaultCardShadow"
         BlurRadius="4"
         CornerRadius="8" />
@@ -35,7 +35,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:CardPanel">
-                    <Grid x:Name="RootContainer" shadow:Shadows.AttachedShadow="{StaticResource DefaultCardShadow}">
+                    <Grid x:Name="RootContainer" shadow:Effects.Shadow="{StaticResource DefaultCardShadow}">
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">

--- a/src/App/Controls/Common/ReaderView.xaml
+++ b/src/App/Controls/Common/ReaderView.xaml
@@ -21,10 +21,10 @@
             ActionContent="{loc:LocaleLocator Name=Refresh}"
             Text="{x:Bind ViewModel.ErrorText, Mode=OneWay}"
             Visibility="{x:Bind ViewModel.IsError, Mode=OneWay}" />
-        <muxc:WebView2
+        <WebView
             x:Name="ReaderWebView"
             VerticalAlignment="Stretch"
-            Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}"
-            WebMessageReceived="OnWebMessageReceivedAsync" />
+            ScriptNotify="OnScriptNotifyAsync"
+            Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}" />
     </Grid>
 </local:CenterPopup>

--- a/src/App/Controls/Common/ReaderView.xaml.cs
+++ b/src/App/Controls/Common/ReaderView.xaml.cs
@@ -2,9 +2,10 @@
 
 using System;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
 using Richasy.Bili.Locator.Uwp;
 using Richasy.Bili.Models.App.Constants;
+using Richasy.Bili.Models.App.Other;
 using Richasy.Bili.Toolkit.Interfaces;
 using Richasy.Bili.ViewModels.Uwp;
 using Windows.System;
@@ -59,7 +60,6 @@ namespace Richasy.Bili.App.Controls
             Title = vm.Title;
             if (!_isPreLoaded)
             {
-                await ReaderWebView.EnsureCoreWebView2Async().AsTask();
                 ReaderWebView.NavigateToString(string.Empty);
                 _isPreLoaded = true;
             }
@@ -101,21 +101,14 @@ namespace Richasy.Bili.App.Controls
             await LoadContentAsync();
         }
 
-        private void OnClosed(object sender, EventArgs e)
-        {
-            ReaderWebView.NavigateToString(string.Empty);
-        }
+        private void OnClosed(object sender, EventArgs e) => ReaderWebView.NavigateToString(string.Empty);
 
-        private async void OnWebMessageReceivedAsync(Microsoft.UI.Xaml.Controls.WebView2 sender, Microsoft.Web.WebView2.Core.CoreWebView2WebMessageReceivedEventArgs args)
+        private async void OnScriptNotifyAsync(object sender, Windows.UI.Xaml.Controls.NotifyEventArgs e)
         {
-            var str = args.TryGetWebMessageAsString();
-            var jobj = JObject.Parse(str);
-            var key = jobj["Key"].ToString();
-            var value = jobj["Value"].ToString();
-
-            if (key == AppConstants.LinkClickEvent)
+            var data = JsonConvert.DeserializeObject<KeyValue<string>>(e.Value);
+            if (data.Key == AppConstants.LinkClickEvent)
             {
-                await Launcher.LaunchUriAsync(new Uri(value));
+                await Launcher.LaunchUriAsync(new Uri(data.Value));
             }
         }
     }

--- a/src/App/Controls/Common/ReplyView.xaml
+++ b/src/App/Controls/Common/ReplyView.xaml
@@ -43,7 +43,7 @@
             </ComboBox>
         </Grid>
         <Grid Grid.Row="1">
-            <muxc:ScrollView
+            <ScrollViewer
                 x:Name="ContentScrollViewer"
                 HorizontalScrollMode="Disabled"
                 VerticalScrollBarVisibility="Hidden">
@@ -58,7 +58,7 @@
                         </DataTemplate>
                     </local:VerticalRepeaterView.ItemTemplate>
                 </local:VerticalRepeaterView>
-            </muxc:ScrollView>
+            </ScrollViewer>
             <local:OverlayLoadingPanel IsBarActive="{x:Bind ViewModel.IsDeltaLoading, Mode=OneWay}" IsRingActive="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay}" />
             <local:ErrorPanel
                 ActionButtonClick="OnReplyRefreshButtonClickAsync"

--- a/src/App/Controls/Common/ReplyView.xaml.cs
+++ b/src/App/Controls/Common/ReplyView.xaml.cs
@@ -69,7 +69,7 @@ namespace Richasy.Bili.App.Controls
             OrderTypeComboBox.SelectedIndex = ViewModel.CurrentMode == Mode.MainListHot ? 0 : 1;
             if (!ViewModel.IsRequested)
             {
-                ContentScrollViewer.ScrollTo(0, 0);
+                ContentScrollViewer.ChangeView(0, 0, 1);
                 await ViewModel.InitializeRequestAsync();
             }
         }

--- a/src/App/Controls/Common/VerticalRepeaterView.xaml.cs
+++ b/src/App/Controls/Common/VerticalRepeaterView.xaml.cs
@@ -81,7 +81,6 @@ namespace Richasy.Bili.App.Controls
             DependencyProperty.Register(nameof(IsStaggered), typeof(bool), typeof(VerticalRepeaterView), new PropertyMetadata(false, new PropertyChangedCallback(OnIsStaggeredChanged)));
 
         private ScrollViewer _parentScrollViewer;
-        private ScrollView _parentScrollView;
         private double _itemHolderHeight = 0d;
 
         /// <summary>
@@ -241,18 +240,10 @@ namespace Richasy.Bili.App.Controls
         {
             if (EnableDetectParentScrollViewer)
             {
-                _parentScrollView = this.FindAscendantElementByType<ScrollView>();
-                if (_parentScrollView == null)
+                _parentScrollViewer = this.FindAscendantElementByType<ScrollViewer>();
+                if (_parentScrollViewer != null)
                 {
-                    _parentScrollViewer = this.FindAscendantElementByType<ScrollViewer>();
-                    if (_parentScrollViewer != null)
-                    {
-                        _parentScrollViewer.ViewChanged += OnParentScrollViewerViewChanged;
-                    }
-                }
-                else
-                {
-                    _parentScrollView.ViewChanged += OnParentScrollViewViewChanged;
+                    _parentScrollViewer.ViewChanged += OnParentScrollViewerViewChanged;
                 }
             }
         }
@@ -264,12 +255,6 @@ namespace Richasy.Bili.App.Controls
                 _parentScrollViewer.ViewChanged -= OnParentScrollViewerViewChanged;
                 _parentScrollViewer = null;
             }
-
-            if (_parentScrollView != null)
-            {
-                _parentScrollView.ViewChanged -= OnParentScrollViewViewChanged;
-                _parentScrollView = null;
-            }
         }
 
         private void OnParentScrollViewerViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
@@ -278,19 +263,6 @@ namespace Richasy.Bili.App.Controls
             {
                 var currentPosition = _parentScrollViewer.VerticalOffset;
                 if (_parentScrollViewer.ScrollableHeight - currentPosition <= _itemHolderHeight &&
-                    this.Visibility == Visibility.Visible)
-                {
-                    RequestLoadMore?.Invoke(this, EventArgs.Empty);
-                }
-            }
-        }
-
-        private void OnParentScrollViewViewChanged(ScrollView sender, object args)
-        {
-            if (_parentScrollView != null)
-            {
-                var currentPosition = _parentScrollView.VerticalOffset;
-                if (_parentScrollView.ScrollableHeight - currentPosition <= _itemHolderHeight &&
                     this.Visibility == Visibility.Visible)
                 {
                     RequestLoadMore?.Invoke(this, EventArgs.Empty);
@@ -328,13 +300,13 @@ namespace Richasy.Bili.App.Controls
                 if (IsAutoFillEnable &&
                     args.Element is IRepeaterItem repeaterItem &&
                     ItemsSource is ICollection collectionSource &&
-                    (_parentScrollViewer != null || _parentScrollView != null) &&
+                    (_parentScrollViewer != null) &&
                     args.Index >= collectionSource.Count - 1)
                 {
                     var size = repeaterItem.GetHolderSize();
                     _itemHolderHeight = size.Height;
-                    var viewportWidth = _parentScrollView != null ? _parentScrollView.ViewportWidth : _parentScrollViewer.ViewportWidth;
-                    var viewportHeight = _parentScrollView != null ? _parentScrollView.ViewportHeight : _parentScrollViewer.ViewportHeight;
+                    var viewportWidth = _parentScrollViewer.ViewportWidth;
+                    var viewportHeight = _parentScrollViewer.ViewportHeight;
                     bool isNeedLoadMore;
                     if (double.IsInfinity(size.Width))
                     {

--- a/src/App/Controls/Favorite/ArticleFavoritePanel.xaml
+++ b/src/App/Controls/Favorite/ArticleFavoritePanel.xaml
@@ -32,7 +32,7 @@
                 </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
-        <muxc:ScrollView
+        <ScrollViewer
             x:Name="ContentScrollViewer"
             Padding="{StaticResource DefaultContainerPadding}"
             HorizontalScrollMode="Disabled"
@@ -62,7 +62,7 @@
                     </DataTemplate>
                 </local:VerticalRepeaterView.ItemTemplate>
             </local:VerticalRepeaterView>
-        </muxc:ScrollView>
+        </ScrollViewer>
 
         <local:OverlayLoadingPanel IsBarActive="{x:Bind ViewModel.IsDeltaLoading, Mode=OneWay}" IsRingActive="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay}" />
         <local:ErrorPanel

--- a/src/App/Controls/Favorite/FavoriteVideoView.xaml
+++ b/src/App/Controls/Favorite/FavoriteVideoView.xaml
@@ -68,7 +68,7 @@
         </Grid>
         <Grid Grid.Row="1">
             <Grid>
-                <muxc:ScrollView HorizontalScrollMode="Disabled" VerticalScrollBarVisibility="Hidden">
+                <ScrollViewer HorizontalScrollMode="Disabled" VerticalScrollBarVisibility="Hidden">
                     <local:VerticalRepeaterView
                         x:Name="VideoView"
                         Margin="0,0,0,12"
@@ -108,7 +108,7 @@
                             </DataTemplate>
                         </local:VerticalRepeaterView.ItemTemplate>
                     </local:VerticalRepeaterView>
-                </muxc:ScrollView>
+                </ScrollViewer>
 
                 <local:OverlayLoadingPanel
                     MinHeight="80"

--- a/src/App/Controls/Favorite/PgcFavoritePanel.xaml
+++ b/src/App/Controls/Favorite/PgcFavoritePanel.xaml
@@ -33,7 +33,7 @@
                 </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
-        <muxc:ScrollView
+        <ScrollViewer
             x:Name="ContentScrollViewer"
             Padding="{StaticResource DefaultContainerPadding}"
             HorizontalScrollMode="Disabled"
@@ -65,7 +65,7 @@
                     </DataTemplate>
                 </local:VerticalRepeaterView.ItemTemplate>
             </local:VerticalRepeaterView>
-        </muxc:ScrollView>
+        </ScrollViewer>
 
         <local:OverlayLoadingPanel IsBarActive="{x:Bind ViewModel.IsDeltaLoading, Mode=OneWay}" IsRingActive="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay}" />
         <local:ErrorPanel

--- a/src/App/Controls/Favorite/VideoFavoritePanel.xaml
+++ b/src/App/Controls/Favorite/VideoFavoritePanel.xaml
@@ -34,7 +34,7 @@
                 </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
-        <muxc:ScrollView
+        <ScrollViewer
             x:Name="ContentScrollViewer"
             Padding="{StaticResource DefaultContainerPadding}"
             HorizontalScrollMode="Disabled"
@@ -238,7 +238,7 @@
                     </muxc:ItemsRepeater.ItemTemplate>
                 </muxc:ItemsRepeater>
             </Grid>
-        </muxc:ScrollView>
+        </ScrollViewer>
         <local:OverlayLoadingPanel IsRingActive="{x:Bind ViewModel.IsVideoInitializeLoading, Mode=OneWay}" />
 
         <local:ErrorPanel

--- a/src/App/Controls/Live/FollowLiveView.xaml
+++ b/src/App/Controls/Live/FollowLiveView.xaml
@@ -72,7 +72,7 @@
         </Grid>
 
 
-        <muxc:ScrollView
+        <ScrollViewer
             x:Name="ContentScrollViewer"
             Grid.Row="1"
             HorizontalScrollMode="Disabled"
@@ -93,6 +93,6 @@
                     </DataTemplate>
                 </muxc:ItemsRepeater.ItemTemplate>
             </muxc:ItemsRepeater>
-        </muxc:ScrollView>
+        </ScrollViewer>
     </Grid>
 </UserControl>

--- a/src/App/Controls/Pgc/PgcDetailView.xaml
+++ b/src/App/Controls/Pgc/PgcDetailView.xaml
@@ -90,7 +90,7 @@
                 </Grid>
             </Grid>
         </Grid>
-        <muxc:ScrollView
+        <ScrollViewer
             Grid.Row="1"
             HorizontalScrollMode="Disabled"
             VerticalScrollBarVisibility="Hidden">
@@ -148,7 +148,7 @@
                         FontWeight="Bold"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         Text="{loc:LocaleLocator Name=CastAndCrew}" />
-                    <muxc:ScrollView
+                    <ScrollViewer
                         HorizontalScrollBarVisibility="Hidden"
                         HorizontalScrollMode="Enabled"
                         VerticalScrollMode="Disabled">
@@ -190,7 +190,7 @@
                                 </DataTemplate>
                             </muxc:ItemsRepeater.ItemTemplate>
                         </muxc:ItemsRepeater>
-                    </muxc:ScrollView>
+                    </ScrollViewer>
                 </StackPanel>
 
                 <StackPanel
@@ -241,6 +241,6 @@
                         TextWrapping="Wrap" />
                 </StackPanel>
             </Grid>
-        </muxc:ScrollView>
+        </ScrollViewer>
     </Grid>
 </local:CenterPopup>

--- a/src/App/Controls/Pgc/PgcPlayListView.xaml
+++ b/src/App/Controls/Pgc/PgcPlayListView.xaml
@@ -25,7 +25,7 @@
             Text="{x:Bind ViewModel.TotalCount, Mode=OneWay}"
             TextWrapping="Wrap" />
         <Grid Grid.Row="1">
-            <muxc:ScrollView HorizontalScrollMode="Disabled" VerticalScrollBarVisibility="Hidden">
+            <ScrollViewer HorizontalScrollMode="Disabled" VerticalScrollBarVisibility="Hidden">
                 <Grid>
                     <local:VerticalRepeaterView
                         x:Name="SeasonView"
@@ -46,7 +46,7 @@
                     </local:VerticalRepeaterView>
 
                 </Grid>
-            </muxc:ScrollView>
+            </ScrollViewer>
             <local:OverlayLoadingPanel
                 MinHeight="80"
                 IsBarActive="{x:Bind ViewModel.IsDeltaLoading, Mode=OneWay}"

--- a/src/App/Controls/Player/PlayerComponent.cs
+++ b/src/App/Controls/Player/PlayerComponent.cs
@@ -16,7 +16,7 @@ namespace Richasy.Bili.App.Controls
         /// <see cref="VerticalScrollMode"/>的依赖属性.
         /// </summary>
         public static readonly DependencyProperty VerticalScrollModeProperty =
-            DependencyProperty.Register(nameof(VerticalScrollMode), typeof(ScrollingScrollMode), typeof(PlayerComponent), new PropertyMetadata(ScrollingScrollMode.Enabled));
+            DependencyProperty.Register(nameof(VerticalScrollMode), typeof(ScrollMode), typeof(PlayerComponent), new PropertyMetadata(ScrollMode.Enabled));
 
         /// <summary>
         /// 播放器视图模型.
@@ -26,9 +26,9 @@ namespace Richasy.Bili.App.Controls
         /// <summary>
         /// 垂直滚动方式.
         /// </summary>
-        public ScrollingScrollMode VerticalScrollMode
+        public ScrollMode VerticalScrollMode
         {
-            get { return (ScrollingScrollMode)GetValue(VerticalScrollModeProperty); }
+            get { return (ScrollMode)GetValue(VerticalScrollModeProperty); }
             set { SetValue(VerticalScrollModeProperty, value); }
         }
     }

--- a/src/App/Controls/Player/Related/EpisodeView.xaml
+++ b/src/App/Controls/Player/Related/EpisodeView.xaml
@@ -12,7 +12,7 @@
     d:DesignWidth="400"
     mc:Ignorable="d">
 
-    <muxc:ScrollView
+    <ScrollViewer
         HorizontalScrollMode="Disabled"
         VerticalScrollBarVisibility="Hidden"
         VerticalScrollMode="{x:Bind VerticalScrollMode, Mode=OneWay}">
@@ -66,5 +66,5 @@
                 </DataTemplate>
             </controls:VerticalRepeaterView.ItemTemplate>
         </controls:VerticalRepeaterView>
-    </muxc:ScrollView>
+    </ScrollViewer>
 </controls:PlayerComponent>

--- a/src/App/Controls/Player/Related/PgcSectionView.xaml
+++ b/src/App/Controls/Player/Related/PgcSectionView.xaml
@@ -11,7 +11,7 @@
     d:DesignWidth="400"
     mc:Ignorable="d">
 
-    <muxc:ScrollView
+    <ScrollViewer
         HorizontalScrollMode="Disabled"
         VerticalScrollBarVisibility="Hidden"
         VerticalScrollMode="{x:Bind VerticalScrollMode, Mode=OneWay}">
@@ -74,5 +74,5 @@
                 <muxc:StackLayout Spacing="20" />
             </muxc:ItemsRepeater.Layout>
         </muxc:ItemsRepeater>
-    </muxc:ScrollView>
+    </ScrollViewer>
 </controls:PlayerComponent>

--- a/src/App/Controls/Player/Related/RelatedVideoView.xaml
+++ b/src/App/Controls/Player/Related/RelatedVideoView.xaml
@@ -12,7 +12,7 @@
     d:DesignWidth="400"
     mc:Ignorable="d">
 
-    <muxc:ScrollView
+    <ScrollViewer
         HorizontalScrollMode="Disabled"
         VerticalScrollBarVisibility="Hidden"
         VerticalScrollMode="{x:Bind VerticalScrollMode, Mode=OneWay}">
@@ -32,5 +32,5 @@
                 </DataTemplate>
             </controls:VerticalRepeaterView.ItemTemplate>
         </controls:VerticalRepeaterView>
-    </muxc:ScrollView>
+    </ScrollViewer>
 </controls:PlayerComponent>

--- a/src/App/Controls/Player/Related/SeasonView.xaml
+++ b/src/App/Controls/Player/Related/SeasonView.xaml
@@ -12,7 +12,7 @@
     d:DesignWidth="400"
     mc:Ignorable="d">
 
-    <muxc:ScrollView
+    <ScrollViewer
         HorizontalScrollMode="Disabled"
         VerticalScrollBarVisibility="Hidden"
         VerticalScrollMode="{x:Bind VerticalScrollMode, Mode=OneWay}">
@@ -68,5 +68,5 @@
                 </DataTemplate>
             </controls:VerticalRepeaterView.ItemTemplate>
         </controls:VerticalRepeaterView>
-    </muxc:ScrollView>
+    </ScrollViewer>
 </controls:PlayerComponent>

--- a/src/App/Controls/Player/Related/VideoPartView.xaml
+++ b/src/App/Controls/Player/Related/VideoPartView.xaml
@@ -12,7 +12,7 @@
     d:DesignWidth="400"
     mc:Ignorable="d">
 
-    <muxc:ScrollView
+    <ScrollViewer
         HorizontalScrollMode="Disabled"
         VerticalScrollBarVisibility="Hidden"
         VerticalScrollMode="{x:Bind VerticalScrollMode, Mode=OneWay}">
@@ -55,5 +55,5 @@
                 </DataTemplate>
             </controls:VerticalRepeaterView.ItemTemplate>
         </controls:VerticalRepeaterView>
-    </muxc:ScrollView>
+    </ScrollViewer>
 </controls:PlayerComponent>

--- a/src/App/Controls/User/UserView.xaml
+++ b/src/App/Controls/User/UserView.xaml
@@ -133,7 +133,7 @@
             </Border>
         </Grid>
         <Grid Grid.Row="1">
-            <muxc:ScrollView
+            <ScrollViewer
                 x:Name="ContentScrollViewer"
                 HorizontalScrollMode="Disabled"
                 VerticalScrollBarVisibility="Hidden">
@@ -159,7 +159,7 @@
                         </DataTemplate>
                     </local:VerticalRepeaterView.ItemTemplate>
                 </local:VerticalRepeaterView>
-            </muxc:ScrollView>
+            </ScrollViewer>
 
             <local:OverlayLoadingPanel
                 MinHeight="80"

--- a/src/App/Pages/DynamicFeedPage.xaml
+++ b/src/App/Pages/DynamicFeedPage.xaml
@@ -32,7 +32,7 @@
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
 
-        <muxc:ScrollView
+        <ScrollViewer
             x:Name="ContentScrollViewer"
             Grid.Row="1"
             Padding="{StaticResource DefaultContainerPadding}"
@@ -52,7 +52,7 @@
                     </DataTemplate>
                 </controls:VerticalRepeaterView.ItemTemplate>
             </controls:VerticalRepeaterView>
-        </muxc:ScrollView>
+        </ScrollViewer>
 
         <controls:OverlayLoadingPanel IsBarActive="{x:Bind ViewModel.IsDeltaLoading, Mode=OneWay}" IsRingActive="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay}" />
         <controls:ErrorPanel

--- a/src/App/Pages/HelpPage.xaml
+++ b/src/App/Pages/HelpPage.xaml
@@ -128,7 +128,7 @@
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                 Text="{loc:LocaleLocator Name=RelatedProjects}"
                                 TextTrimming="CharacterEllipsis" />
-                            <muxc:ScrollView
+                            <ScrollViewer
                                 x:Name="LinkScrollViewer"
                                 Grid.Row="1"
                                 HorizontalScrollBarVisibility="Hidden"
@@ -147,7 +147,7 @@
                                         </DataTemplate>
                                     </muxc:ItemsRepeater.ItemTemplate>
                                 </muxc:ItemsRepeater>
-                            </muxc:ScrollView>
+                            </ScrollViewer>
                         </Grid>
                     </controls:CardPanel>
                 </Grid>
@@ -159,7 +159,7 @@
         </Grid>
 
 
-        <muxc:ScrollView
+        <ScrollViewer
             x:Name="NarrowScrollView"
             Padding="{StaticResource NarrowContainerPadding}"
             HorizontalScrollMode="Disabled"
@@ -173,6 +173,6 @@
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
             </Grid>
-        </muxc:ScrollView>
+        </ScrollViewer>
     </Grid>
 </Page>

--- a/src/App/Pages/LivePage.xaml
+++ b/src/App/Pages/LivePage.xaml
@@ -79,7 +79,7 @@
         </Grid>
 
         <Grid>
-            <muxc:ScrollView
+            <ScrollViewer
                 x:Name="RootScrollViewer"
                 Padding="0,0,24,0"
                 HorizontalScrollMode="Disabled"
@@ -151,7 +151,7 @@
                         </controls:VerticalRepeaterView>
                     </Grid>
                 </Grid>
-            </muxc:ScrollView>
+            </ScrollViewer>
         </Grid>
 
 

--- a/src/App/Pages/Overlay/FansPage.xaml
+++ b/src/App/Pages/Overlay/FansPage.xaml
@@ -46,7 +46,7 @@
         </TextBlock>
 
         <Grid Grid.Row="1">
-            <muxc:ScrollView
+            <ScrollViewer
                 x:Name="ContentScrollViewer"
                 Grid.Row="1"
                 Padding="{StaticResource DefaultContainerPadding}"
@@ -68,7 +68,7 @@
                         </DataTemplate>
                     </controls:VerticalRepeaterView.ItemTemplate>
                 </controls:VerticalRepeaterView>
-            </muxc:ScrollView>
+            </ScrollViewer>
 
             <controls:OverlayLoadingPanel IsBarActive="{x:Bind ViewModel.IsDeltaLoading, Mode=OneWay}" IsRingActive="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay}" />
             <controls:ErrorPanel

--- a/src/App/Pages/Overlay/FollowsPage.xaml
+++ b/src/App/Pages/Overlay/FollowsPage.xaml
@@ -45,7 +45,7 @@
         </TextBlock>
 
         <Grid Grid.Row="1">
-            <muxc:ScrollView
+            <ScrollViewer
                 x:Name="ContentScrollViewer"
                 Grid.Row="1"
                 Padding="{StaticResource DefaultContainerPadding}"
@@ -67,7 +67,7 @@
                         </DataTemplate>
                     </controls:VerticalRepeaterView.ItemTemplate>
                 </controls:VerticalRepeaterView>
-            </muxc:ScrollView>
+            </ScrollViewer>
 
             <controls:OverlayLoadingPanel IsBarActive="{x:Bind ViewModel.IsDeltaLoading, Mode=OneWay}" IsRingActive="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay}" />
             <controls:ErrorPanel

--- a/src/App/Pages/Overlay/HistoryPage.xaml
+++ b/src/App/Pages/Overlay/HistoryPage.xaml
@@ -41,7 +41,7 @@
             FontWeight="Bold"
             Text="{loc:LocaleLocator Name=ViewHistory}" />
         <Grid Grid.Row="1">
-            <muxc:ScrollView
+            <ScrollViewer
                 x:Name="ContentScrollViewer"
                 Padding="{StaticResource DefaultContainerPadding}"
                 HorizontalScrollMode="Disabled"
@@ -98,7 +98,7 @@
                         </controls:VerticalRepeaterView.ItemTemplate>
                     </controls:VerticalRepeaterView>
                 </Grid>
-            </muxc:ScrollView>
+            </ScrollViewer>
 
             <controls:OverlayLoadingPanel IsBarActive="{x:Bind ViewModel.IsDeltaLoading, Mode=OneWay}" IsRingActive="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay}" />
             <controls:ErrorPanel

--- a/src/App/Pages/Overlay/MessagePage.xaml
+++ b/src/App/Pages/Overlay/MessagePage.xaml
@@ -77,7 +77,7 @@
             </muxc:NavigationView.PaneFooter>
 
             <Grid>
-                <muxc:ScrollView
+                <ScrollViewer
                     x:Name="ContentScrollViewer"
                     Padding="{StaticResource DefaultContainerPadding}"
                     HorizontalScrollMode="Disabled"
@@ -87,7 +87,7 @@
                         <controls:AtMessageView x:Name="AtMessageView" Visibility="Collapsed" />
                         <controls:ReplyMessageView x:Name="ReplyMessageView" Visibility="Collapsed" />
                     </Grid>
-                </muxc:ScrollView>
+                </ScrollViewer>
                 <controls:OverlayLoadingPanel IsBarActive="{x:Bind ViewModel.IsDeltaLoading, Mode=OneWay}" IsRingActive="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay}" />
                 <controls:ErrorPanel
                     ActionButtonClick="OnRefreshButtonClickAsync"

--- a/src/App/Pages/Overlay/PartitionDetailPage.xaml
+++ b/src/App/Pages/Overlay/PartitionDetailPage.xaml
@@ -74,7 +74,7 @@
             </muxc:NavigationView.MenuItemTemplate>
             <muxc:NavigationView.Content>
                 <Grid>
-                    <muxc:ScrollView
+                    <ScrollViewer
                         x:Name="ContentScrollViewer"
                         Padding="{StaticResource DefaultContainerPadding}"
                         HorizontalScrollMode="Disabled"
@@ -139,7 +139,7 @@
                                 </controls:VerticalRepeaterView.ItemTemplate>
                             </controls:VerticalRepeaterView>
                         </Grid>
-                    </muxc:ScrollView>
+                    </ScrollViewer>
 
                     <controls:OverlayLoadingPanel IsBarActive="{x:Bind ViewModel.CurrentSelectedSubPartition.IsDeltaLoading, Mode=OneWay}" IsRingActive="{x:Bind ViewModel.CurrentSelectedSubPartition.IsInitializeLoading, Mode=OneWay}" />
                     <controls:ErrorPanel

--- a/src/App/Pages/Overlay/PgcIndexPage.xaml
+++ b/src/App/Pages/Overlay/PgcIndexPage.xaml
@@ -87,7 +87,7 @@
         </Grid>
 
         <Grid Grid.Row="2" Margin="0,12,0,0">
-            <muxc:ScrollView
+            <ScrollViewer
                 x:Name="ContentScrollViewer"
                 Padding="{StaticResource DefaultContainerPadding}"
                 HorizontalScrollMode="Disabled"
@@ -107,7 +107,7 @@
                         </DataTemplate>
                     </controls:VerticalRepeaterView.ItemTemplate>
                 </controls:VerticalRepeaterView>
-            </muxc:ScrollView>
+            </ScrollViewer>
 
             <controls:OverlayLoadingPanel IsBarActive="{x:Bind ViewModel.IsIndexDeltaLoading, Mode=OneWay}" IsRingActive="{x:Bind ViewModel.IsIndexInitializeLoading, Mode=OneWay}" />
             <controls:ErrorPanel

--- a/src/App/Pages/Overlay/PlayerPage.xaml
+++ b/src/App/Pages/Overlay/PlayerPage.xaml
@@ -139,7 +139,7 @@
                 </Grid>
             </Grid>
 
-            <muxc:ScrollView
+            <ScrollViewer
                 x:Name="RootScrollViewer"
                 HorizontalScrollMode="Disabled"
                 VerticalScrollBarVisibility="Auto"

--- a/src/App/Pages/Overlay/SearchPage.xaml
+++ b/src/App/Pages/Overlay/SearchPage.xaml
@@ -109,7 +109,7 @@
                     <controls:SearchUserFilter x:Name="UserFilter" Visibility="Collapsed" />
                 </Grid>
 
-                <muxc:ScrollView
+                <ScrollViewer
                     x:Name="ContentScrollViewer"
                     Grid.Row="1"
                     Padding="{StaticResource DefaultContainerPadding}"
@@ -129,7 +129,7 @@
                         <controls:SearchUserView x:Name="UserView" Visibility="Collapsed" />
                         <controls:SearchLiveView x:Name="LiveView" Visibility="Collapsed" />
                     </Grid>
-                </muxc:ScrollView>
+                </ScrollViewer>
             </Grid>
         </muxc:NavigationView>
     </Grid>

--- a/src/App/Pages/Overlay/TimeLinePage.xaml
+++ b/src/App/Pages/Overlay/TimeLinePage.xaml
@@ -2,6 +2,7 @@
     x:Class="Richasy.Bili.App.Pages.Overlay.TimeLinePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:community="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:controls="using:Richasy.Bili.App.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:loc="using:Richasy.Bili.Locator.Uwp"
@@ -38,7 +39,6 @@
                     <muxc:ItemsRepeater x:Name="Repeater" ItemsSource="{x:Bind EpisodeCollection, Mode=OneWay}">
                         <muxc:ItemsRepeater.Layout>
                             <muxc:UniformGridLayout
-                                ItemsStretch="Fill"
                                 MinColumnSpacing="12"
                                 MinItemHeight="180"
                                 MinItemWidth="300"
@@ -46,7 +46,7 @@
                         </muxc:ItemsRepeater.Layout>
                         <muxc:ItemsRepeater.ItemTemplate>
                             <DataTemplate x:DataType="uwp:SeasonViewModel">
-                                <controls:PgcItem ViewModel="{x:Bind}" />
+                                <controls:PgcItem Height="180" ViewModel="{x:Bind}" />
                             </DataTemplate>
                         </muxc:ItemsRepeater.ItemTemplate>
                     </muxc:ItemsRepeater>
@@ -89,7 +89,10 @@
                     </muxc:ItemsRepeater.Layout>
                     <muxc:ItemsRepeater.ItemTemplate>
                         <DataTemplate x:DataType="uwp:SeasonViewModel">
-                            <controls:PgcItem Orientation="Horizontal" ViewModel="{x:Bind}" />
+                            <controls:PgcItem
+                                Height="180"
+                                Orientation="Horizontal"
+                                ViewModel="{x:Bind}" />
                         </DataTemplate>
                     </muxc:ItemsRepeater.ItemTemplate>
                 </muxc:ItemsRepeater>
@@ -139,7 +142,7 @@
                 TextTrimming="CharacterEllipsis" />
         </StackPanel>
         <Grid Grid.Row="1">
-            <muxc:ScrollView
+            <ScrollViewer
                 x:Name="ContentScrollViewer"
                 Padding="{StaticResource DefaultContainerPadding}"
                 HorizontalScrollMode="Disabled"
@@ -153,7 +156,7 @@
                         <muxc:StackLayout Spacing="20" />
                     </muxc:ItemsRepeater.Layout>
                 </muxc:ItemsRepeater>
-            </muxc:ScrollView>
+            </ScrollViewer>
 
             <controls:OverlayLoadingPanel IsBarActive="False" IsRingActive="{x:Bind ViewModel.IsTimeLineInitializing, Mode=OneWay}" />
             <controls:ErrorPanel

--- a/src/App/Pages/Overlay/ViewLaterPage.xaml
+++ b/src/App/Pages/Overlay/ViewLaterPage.xaml
@@ -43,7 +43,7 @@
                 Text="{loc:LocaleLocator Name=ViewLater}"
                 TextTrimming="CharacterEllipsis" />
             <Grid Grid.Row="1">
-                <muxc:ScrollView
+                <ScrollViewer
                     x:Name="ContentScrollViewer"
                     Padding="{StaticResource DefaultContainerPadding}"
                     HorizontalScrollMode="Disabled"
@@ -97,7 +97,7 @@
                             </controls:VerticalRepeaterView.ItemTemplate>
                         </controls:VerticalRepeaterView>
                     </Grid>
-                </muxc:ScrollView>
+                </ScrollViewer>
 
                 <controls:OverlayLoadingPanel IsBarActive="{x:Bind ViewModel.IsDeltaLoading, Mode=OneWay}" IsRingActive="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay}" />
                 <controls:ErrorPanel

--- a/src/App/Pages/PartitionPage.xaml
+++ b/src/App/Pages/PartitionPage.xaml
@@ -30,7 +30,7 @@
                 </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
-        <muxc:ScrollView
+        <ScrollViewer
             x:Name="RootContainer"
             Padding="{StaticResource DefaultContainerWithBottomPadding}"
             VerticalAlignment="Stretch"
@@ -57,7 +57,7 @@
                         Orientation="Horizontal" />
                 </muxc:ItemsRepeater.Layout>
             </muxc:ItemsRepeater>
-        </muxc:ScrollView>
+        </ScrollViewer>
         <StackPanel
             Margin="{StaticResource DefaultContainerPadding}"
             HorizontalAlignment="Center"

--- a/src/App/Pages/PopularPage.xaml
+++ b/src/App/Pages/PopularPage.xaml
@@ -31,7 +31,7 @@
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
         <Grid>
-            <muxc:ScrollView
+            <ScrollViewer
                 x:Name="ContentScrollViewer"
                 Padding="{StaticResource DefaultContainerPadding}"
                 HorizontalScrollMode="Disabled"
@@ -67,7 +67,7 @@
                         </DataTemplate>
                     </controls:VerticalRepeaterView.ItemTemplate>
                 </controls:VerticalRepeaterView>
-            </muxc:ScrollView>
+            </ScrollViewer>
         </Grid>
 
         <controls:OverlayLoadingPanel IsBarActive="{x:Bind ViewModel.IsDeltaLoading, Mode=OneWay}" IsRingActive="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay}" />

--- a/src/App/Pages/RankPage.xaml
+++ b/src/App/Pages/RankPage.xaml
@@ -57,7 +57,7 @@
 
             <muxc:NavigationView.Content>
                 <Grid Margin="0,4,0,0">
-                    <muxc:ScrollView
+                    <ScrollViewer
                         x:Name="ContentScrollViewer"
                         Padding="{StaticResource DefaultContainerPadding}"
                         HorizontalScrollMode="Disabled"
@@ -89,7 +89,7 @@
                                 </DataTemplate>
                             </controls:VerticalRepeaterView.ItemTemplate>
                         </controls:VerticalRepeaterView>
-                    </muxc:ScrollView>
+                    </ScrollViewer>
                     <controls:OverlayLoadingPanel IsBarActive="False" IsRingActive="{x:Bind ViewModel.IsRankLoading, Mode=OneWay}" />
                     <controls:ErrorPanel
                         x:Name="ErrorPanel"

--- a/src/App/Pages/RankPage.xaml.cs
+++ b/src/App/Pages/RankPage.xaml.cs
@@ -70,7 +70,7 @@ namespace Richasy.Bili.App.Pages
         private async void OnDetailNavigationViewItemInvokedAsync(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs args)
         {
             var item = args.InvokedItem as RankPartition;
-            ContentScrollViewer.ScrollTo(0, 0);
+            ContentScrollViewer.ChangeView(0, 0, 1);
             await ViewModel.SetSelectedRankPartitionAsync(item);
         }
 

--- a/src/App/Pages/RecommendPage.xaml
+++ b/src/App/Pages/RecommendPage.xaml
@@ -31,7 +31,7 @@
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
         <Grid>
-            <muxc:ScrollView
+            <ScrollViewer
                 x:Name="ContentScrollViewer"
                 Padding="{StaticResource DefaultContainerPadding}"
                 HorizontalScrollMode="Disabled"
@@ -67,7 +67,7 @@
                         </DataTemplate>
                     </controls:VerticalRepeaterView.ItemTemplate>
                 </controls:VerticalRepeaterView>
-            </muxc:ScrollView>
+            </ScrollViewer>
         </Grid>
 
         <controls:OverlayLoadingPanel IsBarActive="{x:Bind ViewModel.IsDeltaLoading, Mode=OneWay}" IsRingActive="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay}" />

--- a/src/App/Pages/Reuse/AnimePage.xaml
+++ b/src/App/Pages/Reuse/AnimePage.xaml
@@ -70,7 +70,7 @@
             </muxc:NavigationView.PaneFooter>
             <muxc:NavigationView.Content>
                 <Grid>
-                    <muxc:ScrollView
+                    <ScrollViewer
                         x:Name="ContentScrollViewer"
                         Padding="{StaticResource DefaultContainerPadding}"
                         HorizontalScrollMode="Disabled"
@@ -218,7 +218,7 @@
 
                             </Grid>
                         </Grid>
-                    </muxc:ScrollView>
+                    </ScrollViewer>
 
                     <controls:OverlayLoadingPanel IsBarActive="False" IsRingActive="{x:Bind ViewModel.CurrentTab.IsInitializeLoading, Mode=OneWay}" />
 

--- a/src/App/Pages/Reuse/FeedPage.xaml
+++ b/src/App/Pages/Reuse/FeedPage.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <muxc:ScrollView x:Name="ContentScrollViewer">
+        <ScrollViewer x:Name="ContentScrollViewer">
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup x:Name="LayoutGroup">
                     <VisualState x:Name="WideState">
@@ -74,7 +74,7 @@
                     </controls:VerticalRepeaterView.ItemTemplate>
                 </controls:VerticalRepeaterView>
             </Grid>
-        </muxc:ScrollView>
+        </ScrollViewer>
         <controls:OverlayLoadingPanel IsBarActive="{x:Bind ViewModel.IsDeltaLoading, Mode=OneWay}" IsRingActive="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay}" />
 
         <controls:ErrorPanel

--- a/src/App/Pages/Reuse/FeedPage.xaml.cs
+++ b/src/App/Pages/Reuse/FeedPage.xaml.cs
@@ -43,7 +43,7 @@ namespace Richasy.Bili.App.Pages
         public async Task RefreshAsync()
         {
             await ViewModel.InitializeRequestAsync();
-            ContentScrollViewer.ScrollTo(0, 0);
+            ContentScrollViewer.ChangeView(0, 0, 1);
         }
 
         /// <inheritdoc/>

--- a/src/App/Pages/SettingPage.xaml
+++ b/src/App/Pages/SettingPage.xaml
@@ -35,7 +35,7 @@
                 </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
-        <muxc:ScrollView
+        <ScrollViewer
             x:Name="ContentScrollViewer"
             HorizontalScrollMode="Disabled"
             VerticalScrollBarVisibility="Auto">
@@ -74,6 +74,6 @@
                     <TextBlock Style="{StaticResource TipTextStyle}" Text="{loc:LocaleLocator Name=License}" />
                 </StackPanel>
             </StackPanel>
-        </muxc:ScrollView>
+        </ScrollViewer>
     </Grid>
 </Page>

--- a/src/App/Pages/SpecialColumnPage.xaml
+++ b/src/App/Pages/SpecialColumnPage.xaml
@@ -50,7 +50,7 @@
             </muxc:NavigationView.MenuItemTemplate>
 
             <muxc:NavigationView.Content>
-                <muxc:ScrollView
+                <ScrollViewer
                     x:Name="ContentScrollViewer"
                     Margin="0,8,0,0"
                     Padding="{StaticResource DefaultContainerPadding}"
@@ -152,7 +152,7 @@
 
                         <controls:OverlayLoadingPanel IsBarActive="{x:Bind ViewModel.CurrentCategory.IsDeltaLoading, Mode=OneWay}" IsRingActive="{x:Bind ViewModel.CurrentCategory.IsInitializeLoading, Mode=OneWay}" />
                     </Grid>
-                </muxc:ScrollView>
+                </ScrollViewer>
             </muxc:NavigationView.Content>
         </muxc:NavigationView>
 

--- a/src/App/Resources/Html/ReaderPage.html
+++ b/src/App/Resources/Html/ReaderPage.html
@@ -47,7 +47,7 @@
                         Key: 'LinkClick',
                         Value: link
                     }
-                    chrome.webview.postMessage(JSON.stringify(data));
+                    window.external.notify(JSON.stringify(data));
                 })
             }
         }
@@ -63,7 +63,7 @@
                         Key: 'ImageClick',
                         Value: src
                     };
-                    chrome.webview.postMessage(JSON.stringify(obj));
+                    window.external.notify(JSON.stringify(obj));
                 })
             }
         }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #61 

使用ScrollViewer替代之前的ScrollView，以支持在Win10上的滚动行为

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

Win10上部分页面或组件无法滚动。

## 新的行为是什么？

替换控件后支持滚动。

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

同时升级了WinUI的版本
