### PR TITLE
调整播放控件的最大宽度

### DIFF
--- a/src/App/Controls/Player/BiliPlayer/BiliPlayer.xaml
+++ b/src/App/Controls/Player/BiliPlayer/BiliPlayer.xaml
@@ -25,7 +25,6 @@
                                 <MediaPlayerElement.TransportControls>
                                     <local:BiliPlayerTransportControls
                                         x:Name="MTC"
-                                        MaxWidth="820"
                                         IsCompactOverlayButtonVisible="True"
                                         IsCompactOverlayEnabled="True"
                                         IsFullWindowButtonVisible="False"

--- a/src/App/Controls/Player/BiliPlayer/BiliPlayer.xaml
+++ b/src/App/Controls/Player/BiliPlayer/BiliPlayer.xaml
@@ -25,6 +25,7 @@
                                 <MediaPlayerElement.TransportControls>
                                     <local:BiliPlayerTransportControls
                                         x:Name="MTC"
+                                        MaxWidth="820"
                                         IsCompactOverlayButtonVisible="True"
                                         IsCompactOverlayEnabled="True"
                                         IsFullWindowButtonVisible="False"

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
@@ -588,7 +588,7 @@
                                                 x:Name="FullScreenModeButton"
                                                 AutomationProperties.Name="{loc:LocaleLocator Name=FullScreenMode}"
                                                 Style="{StaticResource MTCAppBarToggleButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="16"
+                                                MediaTransportControlsHelper.DropoutOrder="18"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=FullScreenMode}">
                                                 <AppBarToggleButton.Icon>
                                                     <icons:RegularFluentIcon FontSize="16" Symbol="FullScreenMaximize24" />

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
@@ -11,8 +11,10 @@
         x:Key="MTCAppBarButtonStyle"
         BasedOn="{StaticResource DefaultAppBarButtonStyle}"
         TargetType="AppBarButton">
-        <Setter Property="Height" Value="{ThemeResource MediaTransportControlsAppBarButtonHeight}" />
-        <Setter Property="Width" Value="{ThemeResource MediaTransportControlsAppBarButtonWidth}" />
+        <Setter Property="Height" Value="48" />
+        <Setter Property="Width" Value="40" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="AllowFocusOnInteraction" Value="True" />
     </Style>
     <!-- New AppBarToggle button style 40x40 pixels in size -->
@@ -20,7 +22,7 @@
         x:Key="MTCAppBarToggleButtonStyle"
         BasedOn="{StaticResource DefaultAppBarToggleButtonStyle}"
         TargetType="AppBarToggleButton">
-        <Setter Property="Height" Value="{ThemeResource MediaTransportControlsAppBarButtonHeight}" />
+        <Setter Property="Height" Value="48" />
         <Setter Property="Width" Value="{ThemeResource MediaTransportControlsAppBarButtonWidth}" />
         <Setter Property="AllowFocusOnInteraction" Value="True" />
     </Style>
@@ -289,7 +291,7 @@
                                 Opacity="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DanmakuViewModel.DanmakuOpacity}"
                                 Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DanmakuViewModel.IsShowDanmaku, Converter={StaticResource BoolToVisibilityConverter}}" />
                         </Grid>
-                        <Border x:Name="ControlPanel_ControlPanelVisibilityStates_Border">
+                        <Border x:Name="ControlPanel_ControlPanelVisibilityStates_Border" MaxWidth="820">
                             <Grid
                                 x:Name="ControlPanelGrid"
                                 VerticalAlignment="Bottom"
@@ -395,26 +397,20 @@
                                 <Grid
                                     x:Name="MediaTransportControls_Command_Border"
                                     Grid.Row="2"
-                                    Grid.Column="1">
+                                    Grid.Column="1"
+                                    Margin="0,-8,0,0">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
-                                    <CommandBar
-                                        x:Name="MediaControlsCommandBar"
-                                        Style="{StaticResource MTCCommandBarStyle}"
-                                        IsDynamicOverflowEnabled="False">
-                                        <CommandBar.Resources>
-                                            <Thickness x:Key="AppBarButtonInnerBorderMargin">5</Thickness>
-                                            <Thickness x:Key="AppBarButtonContentViewboxCollapsedMargin">0,12</Thickness>
-                                            <x:Double x:Key="AppBarThemeCompactHeight">40</x:Double>
-                                            <x:Double x:Key="AppBarMoreButtonColumnMinWidth">0</x:Double>
-                                        </CommandBar.Resources>
-                                        <CommandBar.PrimaryCommands>
-                                            <AppBarButton
-                                                x:Name="VolumeMuteButton"
-                                                Style="{StaticResource MTCAppBarButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="19">
+                                    <Grid x:Name="MediaControlsCommandBar">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel x:Name="LeftContainer" Orientation="Horizontal">
+                                            <AppBarButton x:Name="VolumeMuteButton" Style="{StaticResource MTCAppBarButtonStyle}">
                                                 <AppBarButton.Flyout>
                                                     <Flyout
                                                         x:Name="VolumeFlyout"
@@ -462,7 +458,6 @@
                                                 x:Name="FormatButton"
                                                 AutomationProperties.Name="{loc:LocaleLocator Name=Quality}"
                                                 Style="{StaticResource MTCAppBarButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="13"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=Quality}"
                                                 Visibility="Collapsed">
                                                 <AppBarButton.Icon>
@@ -493,22 +488,22 @@
                                             <AppBarButton
                                                 x:Name="PlaybackRateButton"
                                                 Style="{StaticResource MTCAppBarButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="10"
                                                 Visibility="Collapsed">
                                                 <AppBarButton.Icon>
                                                     <FontIcon Glyph="&#xEC57;" />
                                                 </AppBarButton.Icon>
                                             </AppBarButton>
-                                            <AppBarSeparator
-                                                x:Name="LeftSeparator"
-                                                Width="0"
-                                                Height="0"
-                                                Margin="0,0" />
+                                        </StackPanel>
+                                        <StackPanel
+                                            x:Name="CenterContainer"
+                                            Grid.ColumnSpan="3"
+                                            HorizontalAlignment="Center"
+                                            Orientation="Horizontal">
                                             <AppBarButton
                                                 x:Name="BackSkipButton"
+                                                AutomationProperties.Name="{loc:LocaleLocator Name=BackSkip}"
                                                 Style="{StaticResource MTCAppBarButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="2"
-                                                Visibility="Collapsed">
+                                                ToolTipService.ToolTip="{loc:LocaleLocator Name=BackSkip}">
                                                 <AppBarButton.KeyboardAccelerators>
                                                     <KeyboardAccelerator Key="Left" IsEnabled="True" />
                                                 </AppBarButton.KeyboardAccelerators>
@@ -516,10 +511,7 @@
                                                     <icons:RegularFluentIcon FontWeight="Bold" Symbol="ArrowReply48" />
                                                 </AppBarButton.Icon>
                                             </AppBarButton>
-                                            <AppBarButton
-                                                x:Name="PlayPauseButton"
-                                                Style="{StaticResource MTCAppBarButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="23">
+                                            <AppBarButton x:Name="PlayPauseButton" Style="{StaticResource MTCAppBarButtonStyle}">
                                                 <AppBarButton.Icon>
                                                     <icons:RegularFluentIcon x:Name="PlayPauseSymbol" Glyph="&#x002B;" />
                                                 </AppBarButton.Icon>
@@ -532,9 +524,9 @@
                                             </AppBarButton>
                                             <AppBarButton
                                                 x:Name="ForwardSkipButton"
+                                                AutomationProperties.Name="{loc:LocaleLocator Name=ForwardSkip}"
                                                 Style="{StaticResource MTCAppBarButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="2"
-                                                Visibility="Collapsed">
+                                                ToolTipService.ToolTip="{loc:LocaleLocator Name=ForwardSkip}">
                                                 <AppBarButton.KeyboardAccelerators>
                                                     <KeyboardAccelerator Key="Right" IsEnabled="True" />
                                                 </AppBarButton.KeyboardAccelerators>
@@ -542,15 +534,12 @@
                                                     <icons:RegularFluentIcon FontWeight="Bold" Symbol="ArrowForward48" />
                                                 </AppBarButton.Icon>
                                             </AppBarButton>
-                                            <AppBarSeparator
-                                                x:Name="RightSeparator"
-                                                Width="0"
-                                                Height="0"
-                                                Margin="0,0" />
-                                            <AppBarButton
-                                                x:Name="CastButton"
-                                                Style="{StaticResource MTCAppBarButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="11">
+                                        </StackPanel>
+                                        <StackPanel
+                                            Name="RightContainer"
+                                            Grid.Column="2"
+                                            Orientation="Horizontal">
+                                            <AppBarButton x:Name="CastButton" Style="{StaticResource MTCAppBarButtonStyle}">
                                                 <AppBarButton.Icon>
                                                     <FontIcon Glyph="&#xEC15;" />
                                                 </AppBarButton.Icon>
@@ -559,7 +548,6 @@
                                                 x:Name="CompactOverlayModeButton"
                                                 AutomationProperties.Name="{loc:LocaleLocator Name=CompactOverlayMode}"
                                                 Style="{StaticResource MTCAppBarToggleButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="17"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=CompactOverlayMode}">
                                                 <AppBarToggleButton.Icon>
                                                     <icons:RegularFluentIcon FontSize="16" Symbol="ExpandUpRight48" />
@@ -575,7 +563,6 @@
                                                 x:Name="FullWindowModeButton"
                                                 AutomationProperties.Name="{loc:LocaleLocator Name=FullWindowMode}"
                                                 Style="{StaticResource MTCAppBarToggleButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="15"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=FullWindowMode}">
                                                 <AppBarToggleButton.Icon>
                                                     <icons:RegularFluentIcon FontSize="16" Symbol="AutoFitWidth24" />
@@ -588,7 +575,6 @@
                                                 x:Name="FullScreenModeButton"
                                                 AutomationProperties.Name="{loc:LocaleLocator Name=FullScreenMode}"
                                                 Style="{StaticResource MTCAppBarToggleButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="18"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=FullScreenMode}">
                                                 <AppBarToggleButton.Icon>
                                                     <icons:RegularFluentIcon FontSize="16" Symbol="FullScreenMaximize24" />
@@ -597,8 +583,8 @@
                                                     <KeyboardAccelerator Key="F11" IsEnabled="True" />
                                                 </AppBarToggleButton.KeyboardAccelerators>
                                             </AppBarToggleButton>
-                                        </CommandBar.PrimaryCommands>
-                                    </CommandBar>
+                                        </StackPanel>
+                                    </Grid>
                                     <Grid
                                         x:Name="Danmaku_Command_Border"
                                         Grid.Row="1"
@@ -775,7 +761,6 @@
                                         <Setter Target="MediaTransportControls_Command_Border.(Grid.Column)" Value="2" />
                                         <Setter Target="MediaTransportControls_Command_Border.(Grid.Row)" Value="1" />
                                         <Setter Target="ControlPanelGrid.Height" Value="48" />
-                                        <Setter Target="MediaControlsCommandBar.Margin" Value="0" />
                                         <Setter Target="PlayPauseButton.Visibility" Value="Collapsed" />
                                         <Setter Target="ControlPanelGrid.Padding" Value="3" />
                                     </VisualState.Setters>
@@ -846,6 +831,7 @@
                         <Border x:Name="ControlPanel_ControlPanelVisibilityStates_Border">
                             <Grid
                                 x:Name="ControlPanelGrid"
+                                MaxWidth="820"
                                 VerticalAlignment="Bottom"
                                 Background="{ThemeResource MediaTransportControlsPanelBackground}"
                                 BorderBrush="{ThemeResource MediaTransportControlsBorderBrush}"
@@ -897,17 +883,13 @@
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
-                                    <CommandBar
-                                        x:Name="MediaControlsCommandBar"
-                                        Style="{StaticResource MTCCommandBarStyle}"
-                                        IsDynamicOverflowEnabled="False">
-                                        <CommandBar.Resources>
-                                            <Thickness x:Key="AppBarButtonInnerBorderMargin">5</Thickness>
-                                            <Thickness x:Key="AppBarButtonContentViewboxCollapsedMargin">0,12</Thickness>
-                                            <x:Double x:Key="AppBarThemeCompactHeight">40</x:Double>
-                                            <x:Double x:Key="AppBarMoreButtonColumnMinWidth">0</x:Double>
-                                        </CommandBar.Resources>
-                                        <CommandBar.PrimaryCommands>
+                                    <Grid x:Name="MediaControlsCommandBar">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel x:Name="LeftContainer" Orientation="Horizontal">
                                             <AppBarButton
                                                 x:Name="VolumeMuteButton"
                                                 Style="{StaticResource MTCAppBarButtonStyle}"
@@ -1021,11 +1003,11 @@
                                                         Modifiers="Control" />
                                                 </AppBarButton.KeyboardAccelerators>
                                             </AppBarButton>
-                                            <AppBarSeparator
-                                                x:Name="LeftSeparator"
-                                                Width="0"
-                                                Height="0"
-                                                Margin="0,0" />
+                                        </StackPanel>
+                                        <StackPanel
+                                            x:Name="CenterContaienr"
+                                            Grid.ColumnSpan="3"
+                                            HorizontalAlignment="Center">
                                             <AppBarButton
                                                 x:Name="PlayPauseButton"
                                                 Style="{StaticResource MTCAppBarButtonStyle}"
@@ -1041,11 +1023,11 @@
                                                         Modifiers="Control" />
                                                 </AppBarButton.KeyboardAccelerators>
                                             </AppBarButton>
-                                            <AppBarSeparator
-                                                x:Name="RightSeparator"
-                                                Width="0"
-                                                Height="0"
-                                                Margin="0,0" />
+                                        </StackPanel>
+                                        <StackPanel
+                                            x:Name="RightContainer"
+                                            Grid.Column="2"
+                                            Orientation="Horizontal">
                                             <AppBarButton
                                                 x:Name="CastButton"
                                                 Style="{StaticResource MTCAppBarButtonStyle}"
@@ -1096,8 +1078,8 @@
                                                     <KeyboardAccelerator Key="F11" IsEnabled="True" />
                                                 </AppBarToggleButton.KeyboardAccelerators>
                                             </AppBarToggleButton>
-                                        </CommandBar.PrimaryCommands>
-                                    </CommandBar>
+                                        </StackPanel>
+                                    </Grid>
                                     <Grid
                                         x:Name="Danmaku_Command_Border"
                                         Grid.Row="1"

--- a/src/App/Pages/Overlay/PlayerPage.xaml
+++ b/src/App/Pages/Overlay/PlayerPage.xaml
@@ -70,7 +70,6 @@
             <Grid
                 x:Name="ContentGrid"
                 Margin="{StaticResource DefaultContainerWithBottomPadding}"
-                x:Load="False"
                 ColumnSpacing="48"
                 Visibility="{x:Bind ViewModel.IsDetailError, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
                 <Grid.RowDefinitions>

--- a/src/App/Pages/Overlay/PlayerPage.xaml
+++ b/src/App/Pages/Overlay/PlayerPage.xaml
@@ -61,6 +61,7 @@
                         <Setter Target="ContentContainer.Visibility" Value="Collapsed" />
                         <Setter Target="PlayErrorContainer.CornerRadius" Value="0" />
                         <Setter Target="BiliPlayer.CornerRadius" Value="0" />
+                        <Setter Target="PlayerContainer.Margin" Value="0" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
@@ -89,10 +90,11 @@
                     <Grid
                         x:Name="PlayErrorContainer"
                         MinHeight="200"
+                        HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
-                        x:Load="{x:Bind ViewModel.IsPlayInformationError, Mode=OneWay}"
                         Background="{ThemeResource LayerFillColorDefaultBrush}"
-                        CornerRadius="{StaticResource OverlayCornerRadius}">
+                        CornerRadius="{StaticResource OverlayCornerRadius}"
+                        Visibility="{x:Bind ViewModel.IsPlayInformationError, Mode=OneWay}">
                         <StackPanel
                             Padding="20,12"
                             HorizontalAlignment="Center"

--- a/src/App/Pages/Overlay/PlayerPage.xaml.cs
+++ b/src/App/Pages/Overlay/PlayerPage.xaml.cs
@@ -195,18 +195,18 @@ namespace Richasy.Bili.App.Pages.Overlay
         {
             if (ViewModel.PlayerDisplayMode == PlayerDisplayMode.Default)
             {
-                if (RootGrid.Children.Count > 1)
+                if (RootGrid.Children.Contains(PlayerContainer))
                 {
-                    RootGrid.Children.Remove(BiliPlayer);
-                    PlayerContainer.Children.Add(BiliPlayer);
+                    RootGrid.Children.Remove(PlayerContainer);
+                    ContentGrid.Children.Insert(0, PlayerContainer);
                 }
             }
             else
             {
-                if (PlayerContainer.Children.Count > 0)
+                if (ContentGrid.Children.Contains(PlayerContainer))
                 {
-                    PlayerContainer.Children.Remove(BiliPlayer);
-                    RootGrid.Children.Add(BiliPlayer);
+                    ContentGrid.Children.Remove(PlayerContainer);
+                    RootGrid.Children.Add(PlayerContainer);
                 }
             }
         }

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -174,6 +174,9 @@
   <data name="AutoPlayWhenLoaded" xml:space="preserve">
     <value>加载完成后自动播放</value>
   </data>
+  <data name="BackSkip" xml:space="preserve">
+    <value>向后跳转</value>
+  </data>
   <data name="BackToDefaultView" xml:space="preserve">
     <value>返回标准视图</value>
   </data>
@@ -423,6 +426,9 @@
   </data>
   <data name="FontSize" xml:space="preserve">
     <value>字号</value>
+  </data>
+  <data name="ForwardSkip" xml:space="preserve">
+    <value>向前跳转</value>
   </data>
   <data name="FullScreenMode" xml:space="preserve">
     <value>全屏模式</value>

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -338,6 +338,8 @@ namespace Richasy.Bili.Models.Enums
         NoEpisode,
         BackToPrevious,
         NotSupportReplyType,
+        ForwardSkip,
+        BackSkip,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -655,6 +655,12 @@ namespace Richasy.Bili.ViewModels.Uwp
         {
             await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
             {
+                // 在视频未加载时不对报错进行处理.
+                if (PlayerStatus == PlayerStatus.NotLoad)
+                {
+                    return;
+                }
+
                 PlayerStatus = PlayerStatus.End;
                 IsPlayInformationError = true;
                 var message = string.Empty;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #154 

将媒体播放控件的最大宽度调整为 820

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

媒体播放控件的宽度跟随播放窗口的宽度而变化

## 新的行为是什么？

媒体播放控件的最大宽度是820

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->
