### PR TITLE
添加对播放失败状态的监听和状态处理

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -987,6 +987,9 @@
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
       <Version>7.1.0-rc2</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Media">
+      <Version>7.1.0-rc2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.7.0</Version>
     </PackageReference>

--- a/src/App/Controls/CardPanel/CardPanel.cs
+++ b/src/App/Controls/CardPanel/CardPanel.cs
@@ -23,11 +23,11 @@ namespace Richasy.Bili.App.Controls
         /// </summary>
         public CardPanel()
         {
-            this.DefaultStyleKey = typeof(CardPanel);
-            this.Loading += this.OnCardPanelLoading;
-            this.Unloaded += this.OnCardPanelUnloaded;
-            this._compositor = Window.Current.Compositor;
-            this.IsThreeState = false;
+            DefaultStyleKey = typeof(CardPanel);
+            Loading += OnCardPanelLoading;
+            Unloaded += OnCardPanelUnloaded;
+            _compositor = Window.Current.Compositor;
+            IsThreeState = false;
         }
 
         /// <summary>
@@ -44,21 +44,21 @@ namespace Richasy.Bili.App.Controls
         /// <inheritdoc/>
         protected override void OnToggle()
         {
-            if (!this.IsEnableCheck)
+            if (!IsEnableCheck)
             {
-                this.IsChecked = false;
+                IsChecked = false;
             }
         }
 
         /// <inheritdoc/>
         protected override void OnApplyTemplate()
         {
-            this._rootContainer = this.GetTemplateChild("RootContainer") as Grid;
+            _rootContainer = GetTemplateChild("RootContainer") as Grid;
 
-            ElementCompositionPreview.SetIsTranslationEnabled(this._rootContainer, true);
+            ElementCompositionPreview.SetIsTranslationEnabled(_rootContainer, true);
 
-            this._templateApplied = true;
-            this.ApplyShadowAnimation();
+            _templateApplied = true;
+            ApplyShadowAnimation();
             base.OnApplyTemplate();
         }
 
@@ -85,47 +85,47 @@ namespace Richasy.Bili.App.Controls
 
         private void OnCardPanelLoading(FrameworkElement sender, object args)
         {
-            this.ActualThemeChanged += this.OnActualThemeChanged;
+            ActualThemeChanged += OnActualThemeChanged;
 
-            this._pointerOverToken = this.RegisterPropertyChangedCallback(IsPointerOverProperty, this.OnPanelStateChanged);
-            this._pressedToken = this.RegisterPropertyChangedCallback(IsPressedProperty, this.OnPanelStateChanged);
+            _pointerOverToken = RegisterPropertyChangedCallback(IsPointerOverProperty, OnPanelStateChanged);
+            _pressedToken = RegisterPropertyChangedCallback(IsPressedProperty, OnPanelStateChanged);
 
-            this._loaded = true;
-            this.ApplyShadowAnimation();
+            _loaded = true;
+            ApplyShadowAnimation();
         }
 
         private void OnCardPanelUnloaded(object sender, RoutedEventArgs e)
         {
-            this.ActualThemeChanged -= this.OnActualThemeChanged;
+            ActualThemeChanged -= OnActualThemeChanged;
 
-            this.UnregisterPropertyChangedCallback(IsPointerOverProperty, this._pointerOverToken);
-            this.UnregisterPropertyChangedCallback(IsPressedProperty, this._pressedToken);
+            UnregisterPropertyChangedCallback(IsPointerOverProperty, _pointerOverToken);
+            UnregisterPropertyChangedCallback(IsPressedProperty, _pressedToken);
 
-            this._loaded = false;
-            this.DestroyShadow();
+            _loaded = false;
+            DestroyShadow();
         }
 
         private void CreateShadow()
         {
-            if (this._shadowCreated || !this._loaded || !this._templateApplied)
+            if (_shadowCreated || !_loaded || !_templateApplied)
             {
                 // The shadow is either already created, or we're not ready to create it yet
                 return;
             }
 
-            var attachedShadow = Effects.GetShadow(this._rootContainer);
-            if (!this.IsEnableShadow && attachedShadow != null)
+            var attachedShadow = Effects.GetShadow(_rootContainer);
+            if (!IsEnableShadow && attachedShadow != null)
             {
-                this._rootContainer.ClearValue(Effects.ShadowProperty);
+                _rootContainer.ClearValue(Effects.ShadowProperty);
                 return;
             }
 
-            var shadowContext = attachedShadow?.GetElementContext(this._rootContainer);
+            var shadowContext = attachedShadow?.GetElementContext(_rootContainer);
             shadowContext?.CreateResources();
 
             if (shadowContext?.Shadow != null)
             {
-                switch (this.ActualTheme)
+                switch (ActualTheme)
                 {
                     case ElementTheme.Light:
                         shadowContext.Shadow.BlurRadius = LightPointerRestShadowRadius;
@@ -140,43 +140,43 @@ namespace Richasy.Bili.App.Controls
                 }
             }
 
-            this._shadowCreated = true;
+            _shadowCreated = true;
         }
 
         private void DestroyShadow()
         {
-            if (!this._shadowCreated)
+            if (!_shadowCreated)
             {
                 // The shadow has not yet been created or it has already been destroyed
                 return;
             }
 
-            this._shadowCreated = false;
+            _shadowCreated = false;
         }
 
         private void ShowPointerOverShadow()
         {
-            this.CreateShadow();
+            CreateShadow();
 
-            if (!this.IsPointerOver || !this._shadowCreated || !this.IsEnableHoverAnimation)
+            if (!IsPointerOver || !_shadowCreated || !IsEnableHoverAnimation)
             {
                 return;
             }
 
-            var shadowContext = Effects.GetShadow(this._rootContainer)?.GetElementContext(this._rootContainer);
+            var shadowContext = Effects.GetShadow(_rootContainer)?.GetElementContext(_rootContainer);
 
             if (shadowContext?.SpriteVisual != null)
             {
                 shadowContext.SpriteVisual.IsVisible = true;
             }
 
-            AnimationBuilder.Create().Translation(Axis.Y, PointerOverOffsetY, duration: ShowShadowDuration).Start(this._rootContainer);
+            AnimationBuilder.Create().Translation(Axis.Y, PointerOverOffsetY, duration: ShowShadowDuration).Start(_rootContainer);
 
             var shadowRadius = 0f;
             var shadowOffset = Vector3.Zero;
             var shadowOpacity = 0f;
 
-            switch (this.ActualTheme)
+            switch (ActualTheme)
             {
                 case ElementTheme.Default:
                 case ElementTheme.Dark:
@@ -193,37 +193,37 @@ namespace Richasy.Bili.App.Controls
 
             if (shadowContext?.Shadow != null)
             {
-                var shadowAnimationGroup = this._compositor.CreateAnimationGroup();
-                shadowAnimationGroup.Add(this._compositor.CreateScalarKeyFrameAnimation(nameof(DropShadow.BlurRadius), shadowRadius, duration: ShowShadowDuration));
-                shadowAnimationGroup.Add(this._compositor.CreateVector3KeyFrameAnimation(nameof(DropShadow.Offset), shadowOffset, duration: ShowShadowDuration));
-                shadowAnimationGroup.Add(this._compositor.CreateScalarKeyFrameAnimation(nameof(DropShadow.Opacity), shadowOpacity, duration: ShowShadowDuration));
+                var shadowAnimationGroup = _compositor.CreateAnimationGroup();
+                shadowAnimationGroup.Add(_compositor.CreateScalarKeyFrameAnimation(nameof(DropShadow.BlurRadius), shadowRadius, duration: ShowShadowDuration));
+                shadowAnimationGroup.Add(_compositor.CreateVector3KeyFrameAnimation(nameof(DropShadow.Offset), shadowOffset, duration: ShowShadowDuration));
+                shadowAnimationGroup.Add(_compositor.CreateScalarKeyFrameAnimation(nameof(DropShadow.Opacity), shadowOpacity, duration: ShowShadowDuration));
                 shadowContext.Shadow.StartAnimationGroup(shadowAnimationGroup);
             }
         }
 
         private void ShowPointerPressedShadow()
         {
-            this.CreateShadow();
+            CreateShadow();
 
-            if (!this.IsPressed || !this._shadowCreated || !this.IsEnableHoverAnimation)
+            if (!IsPressed || !_shadowCreated || !IsEnableHoverAnimation)
             {
                 return;
             }
 
-            var shadowContext = Effects.GetShadow(this._rootContainer)?.GetElementContext(this._rootContainer);
+            var shadowContext = Effects.GetShadow(_rootContainer)?.GetElementContext(_rootContainer);
 
             if (shadowContext?.SpriteVisual != null)
             {
                 shadowContext.SpriteVisual.IsVisible = true;
             }
 
-            AnimationBuilder.Create().Translation(Axis.Y, 0, duration: PressShadowDuration).Start(this._rootContainer);
+            AnimationBuilder.Create().Translation(Axis.Y, 0, duration: PressShadowDuration).Start(_rootContainer);
 
             var shadowRadius = 0f;
             var shadowOffset = Vector3.Zero;
             var shadowOpacity = 0f;
 
-            switch (this.ActualTheme)
+            switch (ActualTheme)
             {
                 case ElementTheme.Default:
                 case ElementTheme.Dark:
@@ -240,30 +240,30 @@ namespace Richasy.Bili.App.Controls
 
             if (shadowContext?.Shadow != null)
             {
-                var shadowAnimationGroup = this._compositor.CreateAnimationGroup();
-                shadowAnimationGroup.Add(this._compositor.CreateScalarKeyFrameAnimation(nameof(DropShadow.BlurRadius), shadowRadius, duration: PressShadowDuration));
-                shadowAnimationGroup.Add(this._compositor.CreateVector3KeyFrameAnimation(nameof(DropShadow.Offset), shadowOffset, duration: PressShadowDuration));
-                shadowAnimationGroup.Add(this._compositor.CreateScalarKeyFrameAnimation(nameof(DropShadow.Opacity), shadowOpacity, duration: PressShadowDuration));
+                var shadowAnimationGroup = _compositor.CreateAnimationGroup();
+                shadowAnimationGroup.Add(_compositor.CreateScalarKeyFrameAnimation(nameof(DropShadow.BlurRadius), shadowRadius, duration: PressShadowDuration));
+                shadowAnimationGroup.Add(_compositor.CreateVector3KeyFrameAnimation(nameof(DropShadow.Offset), shadowOffset, duration: PressShadowDuration));
+                shadowAnimationGroup.Add(_compositor.CreateScalarKeyFrameAnimation(nameof(DropShadow.Opacity), shadowOpacity, duration: PressShadowDuration));
                 shadowContext.Shadow.StartAnimationGroup(shadowAnimationGroup);
             }
         }
 
         private void HideShadow()
         {
-            this.CreateShadow();
+            CreateShadow();
 
-            if (this.IsPointerOver || !this._shadowCreated)
+            if (IsPointerOver || !_shadowCreated)
             {
                 return;
             }
 
-            AnimationBuilder.Create().Translation(Axis.Y, 0, duration: HideShadowDuration).Start(this._rootContainer);
+            AnimationBuilder.Create().Translation(Axis.Y, 0, duration: HideShadowDuration).Start(_rootContainer);
 
             var shadowRadius = 0f;
             var shadowOffset = Vector3.Zero;
             var shadowOpacity = 0f;
 
-            switch (this.ActualTheme)
+            switch (ActualTheme)
             {
                 case ElementTheme.Default:
                 case ElementTheme.Dark:
@@ -278,31 +278,31 @@ namespace Richasy.Bili.App.Controls
                     break;
             }
 
-            var shadowContext = Effects.GetShadow(this._rootContainer)?.GetElementContext(this._rootContainer);
+            var shadowContext = Effects.GetShadow(_rootContainer)?.GetElementContext(_rootContainer);
 
             if (shadowContext?.Shadow != null)
             {
-                var shadowAnimationGroup = this._compositor.CreateAnimationGroup();
-                shadowAnimationGroup.Add(this._compositor.CreateScalarKeyFrameAnimation(nameof(DropShadow.BlurRadius), shadowRadius, duration: HideShadowDuration));
-                shadowAnimationGroup.Add(this._compositor.CreateVector3KeyFrameAnimation(nameof(DropShadow.Offset), shadowOffset, duration: HideShadowDuration));
-                shadowAnimationGroup.Add(this._compositor.CreateScalarKeyFrameAnimation(nameof(DropShadow.Opacity), shadowOpacity, duration: HideShadowDuration));
+                var shadowAnimationGroup = _compositor.CreateAnimationGroup();
+                shadowAnimationGroup.Add(_compositor.CreateScalarKeyFrameAnimation(nameof(DropShadow.BlurRadius), shadowRadius, duration: HideShadowDuration));
+                shadowAnimationGroup.Add(_compositor.CreateVector3KeyFrameAnimation(nameof(DropShadow.Offset), shadowOffset, duration: HideShadowDuration));
+                shadowAnimationGroup.Add(_compositor.CreateScalarKeyFrameAnimation(nameof(DropShadow.Opacity), shadowOpacity, duration: HideShadowDuration));
                 shadowContext.Shadow.StartAnimationGroup(shadowAnimationGroup);
             }
         }
 
         private void ApplyShadowAnimation()
         {
-            if (this.IsPressed)
+            if (IsPressed)
             {
-                this.ShowPointerPressedShadow();
+                ShowPointerPressedShadow();
             }
-            else if (this.IsPointerOver)
+            else if (IsPointerOver)
             {
-                this.ShowPointerOverShadow();
+                ShowPointerOverShadow();
             }
             else
             {
-                this.HideShadow();
+                HideShadow();
             }
         }
 
@@ -310,14 +310,14 @@ namespace Richasy.Bili.App.Controls
         {
             if (sender is CompositionScopedBatch batch)
             {
-                batch.Completed -= this.OnHideAnimationCompleted;
+                batch.Completed -= OnHideAnimationCompleted;
                 batch.Dispose();
             }
 
-            var shadowContext = Effects.GetShadow(this._rootContainer)?.GetElementContext(this._rootContainer);
+            var shadowContext = Effects.GetShadow(_rootContainer)?.GetElementContext(_rootContainer);
 
             // Set SpriteVisible.IsVisible to false when the hide animation is complete to make sure it doesn't use GPU resources.
-            if (!this.IsPointerOver && this._shadowCreated && shadowContext?.SpriteVisual != null)
+            if (!IsPointerOver && _shadowCreated && shadowContext?.SpriteVisual != null)
             {
                 shadowContext.SpriteVisual.IsVisible = false;
             }
@@ -325,14 +325,14 @@ namespace Richasy.Bili.App.Controls
 
         private void OnActualThemeChanged(FrameworkElement sender, object args)
         {
-            this.ApplyShadowAnimation();
+            ApplyShadowAnimation();
         }
 
         private void OnPanelStateChanged(DependencyObject sender, DependencyProperty dp)
         {
-            var changedArgs = new CardPanelStateChangedEventArgs(this.IsPointerOver, this.IsPressed);
-            this.StateChanged?.Invoke(this, changedArgs);
-            this.ApplyShadowAnimation();
+            var changedArgs = new CardPanelStateChangedEventArgs(IsPointerOver, IsPressed);
+            StateChanged?.Invoke(this, changedArgs);
+            ApplyShadowAnimation();
         }
     }
 }

--- a/src/App/Controls/CardPanel/CardPanel.xaml
+++ b/src/App/Controls/CardPanel/CardPanel.xaml
@@ -2,8 +2,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Richasy.Bili.App.Controls"
+    xmlns:media="using:Microsoft.Toolkit.Uwp.UI.Media"
     xmlns:shadow="using:Microsoft.Toolkit.Uwp.UI">
-    <shadow:AttachedDropShadow
+    <media:AttachedCardShadow
         x:Key="DefaultCardShadow"
         BlurRadius="4"
         CornerRadius="8" />
@@ -122,7 +123,6 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-
                         <Grid
                             x:Name="HostContainer"
                             Background="{TemplateBinding Background}"

--- a/src/App/Controls/Danmaku/DanmakuBuilder.cs
+++ b/src/App/Controls/Danmaku/DanmakuBuilder.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Graphics.Canvas;
 using Microsoft.Graphics.Canvas.Geometry;
 using Microsoft.Graphics.Canvas.Text;
-using Microsoft.Toolkit.Uwp.UI.Controls;
+using Microsoft.Toolkit.Uwp.UI;
 using Windows.Storage.Streams;
 using Windows.UI;
 using Windows.UI.Text;
@@ -237,17 +237,21 @@ namespace Richasy.Bili.App.Controls
             tx.FontSize = size;
 
             var grid = new Grid();
-            var dropShadowPanel = new DropShadowPanel()
+            var hostGrid = new Grid();
+
+            var shadow = new AttachedDropShadow();
+            shadow.BlurRadius = 2;
+            shadow.Opacity = 0.8;
+            shadow.Offset = "1,1,0";
+            shadow.Color = _model.Color.R <= 80 ? Colors.White : Colors.Black;
+            grid.Children.Add(hostGrid);
+            grid.Children.Add(tx);
+            grid.Loaded += (s, e) =>
             {
-                BlurRadius = 2,
-                ShadowOpacity = 0.8,
-                OffsetX = 1,
-                OffsetY = 1,
-                Color = _model.Color.R <= 80 ? Colors.White : Colors.Black,
+                shadow.CastTo = hostGrid;
             };
 
-            dropShadowPanel.Content = tx;
-            grid.Children.Add(dropShadowPanel);
+            Effects.SetShadow(tx, shadow);
             grid.Tag = _model;
             return grid;
         }

--- a/src/App/Pages/Overlay/PlayerPage.xaml
+++ b/src/App/Pages/Overlay/PlayerPage.xaml
@@ -109,6 +109,11 @@
                                 HorizontalAlignment="Center"
                                 Text="{x:Bind ViewModel.PlayInformationErrorText, Mode=OneWay}"
                                 TextAlignment="Center" />
+                            <Button
+                                x:Name="RefreshButton"
+                                HorizontalAlignment="Center"
+                                Click="OnRefreshButtonClickAsync"
+                                Content="{loc:LocaleLocator Name=Refresh}" />
                         </StackPanel>
                     </Grid>
                 </Grid>

--- a/src/App/Pages/RootPage.xaml
+++ b/src/App/Pages/RootPage.xaml
@@ -6,8 +6,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:Richasy.Bili.App.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-    muxc:BackdropMaterial.ApplyToRootOrPageBackground="True"
     mc:Ignorable="d">
 
     <Grid>

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Aborted" xml:space="preserve">
+    <value>操作中止</value>
+  </data>
   <data name="AboutThisApp" xml:space="preserve">
     <value>关于此应用</value>
   </data>
@@ -296,6 +299,9 @@
   </data>
   <data name="Dark" xml:space="preserve">
     <value>深色</value>
+  </data>
+  <data name="DecodingError" xml:space="preserve">
+    <value>解码失败或者正在切换片源</value>
   </data>
   <data name="Default" xml:space="preserve">
     <value>默认</value>
@@ -568,6 +574,9 @@
   </data>
   <data name="NeedScaleToShowReply" xml:space="preserve">
     <value>你需要拉宽应用以显示评论列表</value>
+  </data>
+  <data name="NetworkError" xml:space="preserve">
+    <value>网络连接错误，请稍后重试</value>
   </data>
   <data name="NoFans" xml:space="preserve">
     <value>该用户还木有粉丝哟~</value>
@@ -959,6 +968,9 @@
   <data name="SortByReply" xml:space="preserve">
     <value>评论最多</value>
   </data>
+  <data name="SourceNotSupported" xml:space="preserve">
+    <value>不支持该源</value>
+  </data>
   <data name="SpecialColumn" xml:space="preserve">
     <value>专栏</value>
   </data>
@@ -1021,6 +1033,9 @@
   </data>
   <data name="UnFavoriteWarning" xml:space="preserve">
     <value>是否不再关注该收藏夹？</value>
+  </data>
+  <data name="UnknownError" xml:space="preserve">
+    <value>未知错误发生了</value>
   </data>
   <data name="Updated" xml:space="preserve">
     <value>已更新</value>

--- a/src/Controller/Controller.Uwp/BiliController.Player.cs
+++ b/src/Controller/Controller.Uwp/BiliController.Player.cs
@@ -117,8 +117,6 @@ namespace Richasy.Bili.Controller.Uwp
                     {
                         isSuccess = await _playerProvider.ReportProgressAsync(videoId, partId, Convert.ToInt64(progress.TotalSeconds));
                     }
-
-                    _loggerModule.LogInformation("播放历史记录" + (isSuccess ? "成功" : "失败"));
                 }
                 catch (Exception ex)
                 {

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -330,6 +330,11 @@ namespace Richasy.Bili.Models.Enums
         FailedToClearLog,
         AboutThisApp,
         License,
+        UnknownError,
+        Aborted,
+        NetworkError,
+        DecodingError,
+        SourceNotSupported,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
@@ -7,6 +7,7 @@ using Bilibili.App.View.V1;
 using FFmpegInterop;
 using ReactiveUI.Fody.Helpers;
 using Richasy.Bili.Controller.Uwp;
+using Richasy.Bili.Controller.Uwp.Interfaces;
 using Richasy.Bili.Models.BiliBili;
 using Richasy.Bili.Models.Enums;
 using Richasy.Bili.Toolkit.Interfaces;
@@ -26,6 +27,7 @@ namespace Richasy.Bili.ViewModels.Uwp
         private readonly IResourceToolkit _resourceToolkit;
         private readonly ISettingsToolkit _settingsToolkit;
         private readonly IFileToolkit _fileToolkit;
+        private readonly ILoggerModule _logger;
 
         private readonly FFmpegInteropConfig _liveFFConfig;
 

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -51,7 +51,8 @@ namespace Richasy.Bili.ViewModels.Uwp
             ServiceLocator.Instance.LoadService(out _numberToolkit)
                                    .LoadService(out _resourceToolkit)
                                    .LoadService(out _settingsToolkit)
-                                   .LoadService(out _fileToolkit);
+                                   .LoadService(out _fileToolkit)
+                                   .LoadService(out _logger);
             PlayerDisplayMode = _settingsToolkit.ReadLocalSetting(SettingNames.DefaultPlayerDisplayMode, PlayerDisplayMode.Default);
             Volume = _settingsToolkit.ReadLocalSetting(SettingNames.Volume, 100d);
             InitializeTimer();
@@ -116,6 +117,7 @@ namespace Richasy.Bili.ViewModels.Uwp
 
             IsDetailCanLoaded = true;
             DanmakuViewModel.Instance.Reset();
+            IsPlayInformationError = false;
 
             switch (_videoType)
             {
@@ -493,6 +495,10 @@ namespace Richasy.Bili.ViewModels.Uwp
                         _settingsToolkit.WriteLocalSetting(SettingNames.Volume, Volume);
                     }
 
+                    break;
+                case nameof(IsPlayInformationError):
+                case nameof(IsDetailError):
+                    PlayerDisplayMode = PlayerDisplayMode.Default;
                     break;
                 default:
                     break;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #77 #80 

对播放状态进行更多的检测，在进入播放状态时重置错误状态以避免上一次的播放错误影响到后一个视频的播放。

在错误界面增加刷新按钮。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

1. 缺少对播放失败的检测和日志记录
2. 缺少错误下的刷新功能入口
3. 上一次播放失败会影响到下一个视频的播放。

## 新的行为是什么？

解决了上述的问题

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

--
