### PR TITLE
完善评论展示

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -115,6 +115,9 @@
     <Compile Include="Controls\App\QuestionPanel.xaml.cs">
       <DependentUpon>QuestionPanel.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\Common\ReplyModuleView.xaml.cs">
+      <DependentUpon>ReplyModuleView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\User\AccountPanel.xaml.cs">
       <DependentUpon>AccountPanel.xaml</DependentUpon>
     </Compile>
@@ -605,6 +608,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Controls\App\QuestionPanel.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\Common\ReplyModuleView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/App/Controls/Common/ReplyDetailView.xaml
+++ b/src/App/Controls/Common/ReplyDetailView.xaml
@@ -13,15 +13,6 @@
     mc:Ignorable="d">
 
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <local:ReplyItem x:Name="RootReplyItem" DetailCountVisibility="Collapsed" />
-        <local:ReplyView
-            x:Name="ReplyView"
-            Grid.Row="1"
-            HorizontalAlignment="Stretch"
-            HeaderVisibility="Collapsed" />
+        <local:ReplyModuleView x:Name="ModuleView" />
     </Grid>
 </local:CenterPopup>

--- a/src/App/Controls/Common/ReplyDetailView.xaml.cs
+++ b/src/App/Controls/Common/ReplyDetailView.xaml.cs
@@ -2,9 +2,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Bilibili.Main.Community.Reply.V1;
-using Richasy.Bili.ViewModels.Uwp;
-using Windows.UI.Xaml;
 
 namespace Richasy.Bili.App.Controls
 {

--- a/src/App/Controls/Common/ReplyDetailView.xaml.cs
+++ b/src/App/Controls/Common/ReplyDetailView.xaml.cs
@@ -14,18 +14,11 @@ namespace Richasy.Bili.App.Controls
     public partial class ReplyDetailView : CenterPopup
     {
         /// <summary>
-        /// <see cref="ViewModel"/>的依赖属性.
-        /// </summary>
-        public static readonly DependencyProperty ViewModelProperty =
-            DependencyProperty.Register(nameof(ViewModel), typeof(ReplyDetailViewModel), typeof(ReplyDetailView), new PropertyMetadata(ReplyDetailViewModel.Instance));
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="ReplyDetailView"/> class.
         /// </summary>
         protected ReplyDetailView()
         {
             this.InitializeComponent();
-            ReplyView.ViewModel = ViewModel;
         }
 
         /// <summary>
@@ -34,28 +27,14 @@ namespace Richasy.Bili.App.Controls
         public static ReplyDetailView Instance { get; } = new Lazy<ReplyDetailView>(() => new ReplyDetailView()).Value;
 
         /// <summary>
-        /// 视图模型.
-        /// </summary>
-        public ReplyDetailViewModel ViewModel
-        {
-            get { return (ReplyDetailViewModel)GetValue(ViewModelProperty); }
-            set { SetValue(ViewModelProperty, value); }
-        }
-
-        /// <summary>
         /// 显示.
         /// </summary>
-        /// <param name="rootReply">根评论.</param>
+        /// <param name="data">数据.</param>
         /// <returns><see cref="Task"/>.</returns>
-        public async Task ShowAsync(ReplyInfo rootReply)
+        public async Task ShowAsync(object data)
         {
             Container.Show();
-            RootReplyItem.Data = rootReply;
-            if (ViewModel == null || ViewModel.RootReply?.Id != rootReply.Id)
-            {
-                ViewModel.SetRootReply(rootReply);
-                await ReplyView.CheckInitializeAsync();
-            }
+            await ModuleView.InitializeAsync(data);
         }
     }
 }

--- a/src/App/Controls/Common/ReplyItem.xaml
+++ b/src/App/Controls/Common/ReplyItem.xaml
@@ -71,7 +71,7 @@
                         Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
                 </Grid>
                 <Grid Grid.Row="1">
-                    <local:TrimTextBlock x:Name="ReplyContentBlock" HorizontalAlignment="Stretch" />
+                    <local:TrimTextBlock x:Name="ReplyContentBlock" HorizontalAlignment="Left" />
                 </Grid>
                 <Grid Grid.Row="2" ColumnSpacing="12">
                     <Grid.ColumnDefinitions>

--- a/src/App/Controls/Common/ReplyItem.xaml
+++ b/src/App/Controls/Common/ReplyItem.xaml
@@ -11,7 +11,10 @@
     d:DesignWidth="400"
     mc:Ignorable="d">
 
-    <local:CardPanel IsEnableHoverAnimation="False" IsEnableShadow="False" Click="OnCardClick">
+    <local:CardPanel
+        Click="OnCardClick"
+        IsEnableHoverAnimation="False"
+        IsEnableShadow="False">
         <Grid Padding="12" ColumnSpacing="12">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
@@ -95,7 +98,7 @@
                         Grid.Column="1"
                         HorizontalAlignment="Left"
                         Visibility="{x:Bind DetailCountVisibility, Mode=OneWay}">
-                        <HyperlinkButton x:Name="MoreButton" Click="OnMoreButtonClickAsync">
+                        <HyperlinkButton x:Name="MoreButton" Click="OnMoreButtonClick">
                             <TextBlock x:Name="MoreBlock" FontSize="12" />
                         </HyperlinkButton>
                     </StackPanel>

--- a/src/App/Controls/Common/ReplyItem.xaml.cs
+++ b/src/App/Controls/Common/ReplyItem.xaml.cs
@@ -38,6 +38,8 @@ namespace Richasy.Bili.App.Controls
             Orientation = Orientation.Horizontal;
         }
 
+        public event EventHandler<ReplyInfo> MoreButtonClick;
+
         /// <summary>
         /// 条目被点击时发生.
         /// </summary>
@@ -93,9 +95,9 @@ namespace Richasy.Bili.App.Controls
             }
         }
 
-        private async void OnMoreButtonClickAsync(object sender, RoutedEventArgs e)
+        private void OnMoreButtonClick(object sender, RoutedEventArgs e)
         {
-            await ReplyDetailView.Instance.ShowAsync(Data);
+            MoreButtonClick?.Invoke(this, Data);
         }
 
         private async void OnLikeButtonClickAsync(object sender, RoutedEventArgs e)

--- a/src/App/Controls/Common/ReplyModuleView.xaml
+++ b/src/App/Controls/Common/ReplyModuleView.xaml
@@ -1,0 +1,42 @@
+﻿<UserControl
+    x:Class="Richasy.Bili.App.Controls.ReplyModuleView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:animations="using:Microsoft.Toolkit.Uwp.UI.Animations"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:loc="using:Richasy.Bili.Locator.Uwp"
+    xmlns:local="using:Richasy.Bili.App.Controls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    d:DesignHeight="300"
+    d:DesignWidth="400"
+    mc:Ignorable="d">
+
+    <Grid>
+        <Grid x:Name="MainContainer">
+            <local:ReplyView x:Name="MainView" RequestDetailView="OnRequestDetailViewAsync" />
+        </Grid>
+        <Grid x:Name="DetailContainer" Visibility="Collapsed">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <HyperlinkButton
+                x:Name="BackButton"
+                Margin="0,0,0,12"
+                HorizontalAlignment="Left"
+                Click="OnBackButtonClick"
+                Content="{loc:LocaleLocator Name=BackToPrevious}"
+                Visibility="{x:Bind CanShowBackButton, Mode=OneWay}" />
+            <local:ReplyItem
+                x:Name="RootReplyItem"
+                Grid.Row="1"
+                DetailCountVisibility="Collapsed" />
+            <local:ReplyView
+                x:Name="DetailView"
+                Grid.Row="2"
+                HorizontalAlignment="Stretch"
+                HeaderVisibility="Collapsed" />
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/App/Controls/Common/ReplyModuleView.xaml.cs
+++ b/src/App/Controls/Common/ReplyModuleView.xaml.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Richasy. All rights reserved.
+
+using System.Threading.Tasks;
+using Bilibili.Main.Community.Reply.V1;
+using Richasy.Bili.ViewModels.Uwp;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Richasy.Bili.App.Controls
+{
+    /// <summary>
+    /// 回复模块视图.
+    /// </summary>
+    public sealed partial class ReplyModuleView : UserControl
+    {
+        /// <summary>
+        /// <see cref="CanShowBackButton"/>的依赖属性.
+        /// </summary>
+        public static readonly DependencyProperty CanShowBackButtonProperty =
+            DependencyProperty.Register(nameof(CanShowBackButton), typeof(bool), typeof(ReplyModuleView), new PropertyMetadata(false));
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReplyModuleView"/> class.
+        /// </summary>
+        public ReplyModuleView()
+        {
+            this.InitializeComponent();
+            MainView.ViewModel = ReplyModuleViewModel.Instance;
+            DetailView.ViewModel = ReplyDetailViewModel.Instance;
+        }
+
+        /// <summary>
+        /// 是否可以显示返回主列表的按钮.
+        /// </summary>
+        public bool CanShowBackButton
+        {
+            get { return (bool)GetValue(CanShowBackButtonProperty); }
+            set { SetValue(CanShowBackButtonProperty, value); }
+        }
+
+        /// <summary>
+        /// 初始化.
+        /// </summary>
+        /// <param name="item">数据.</param>
+        /// <returns><see cref="Task"/>.</returns>
+        public async Task InitializeAsync(object item)
+        {
+            if (item is ReplyModuleViewModel)
+            {
+                MainContainer.Visibility = Visibility.Visible;
+                DetailContainer.Visibility = Visibility.Collapsed;
+                CanShowBackButton = true;
+                await MainView.CheckInitializeAsync();
+            }
+            else if (item is ReplyInfo info)
+            {
+                MainContainer.Visibility = Visibility.Collapsed;
+                DetailContainer.Visibility = Visibility.Visible;
+                CanShowBackButton = false;
+                await DetailView.CheckInitializeAsync();
+            }
+        }
+
+        private void OnBackButtonClick(object sender, RoutedEventArgs e)
+        {
+            DetailContainer.Visibility = Visibility.Collapsed;
+            MainContainer.Visibility = Visibility.Visible;
+        }
+
+        private async void OnRequestDetailViewAsync(object sender, ReplyInfo e)
+        {
+            MainContainer.Visibility = Visibility.Collapsed;
+            DetailContainer.Visibility = Visibility.Visible;
+            RootReplyItem.Data = e;
+            ReplyDetailViewModel.Instance.SetRootReply(e);
+            await DetailView.CheckInitializeAsync();
+        }
+    }
+}

--- a/src/App/Controls/Common/ReplyView.xaml
+++ b/src/App/Controls/Common/ReplyView.xaml
@@ -54,7 +54,10 @@
                     RequestLoadMore="OnReplyRequestLoadMoreAsync">
                     <local:VerticalRepeaterView.ItemTemplate>
                         <DataTemplate x:DataType="v1:ReplyInfo">
-                            <local:ReplyItem Click="OnReplyItemClick" Data="{x:Bind}" />
+                            <local:ReplyItem
+                                Click="OnReplyItemClick"
+                                Data="{x:Bind}"
+                                MoreButtonClick="OnMoreButtonClick" />
                         </DataTemplate>
                     </local:VerticalRepeaterView.ItemTemplate>
                 </local:VerticalRepeaterView>

--- a/src/App/Controls/Common/ReplyView.xaml.cs
+++ b/src/App/Controls/Common/ReplyView.xaml.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
+using System;
 using System.Threading.Tasks;
 using Bilibili.Main.Community.Reply.V1;
 using Richasy.Bili.Locator.Uwp;
@@ -37,6 +38,8 @@ namespace Richasy.Bili.App.Controls
             this.InitializeComponent();
         }
 
+        public event EventHandler<ReplyInfo> RequestDetailView;
+
         /// <summary>
         /// 依赖属性.
         /// </summary>
@@ -69,8 +72,8 @@ namespace Richasy.Bili.App.Controls
             OrderTypeComboBox.SelectedIndex = ViewModel.CurrentMode == Mode.MainListHot ? 0 : 1;
             if (!ViewModel.IsRequested)
             {
-                ContentScrollViewer.ChangeView(0, 0, 1);
                 await ViewModel.InitializeRequestAsync();
+                ContentScrollViewer.ChangeView(0, 0, 1);
             }
         }
 
@@ -187,6 +190,11 @@ namespace Richasy.Bili.App.Controls
             {
                 await SendReplyAsync();
             }
+        }
+
+        private void OnMoreButtonClick(object sender, ReplyInfo e)
+        {
+            RequestDetailView?.Invoke(this, e);
         }
     }
 }

--- a/src/App/Controls/Message/ReplyMessageItem.xaml.cs
+++ b/src/App/Controls/Message/ReplyMessageItem.xaml.cs
@@ -2,7 +2,10 @@
 
 using System;
 using Richasy.Bili.Locator.Uwp;
+using Richasy.Bili.Models.App.Constants;
+using Richasy.Bili.Models.Enums.Bili;
 using Richasy.Bili.Toolkit.Interfaces;
+using Richasy.Bili.ViewModels.Uwp;
 using Windows.Foundation;
 using Windows.System;
 using Windows.UI.Xaml;
@@ -69,7 +72,26 @@ namespace Richasy.Bili.App.Controls
 
         private async void OnMessageItemClickAsync(object sender, RoutedEventArgs e)
         {
-            await Launcher.LaunchUriAsync(new Uri(Data.Item.Uri));
+            var type = ReplyType.None;
+            var isParseFaield = false;
+            try
+            {
+                type = (ReplyType)Convert.ToInt32(Data.Item.BusinessId);
+            }
+            catch (Exception)
+            {
+                isParseFaield = true;
+            }
+
+            if (isParseFaield || type == ReplyType.None)
+            {
+                var resourceToolkit = ServiceLocator.Instance.GetService<IResourceToolkit>();
+                AppViewModel.Instance.ShowTip(resourceToolkit.GetLocaleString(Models.Enums.LanguageNames.NotSupportReplyType), Models.Enums.App.InfoType.Warning);
+                return;
+            }
+
+            ReplyModuleViewModel.Instance.SetInformation(Data.Item.SubjectId, type, Bilibili.Main.Community.Reply.V1.Mode.MainListTime);
+            await ReplyDetailView.Instance.ShowAsync(ReplyModuleViewModel.Instance);
         }
     }
 }

--- a/src/App/Controls/Player/Related/PlayerReplyView.xaml
+++ b/src/App/Controls/Player/Related/PlayerReplyView.xaml
@@ -31,7 +31,7 @@
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
         <Grid x:Name="StandardContainer" RowSpacing="12">
-            <controls:ReplyView x:Name="ReplyView" />
+            <controls:ReplyModuleView x:Name="ReplyView" />
         </Grid>
         <Grid x:Name="NarrowContainer" Visibility="Collapsed">
             <StackPanel

--- a/src/App/Controls/Player/Related/PlayerReplyView.xaml.cs
+++ b/src/App/Controls/Player/Related/PlayerReplyView.xaml.cs
@@ -24,7 +24,6 @@ namespace Richasy.Bili.App.Controls.Player.Related
         public PlayerReplyView()
         {
             this.InitializeComponent();
-            ReplyView.ViewModel = ViewModel;
         }
 
         /// <summary>
@@ -42,7 +41,7 @@ namespace Richasy.Bili.App.Controls.Player.Related
         /// <returns><see cref="Task"/>.</returns>
         public Task CheckInitializeAsync()
         {
-            return ReplyView.CheckInitializeAsync();
+            return ReplyView.InitializeAsync(ReplyModuleViewModel.Instance);
         }
     }
 }

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -177,6 +177,9 @@
   <data name="BackToDefaultView" xml:space="preserve">
     <value>返回标准视图</value>
   </data>
+  <data name="BackToPrevious" xml:space="preserve">
+    <value>返回上一级</value>
+  </data>
   <data name="Bangumi" xml:space="preserve">
     <value>番剧</value>
   </data>

--- a/src/Controller/Controller.Uwp/BiliController.Community.cs
+++ b/src/Controller/Controller.Uwp/BiliController.Community.cs
@@ -19,7 +19,7 @@ namespace Richasy.Bili.Controller.Uwp
         /// <param name="type">评论区类型.</param>
         /// <param name="cursor">游标.</param>
         /// <returns><see cref="Task"/>.</returns>
-        public async Task RequestMainReplyListAsync(int targetId, ReplyType type, CursorReq cursor)
+        public async Task RequestMainReplyListAsync(long targetId, ReplyType type, CursorReq cursor)
         {
             ThrowWhenNetworkUnavaliable();
 
@@ -47,7 +47,7 @@ namespace Richasy.Bili.Controller.Uwp
         /// <param name="rootId">根评论Id.</param>
         /// <param name="cursor">游标.</param>
         /// <returns>评论列表响应.</returns>
-        public async Task<DetailListReply> RequestDeltailReplyListAsync(int targetId, ReplyType type, long rootId, CursorReq cursor)
+        public async Task<DetailListReply> RequestDeltailReplyListAsync(long targetId, ReplyType type, long rootId, CursorReq cursor)
         {
             ThrowWhenNetworkUnavaliable();
 
@@ -77,7 +77,7 @@ namespace Richasy.Bili.Controller.Uwp
         /// <param name="targetId">目标评论区Id.</param>
         /// <param name="type">评论区类型.</param>
         /// <returns>结果.</returns>
-        public async Task<bool> LikeReplyAsync(bool isLike, long replyId, int targetId, ReplyType type)
+        public async Task<bool> LikeReplyAsync(bool isLike, long replyId, long targetId, ReplyType type)
         {
             try
             {
@@ -99,7 +99,7 @@ namespace Richasy.Bili.Controller.Uwp
         /// <param name="rootId">根评论Id.</param>
         /// <param name="parentId">正在回复的评论Id.</param>
         /// <returns>发布结果.</returns>
-        public async Task<bool> AddReplyAsync(string message, int targetId, ReplyType type, long rootId, long parentId)
+        public async Task<bool> AddReplyAsync(string message, long targetId, ReplyType type, long rootId, long parentId)
         {
             try
             {

--- a/src/Lib/Lib.Interfaces/ICommunityProvider.cs
+++ b/src/Lib/Lib.Interfaces/ICommunityProvider.cs
@@ -19,7 +19,7 @@ namespace Richasy.Bili.Lib.Interfaces
         /// <param name="type">评论区类型.</param>
         /// <param name="cursor">游标.</param>
         /// <returns>评论列表响应.</returns>
-        Task<MainListReply> GetReplyMainListAsync(int targetId, ReplyType type, CursorReq cursor);
+        Task<MainListReply> GetReplyMainListAsync(long targetId, ReplyType type, CursorReq cursor);
 
         /// <summary>
         /// 获取单层评论详情列表.
@@ -29,7 +29,7 @@ namespace Richasy.Bili.Lib.Interfaces
         /// <param name="rootId">根评论Id.</param>
         /// <param name="cursor">游标.</param>
         /// <returns>评论列表响应.</returns>
-        Task<DetailListReply> GetReplyDetailListAsync(int targetId, ReplyType type, long rootId, CursorReq cursor);
+        Task<DetailListReply> GetReplyDetailListAsync(long targetId, ReplyType type, long rootId, CursorReq cursor);
 
         /// <summary>
         /// 给评论点赞/取消点赞.
@@ -39,7 +39,7 @@ namespace Richasy.Bili.Lib.Interfaces
         /// <param name="targetId">目标评论区Id.</param>
         /// <param name="type">评论区类型.</param>
         /// <returns>结果.</returns>
-        Task<bool> LikeReplyAsync(bool isLike, long replyId, int targetId, ReplyType type);
+        Task<bool> LikeReplyAsync(bool isLike, long replyId, long targetId, ReplyType type);
 
         /// <summary>
         /// 添加评论.
@@ -50,7 +50,7 @@ namespace Richasy.Bili.Lib.Interfaces
         /// <param name="rootId">根评论Id.</param>
         /// <param name="parentId">正在回复的评论Id.</param>
         /// <returns>发布结果.</returns>
-        Task<bool> AddReplyAsync(string message, int targetId, ReplyType type, long rootId, long parentId);
+        Task<bool> AddReplyAsync(string message, long targetId, ReplyType type, long rootId, long parentId);
 
         /// <summary>
         /// 获取视频动态列表.

--- a/src/Lib/Lib.Uwp/CommunityProvider/CommunityProvider.cs
+++ b/src/Lib/Lib.Uwp/CommunityProvider/CommunityProvider.cs
@@ -30,7 +30,7 @@ namespace Richasy.Bili.Lib.Uwp
         }
 
         /// <inheritdoc/>
-        public async Task<DetailListReply> GetReplyDetailListAsync(int targetId, ReplyType type, long rootId, CursorReq cursor)
+        public async Task<DetailListReply> GetReplyDetailListAsync(long targetId, ReplyType type, long rootId, CursorReq cursor)
         {
             var req = new DetailListReq
             {
@@ -48,7 +48,7 @@ namespace Richasy.Bili.Lib.Uwp
         }
 
         /// <inheritdoc/>
-        public async Task<MainListReply> GetReplyMainListAsync(int targetId, ReplyType type, CursorReq cursor)
+        public async Task<MainListReply> GetReplyMainListAsync(long targetId, ReplyType type, CursorReq cursor)
         {
             var req = new MainListReq
             {
@@ -65,7 +65,7 @@ namespace Richasy.Bili.Lib.Uwp
         }
 
         /// <inheritdoc/>
-        public async Task<bool> AddReplyAsync(string message, int targetId, ReplyType type, long rootId, long parentId)
+        public async Task<bool> AddReplyAsync(string message, long targetId, ReplyType type, long rootId, long parentId)
         {
             var queryParameters = new Dictionary<string, string>
             {
@@ -84,7 +84,7 @@ namespace Richasy.Bili.Lib.Uwp
         }
 
         /// <inheritdoc/>
-        public async Task<bool> LikeReplyAsync(bool isLike, long replyId, int targetId, ReplyType type)
+        public async Task<bool> LikeReplyAsync(bool isLike, long replyId, long targetId, ReplyType type)
         {
             var queryParameters = new Dictionary<string, string>
             {

--- a/src/Models/Models.App/Args/ReplyIterationEventArgs.cs
+++ b/src/Models/Models.App/Args/ReplyIterationEventArgs.cs
@@ -17,7 +17,7 @@ namespace Richasy.Bili.Models.App.Args
         /// </summary>
         /// <param name="reply">评论响应结果.</param>
         /// <param name="targetId">目标区Id.</param>
-        public ReplyIterationEventArgs(MainListReply reply, int targetId)
+        public ReplyIterationEventArgs(MainListReply reply, long targetId)
         {
             TargetId = targetId;
             Cursor = reply.Cursor;
@@ -30,7 +30,7 @@ namespace Richasy.Bili.Models.App.Args
         /// </summary>
         /// <param name="reply">评论响应结果.</param>
         /// <param name="targetId">目标区Id.</param>
-        public ReplyIterationEventArgs(DetailListReply reply, int targetId)
+        public ReplyIterationEventArgs(DetailListReply reply, long targetId)
         {
             TargetId = targetId;
             Cursor = reply.Cursor;
@@ -41,7 +41,7 @@ namespace Richasy.Bili.Models.App.Args
         /// <summary>
         /// 目标区Id.
         /// </summary>
-        public int TargetId { get; set; }
+        public long TargetId { get; set; }
 
         /// <summary>
         /// 游标.

--- a/src/Models/Models.BiliBili/User/MessageItem.cs
+++ b/src/Models/Models.BiliBili/User/MessageItem.cs
@@ -36,6 +36,12 @@ namespace Richasy.Bili.Models.BiliBili
         public string Business { get; set; }
 
         /// <summary>
+        /// 消息对象Id.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "business_id", Required = Required.Default)]
+        public string BusinessId { get; set; }
+
+        /// <summary>
         /// 标题.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "title", Required = Required.Default)]

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -336,6 +336,7 @@ namespace Richasy.Bili.Models.Enums
         DecodingError,
         SourceNotSupported,
         NoEpisode,
+        BackToPrevious,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -337,6 +337,7 @@ namespace Richasy.Bili.Models.Enums
         SourceNotSupported,
         NoEpisode,
         BackToPrevious,
+        NotSupportReplyType,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/Models/Models.Enums/Bili/ReplyType.cs
+++ b/src/Models/Models.Enums/Bili/ReplyType.cs
@@ -13,6 +13,11 @@ namespace Richasy.Bili.Models.Enums.Bili
         Video = 1,
 
         /// <summary>
+        /// 相簿/图片动态.
+        /// </summary>
+        Album = 11,
+
+        /// <summary>
         /// 专栏文章.
         /// </summary>
         Article = 12,
@@ -23,9 +28,14 @@ namespace Richasy.Bili.Models.Enums.Bili
         Music = 14,
 
         /// <summary>
-        /// 动态.
+        /// 纯文本动态/分享.
         /// </summary>
         Dynamic = 17,
+
+        /// <summary>
+        /// 课程.
+        /// </summary>
+        Course = 33,
 
         /// <summary>
         /// 不设置.

--- a/src/ViewModels/ViewModels.Uwp/Base/ReplyViewModelBase.cs
+++ b/src/ViewModels/ViewModels.Uwp/Base/ReplyViewModelBase.cs
@@ -17,7 +17,7 @@ namespace Richasy.Bili.ViewModels.Uwp
         /// <summary>
         /// 目标Id.
         /// </summary>
-        public int TargetId { get; set; }
+        public long TargetId { get; set; }
 
         /// <summary>
         /// 评论区类型.

--- a/src/ViewModels/ViewModels.Uwp/Common/ReplyModuleViewModel/ReplyModuleViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/ReplyModuleViewModel/ReplyModuleViewModel.cs
@@ -33,11 +33,12 @@ namespace Richasy.Bili.ViewModels.Uwp
         /// </summary>
         /// <param name="targetId">目标评论区Id.</param>
         /// <param name="type">评论区类型.</param>
-        public void SetInformation(int targetId, ReplyType type)
+        /// <param name="currentMode">当前显示模式.</param>
+        public void SetInformation(long targetId, ReplyType type, Mode currentMode = Mode.MainListHot)
         {
             TargetId = targetId;
             Type = type;
-            CurrentMode = Mode.MainListHot;
+            CurrentMode = currentMode;
             Reset();
         }
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #173 #133 #129 

创建一个新的组件，合并回复列表视图与回复详情视图。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

1. 播放视频时，点开相关评论的详情，会显示一个居中的弹窗
2. 点击消息界面的回复信息条目时，会打开浏览器跳转到评论所在的媒体资源页面

## 新的行为是什么？

1. 取消打开某一楼层评论详情时的居中弹窗，改为在右侧同位置显示
2. 支持在回复消息界面直接展开回复详情

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 新组件
  - [x] 对于控件，已将控件放在主项目的 Controls 文件夹内
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

目前仍不支持跳转到指定的评论处开始浏览
