### PR TITLE
修复首页推荐刷新错误

### DIFF
--- a/src/App/Controls/Danmaku/DanmakuBox.xaml
+++ b/src/App/Controls/Danmaku/DanmakuBox.xaml
@@ -36,7 +36,7 @@
         <StackPanel
             Grid.Column="2"
             Orientation="Horizontal"
-            Spacing="8">
+            Spacing="6">
             <Button
                 x:Name="DanmakuSendSettingsButton"
                 AutomationProperties.Name="{loc:LocaleLocator Name=DanmakuSendSettings}"

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.Properties.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.Properties.cs
@@ -5,6 +5,7 @@ using Richasy.Bili.ViewModels.Uwp;
 using Richasy.Bili.ViewModels.Uwp.Common;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Shapes;
 
 namespace Richasy.Bili.App.Controls
@@ -51,18 +52,18 @@ namespace Richasy.Bili.App.Controls
         private DispatcherTimer _danmakuTimer;
         private DispatcherTimer _cursorTimer;
         private DanmakuView _danmakuView;
-        private AppBarToggleButton _fullWindowPlayModeButton;
-        private AppBarToggleButton _fullScreenPlayModeButton;
-        private AppBarToggleButton _compactOverlayPlayModeButton;
+        private ToggleButton _fullWindowPlayModeButton;
+        private ToggleButton _fullScreenPlayModeButton;
+        private ToggleButton _compactOverlayPlayModeButton;
         private Rectangle _interactionControl;
         private Border _controlPanel;
         private ListView _formatListView;
         private ListView _liveQualityListView;
         private ListView _livePlayLineListView;
         private Button _backButton;
-        private AppBarButton _backSkipButton;
-        private AppBarButton _forwardSkipButton;
-        private AppBarButton _playPauseButton;
+        private Button _backSkipButton;
+        private Button _forwardSkipButton;
+        private Button _playPauseButton;
         private int _segmentIndex;
         private double _cursorStayTime;
 

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
@@ -13,6 +13,7 @@ using Richasy.Bili.ViewModels.Uwp;
 using Windows.Media.Playback;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Shapes;
 
@@ -48,18 +49,18 @@ namespace Richasy.Bili.App.Controls
         protected override void OnApplyTemplate()
         {
             _danmakuView = GetTemplateChild(DanmakuViewName) as DanmakuView;
-            _fullWindowPlayModeButton = GetTemplateChild(FullWindowPlayModeButtonName) as AppBarToggleButton;
-            _fullScreenPlayModeButton = GetTemplateChild(FullScreenPlayModeButtonName) as AppBarToggleButton;
-            _compactOverlayPlayModeButton = GetTemplateChild(CompactOverlayPlayModeButtonName) as AppBarToggleButton;
+            _fullWindowPlayModeButton = GetTemplateChild(FullWindowPlayModeButtonName) as ToggleButton;
+            _fullScreenPlayModeButton = GetTemplateChild(FullScreenPlayModeButtonName) as ToggleButton;
+            _compactOverlayPlayModeButton = GetTemplateChild(CompactOverlayPlayModeButtonName) as ToggleButton;
             _interactionControl = GetTemplateChild(InteractionControlName) as Rectangle;
             _controlPanel = GetTemplateChild(ControlPanelName) as Border;
             _formatListView = GetTemplateChild(FormatListViewName) as ListView;
             _livePlayLineListView = GetTemplateChild(LivePlayLineListViewName) as ListView;
             _liveQualityListView = GetTemplateChild(LiveQualityListViewName) as ListView;
             _backButton = GetTemplateChild(BackButtonName) as Button;
-            _backSkipButton = GetTemplateChild(BackSkipButtonName) as AppBarButton;
-            _forwardSkipButton = GetTemplateChild(ForwardSkipButtonName) as AppBarButton;
-            _playPauseButton = GetTemplateChild(PlayPauseButtonName) as AppBarButton;
+            _backSkipButton = GetTemplateChild(BackSkipButtonName) as Button;
+            _forwardSkipButton = GetTemplateChild(ForwardSkipButtonName) as Button;
+            _playPauseButton = GetTemplateChild(PlayPauseButtonName) as Button;
 
             _fullWindowPlayModeButton.Click += OnPlayModeButtonClick;
             _fullScreenPlayModeButton.Click += OnPlayModeButtonClick;
@@ -210,7 +211,7 @@ namespace Richasy.Bili.App.Controls
 
         private void OnPlayModeButtonClick(object sender, RoutedEventArgs e)
         {
-            var btn = sender as AppBarToggleButton;
+            var btn = sender as ToggleButton;
             PlayerDisplayMode mode = default;
             switch (btn.Name)
             {

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
@@ -8,23 +8,26 @@
 
     <!-- New AppBar button style 40x40 pixels in size -->
     <Style
-        x:Key="MTCAppBarButtonStyle"
-        BasedOn="{StaticResource DefaultAppBarButtonStyle}"
-        TargetType="AppBarButton">
-        <Setter Property="Height" Value="48" />
-        <Setter Property="Width" Value="40" />
+        x:Key="MTCButtonStyle"
+        BasedOn="{StaticResource DefaultButtonStyle}"
+        TargetType="Button">
+        <Setter Property="Height" Value="32" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="AllowFocusOnInteraction" Value="True" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Background" Value="Transparent" />
     </Style>
     <!-- New AppBarToggle button style 40x40 pixels in size -->
     <Style
-        x:Key="MTCAppBarToggleButtonStyle"
-        BasedOn="{StaticResource DefaultAppBarToggleButtonStyle}"
-        TargetType="AppBarToggleButton">
-        <Setter Property="Height" Value="48" />
-        <Setter Property="Width" Value="{ThemeResource MediaTransportControlsAppBarButtonWidth}" />
+        x:Key="MTCToggleButtonStyle"
+        BasedOn="{StaticResource DefaultToggleButtonStyle}"
+        TargetType="ToggleButton">
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="Height" Value="32" />
         <Setter Property="AllowFocusOnInteraction" Value="True" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Background" Value="Transparent" />
     </Style>
     <!-- New CommandBar Style -->
     <Style
@@ -58,9 +61,9 @@
         BasedOn="{StaticResource DefaultSliderStyle}"
         TargetType="Slider" />
     <Style
-        x:Key="MediaControlAppBarButtonStyle"
-        BasedOn="{StaticResource DefaultAppBarButtonStyle}"
-        TargetType="AppBarButton" />
+        x:Key="MediaControlButtonStyle"
+        BasedOn="{StaticResource DefaultButtonStyle}"
+        TargetType="Button" />
 
     <Style BasedOn="{StaticResource DefaultMTCStyle}" TargetType="local:BiliPlayerTransportControls" />
 
@@ -76,6 +79,11 @@
             <Setter.Value>
                 <ControlTemplate TargetType="local:BiliPlayerTransportControls">
                     <Grid x:Name="RootGrid" Background="Transparent">
+                        <Grid.Resources>
+                            <Style TargetType="icons:RegularFluentIcon">
+                                <Setter Property="FontSize" Value="16" />
+                            </Style>
+                        </Grid.Resources>
                         <VisualStateManager.VisualStateGroups>
                             <!-- ControlPanel Visibility states -->
                             <VisualStateGroup x:Name="ControlPanelVisibilityStates">
@@ -371,56 +379,55 @@
                                     Grid.Row="1"
                                     Grid.Column="0"
                                     Visibility="Collapsed">
-                                    <AppBarButton
+                                    <Button
                                         x:Name="PlayPauseButtonOnLeft"
-                                        Style="{StaticResource MTCAppBarButtonStyle}"
+                                        Style="{StaticResource MTCButtonStyle}"
                                         Margin="0"
                                         VerticalAlignment="Center">
-                                        <AppBarButton.Resources>
-                                            <Thickness x:Key="AppBarButtonInnerBorderMargin">5</Thickness>
-                                            <Thickness x:Key="AppBarButtonContentViewboxCollapsedMargin">0,12</Thickness>
-                                        </AppBarButton.Resources>
-                                        <AppBarButton.Icon>
+                                        <Button.Resources>
+                                            <Thickness x:Key="ButtonInnerBorderMargin">5</Thickness>
+                                            <Thickness x:Key="ButtonContentViewboxCollapsedMargin">0,12</Thickness>
+                                        </Button.Resources>
+                                        <Button.Content>
                                             <FontIcon x:Name="PlayPauseSymbolLeft" Glyph="&#xF5B0;" />
-                                        </AppBarButton.Icon>
-                                    </AppBarButton>
+                                        </Button.Content>
+                                    </Button>
                                 </Border>
                                 <Grid
                                     x:Name="MediaTransportControls_Command_Border"
                                     Grid.Row="2"
-                                    Grid.Column="1"
-                                    Margin="0,-8,0,0">
+                                    Grid.Column="1">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
-                                    <Grid x:Name="MediaControlsCommandBar">
+                                    <Grid x:Name="MediaControlsCommandBar" Padding="4,0,4,4">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
                                         <StackPanel x:Name="LeftContainer" Orientation="Horizontal">
-                                            <AppBarButton x:Name="VolumeMuteButton" Style="{StaticResource MTCAppBarButtonStyle}">
-                                                <AppBarButton.Flyout>
+                                            <Button x:Name="VolumeMuteButton" Style="{StaticResource MTCButtonStyle}">
+                                                <Button.Flyout>
                                                     <Flyout
                                                         x:Name="VolumeFlyout"
                                                         contract8Present:ShouldConstrainToRootBounds="False"
                                                         FlyoutPresenterStyle="{StaticResource MTCFlyoutStyle}">
                                                         <StackPanel Padding="4,0,16,0" Orientation="Horizontal">
-                                                            <AppBarButton
+                                                            <Button
                                                                 x:Name="AudioMuteButton"
-                                                                Style="{StaticResource MTCAppBarButtonStyle}"
+                                                                Style="{StaticResource MTCButtonStyle}"
                                                                 HorizontalAlignment="Center"
                                                                 VerticalAlignment="Center">
-                                                                <AppBarButton.Resources>
-                                                                    <Thickness x:Key="AppBarButtonContentViewboxCollapsedMargin">0,12</Thickness>
-                                                                    <Thickness x:Key="AppBarButtonInnerBorderMargin">5</Thickness>
-                                                                </AppBarButton.Resources>
-                                                                <AppBarButton.Icon>
+                                                                <Button.Resources>
+                                                                    <Thickness x:Key="ButtonContentViewboxCollapsedMargin">0,12</Thickness>
+                                                                    <Thickness x:Key="ButtonInnerBorderMargin">5</Thickness>
+                                                                </Button.Resources>
+                                                                <Button.Content>
                                                                     <SymbolIcon x:Name="AudioMuteSymbol" Symbol="Volume" />
-                                                                </AppBarButton.Icon>
-                                                            </AppBarButton>
+                                                                </Button.Content>
+                                                            </Button>
                                                             <Slider
                                                                 x:Name="VolumeSlider"
                                                                 Width="{ThemeResource MediaTransportControlsSliderWidth}"
@@ -440,20 +447,20 @@
                                                                 TextAlignment="Right" />
                                                         </StackPanel>
                                                     </Flyout>
-                                                </AppBarButton.Flyout>
-                                                <AppBarButton.Icon>
-                                                    <SymbolIcon x:Name="VolumeMuteSymbol" Symbol="Volume" />
-                                                </AppBarButton.Icon>
-                                            </AppBarButton>
-                                            <AppBarButton
+                                                </Button.Flyout>
+                                                <Button.Content>
+                                                    <icons:RegularFluentIcon Symbol="Speaker220" />
+                                                </Button.Content>
+                                            </Button>
+                                            <Button
                                                 x:Name="FormatButton"
                                                 AutomationProperties.Name="{loc:LocaleLocator Name=Quality}"
-                                                Style="{StaticResource MTCAppBarButtonStyle}"
+                                                Style="{StaticResource MTCButtonStyle}"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=Quality}">
-                                                <AppBarButton.Icon>
+                                                <Button.Content>
                                                     <icons:RegularFluentIcon Symbol="Hd24" />
-                                                </AppBarButton.Icon>
-                                                <AppBarButton.Flyout>
+                                                </Button.Content>
+                                                <Button.Flyout>
                                                     <Flyout FlyoutPresenterStyle="{StaticResource MTCFlyoutStyle}" Placement="Top">
                                                         <ListView
                                                             x:Name="FormatListView"
@@ -467,115 +474,115 @@
                                                             </ListView.ItemTemplate>
                                                         </ListView>
                                                     </Flyout>
-                                                </AppBarButton.Flyout>
-                                                <AppBarButton.KeyboardAccelerators>
+                                                </Button.Flyout>
+                                                <Button.KeyboardAccelerators>
                                                     <KeyboardAccelerator
                                                         Key="Q"
                                                         IsEnabled="True"
                                                         Modifiers="Control" />
-                                                </AppBarButton.KeyboardAccelerators>
-                                            </AppBarButton>
-                                            <AppBarButton x:Name="PlaybackRateButton" Style="{StaticResource MTCAppBarButtonStyle}">
-                                                <AppBarButton.Icon>
-                                                    <FontIcon Glyph="&#xEC57;" />
-                                                </AppBarButton.Icon>
-                                            </AppBarButton>
+                                                </Button.KeyboardAccelerators>
+                                            </Button>
+                                            <Button x:Name="PlaybackRateButton" Style="{StaticResource MTCButtonStyle}">
+                                                <Button.Content>
+                                                    <icons:RegularFluentIcon Symbol="Replay20" />
+                                                </Button.Content>
+                                            </Button>
                                         </StackPanel>
                                         <StackPanel
                                             x:Name="CenterContainer"
                                             Grid.ColumnSpan="3"
                                             HorizontalAlignment="Center"
                                             Orientation="Horizontal">
-                                            <AppBarButton
+                                            <Button
                                                 x:Name="BackSkipButton"
                                                 AutomationProperties.Name="{loc:LocaleLocator Name=BackSkip}"
-                                                Style="{StaticResource MTCAppBarButtonStyle}"
+                                                Style="{StaticResource MTCButtonStyle}"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=BackSkip}">
-                                                <AppBarButton.KeyboardAccelerators>
+                                                <Button.KeyboardAccelerators>
                                                     <KeyboardAccelerator Key="Left" IsEnabled="True" />
-                                                </AppBarButton.KeyboardAccelerators>
-                                                <AppBarButton.Icon>
+                                                </Button.KeyboardAccelerators>
+                                                <Button.Content>
                                                     <icons:RegularFluentIcon FontWeight="Bold" Symbol="ArrowReply48" />
-                                                </AppBarButton.Icon>
-                                            </AppBarButton>
-                                            <AppBarButton x:Name="PlayPauseButton" Style="{StaticResource MTCAppBarButtonStyle}">
-                                                <AppBarButton.Icon>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button x:Name="PlayPauseButton" Style="{StaticResource MTCButtonStyle}">
+                                                <Button.Content>
                                                     <icons:RegularFluentIcon x:Name="PlayPauseSymbol" Glyph="&#x002B;" />
-                                                </AppBarButton.Icon>
-                                                <AppBarButton.KeyboardAccelerators>
+                                                </Button.Content>
+                                                <Button.KeyboardAccelerators>
                                                     <KeyboardAccelerator
                                                         Key="P"
                                                         IsEnabled="True"
                                                         Modifiers="Control" />
-                                                </AppBarButton.KeyboardAccelerators>
-                                            </AppBarButton>
-                                            <AppBarButton
+                                                </Button.KeyboardAccelerators>
+                                            </Button>
+                                            <Button
                                                 x:Name="ForwardSkipButton"
                                                 AutomationProperties.Name="{loc:LocaleLocator Name=ForwardSkip}"
-                                                Style="{StaticResource MTCAppBarButtonStyle}"
+                                                Style="{StaticResource MTCButtonStyle}"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=ForwardSkip}">
-                                                <AppBarButton.KeyboardAccelerators>
+                                                <Button.KeyboardAccelerators>
                                                     <KeyboardAccelerator Key="Right" IsEnabled="True" />
-                                                </AppBarButton.KeyboardAccelerators>
-                                                <AppBarButton.Icon>
+                                                </Button.KeyboardAccelerators>
+                                                <Button.Content>
                                                     <icons:RegularFluentIcon FontWeight="Bold" Symbol="ArrowForward48" />
-                                                </AppBarButton.Icon>
-                                            </AppBarButton>
+                                                </Button.Content>
+                                            </Button>
                                         </StackPanel>
                                         <StackPanel
                                             Name="RightContainer"
                                             Grid.Column="2"
                                             Orientation="Horizontal">
-                                            <AppBarButton x:Name="CastButton" Style="{StaticResource MTCAppBarButtonStyle}">
-                                                <AppBarButton.Icon>
-                                                    <FontIcon Glyph="&#xEC15;" />
-                                                </AppBarButton.Icon>
-                                            </AppBarButton>
-                                            <AppBarToggleButton
+                                            <Button x:Name="CastButton" Style="{StaticResource MTCButtonStyle}">
+                                                <Button.Content>
+                                                    <icons:RegularFluentIcon Symbol="Cast20" />
+                                                </Button.Content>
+                                            </Button>
+                                            <ToggleButton
                                                 x:Name="CompactOverlayModeButton"
                                                 AutomationProperties.Name="{loc:LocaleLocator Name=CompactOverlayMode}"
-                                                Style="{StaticResource MTCAppBarToggleButtonStyle}"
+                                                Style="{StaticResource MTCToggleButtonStyle}"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=CompactOverlayMode}">
-                                                <AppBarToggleButton.Icon>
+                                                <ToggleButton.Content>
                                                     <icons:RegularFluentIcon FontSize="16" Symbol="ExpandUpRight48" />
-                                                </AppBarToggleButton.Icon>
-                                                <AppBarToggleButton.KeyboardAccelerators>
+                                                </ToggleButton.Content>
+                                                <ToggleButton.KeyboardAccelerators>
                                                     <KeyboardAccelerator
                                                         Key="M"
                                                         IsEnabled="True"
                                                         Modifiers="Control" />
-                                                </AppBarToggleButton.KeyboardAccelerators>
-                                            </AppBarToggleButton>
-                                            <AppBarToggleButton
+                                                </ToggleButton.KeyboardAccelerators>
+                                            </ToggleButton>
+                                            <ToggleButton
                                                 x:Name="FullWindowModeButton"
                                                 AutomationProperties.Name="{loc:LocaleLocator Name=FullWindowMode}"
-                                                Style="{StaticResource MTCAppBarToggleButtonStyle}"
+                                                Style="{StaticResource MTCToggleButtonStyle}"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=FullWindowMode}">
-                                                <AppBarToggleButton.Icon>
+                                                <ToggleButton.Content>
                                                     <icons:RegularFluentIcon FontSize="16" Symbol="AutoFitWidth24" />
-                                                </AppBarToggleButton.Icon>
-                                                <AppBarToggleButton.KeyboardAccelerators>
+                                                </ToggleButton.Content>
+                                                <ToggleButton.KeyboardAccelerators>
                                                     <KeyboardAccelerator Key="F10" IsEnabled="True" />
-                                                </AppBarToggleButton.KeyboardAccelerators>
-                                            </AppBarToggleButton>
-                                            <AppBarToggleButton
+                                                </ToggleButton.KeyboardAccelerators>
+                                            </ToggleButton>
+                                            <ToggleButton
                                                 x:Name="FullScreenModeButton"
                                                 AutomationProperties.Name="{loc:LocaleLocator Name=FullScreenMode}"
-                                                Style="{StaticResource MTCAppBarToggleButtonStyle}"
+                                                Style="{StaticResource MTCToggleButtonStyle}"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=FullScreenMode}">
-                                                <AppBarToggleButton.Icon>
+                                                <ToggleButton.Content>
                                                     <icons:RegularFluentIcon FontSize="16" Symbol="FullScreenMaximize24" />
-                                                </AppBarToggleButton.Icon>
-                                                <AppBarToggleButton.KeyboardAccelerators>
+                                                </ToggleButton.Content>
+                                                <ToggleButton.KeyboardAccelerators>
                                                     <KeyboardAccelerator Key="F11" IsEnabled="True" />
-                                                </AppBarToggleButton.KeyboardAccelerators>
-                                            </AppBarToggleButton>
+                                                </ToggleButton.KeyboardAccelerators>
+                                            </ToggleButton>
                                         </StackPanel>
                                     </Grid>
                                     <Grid
                                         x:Name="Danmaku_Command_Border"
                                         Grid.Row="1"
-                                        Padding="4,8"
+                                        Padding="4,4,8,4"
                                         BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
                                         BorderThickness="0,1,0,0">
                                         <local:DanmakuBox />
@@ -623,6 +630,11 @@
             <Setter.Value>
                 <ControlTemplate TargetType="local:BiliPlayerTransportControls">
                     <Grid x:Name="RootGrid" Background="Transparent">
+                        <Grid.Resources>
+                            <Style TargetType="icons:RegularFluentIcon">
+                                <Setter Property="FontSize" Value="16" />
+                            </Style>
+                        </Grid.Resources>
                         <VisualStateManager.VisualStateGroups>
                             <!-- ControlPanel Visibility states -->
                             <VisualStateGroup x:Name="ControlPanelVisibilityStates">
@@ -861,36 +873,33 @@
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
-                                    <Grid x:Name="MediaControlsCommandBar">
+                                    <Grid x:Name="MediaControlsCommandBar" Padding="4">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
                                         <StackPanel x:Name="LeftContainer" Orientation="Horizontal">
-                                            <AppBarButton
-                                                x:Name="VolumeMuteButton"
-                                                Style="{StaticResource MTCAppBarButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="19">
-                                                <AppBarButton.Flyout>
+                                            <Button x:Name="VolumeMuteButton" Style="{StaticResource MTCButtonStyle}">
+                                                <Button.Flyout>
                                                     <Flyout
                                                         x:Name="VolumeFlyout"
                                                         contract8Present:ShouldConstrainToRootBounds="False"
                                                         FlyoutPresenterStyle="{StaticResource MTCFlyoutStyle}">
                                                         <StackPanel Padding="4,0,16,0" Orientation="Horizontal">
-                                                            <AppBarButton
+                                                            <Button
                                                                 x:Name="AudioMuteButton"
-                                                                Style="{StaticResource MTCAppBarButtonStyle}"
+                                                                Style="{StaticResource MTCButtonStyle}"
                                                                 HorizontalAlignment="Center"
                                                                 VerticalAlignment="Center">
-                                                                <AppBarButton.Resources>
-                                                                    <Thickness x:Key="AppBarButtonContentViewboxCollapsedMargin">0,12</Thickness>
-                                                                    <Thickness x:Key="AppBarButtonInnerBorderMargin">5</Thickness>
-                                                                </AppBarButton.Resources>
-                                                                <AppBarButton.Icon>
+                                                                <Button.Resources>
+                                                                    <Thickness x:Key="ButtonContentViewboxCollapsedMargin">0,12</Thickness>
+                                                                    <Thickness x:Key="ButtonInnerBorderMargin">5</Thickness>
+                                                                </Button.Resources>
+                                                                <Button.Content>
                                                                     <SymbolIcon x:Name="AudioMuteSymbol" Symbol="Volume" />
-                                                                </AppBarButton.Icon>
-                                                            </AppBarButton>
+                                                                </Button.Content>
+                                                            </Button>
                                                             <Slider
                                                                 x:Name="VolumeSlider"
                                                                 Width="{ThemeResource MediaTransportControlsSliderWidth}"
@@ -910,21 +919,20 @@
                                                                 TextAlignment="Right" />
                                                         </StackPanel>
                                                     </Flyout>
-                                                </AppBarButton.Flyout>
-                                                <AppBarButton.Icon>
-                                                    <SymbolIcon x:Name="VolumeMuteSymbol" Symbol="Volume" />
-                                                </AppBarButton.Icon>
-                                            </AppBarButton>
-                                            <AppBarButton
+                                                </Button.Flyout>
+                                                <Button.Content>
+                                                    <icons:RegularFluentIcon Symbol="Speaker220" />
+                                                </Button.Content>
+                                            </Button>
+                                            <Button
                                                 x:Name="LiveQualityButton"
                                                 AutomationProperties.Name="{loc:LocaleLocator Name=Quality}"
-                                                Style="{StaticResource MTCAppBarButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="17"
+                                                Style="{StaticResource MTCButtonStyle}"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=Quality}">
-                                                <AppBarButton.Icon>
+                                                <Button.Content>
                                                     <icons:RegularFluentIcon Symbol="Hd24" />
-                                                </AppBarButton.Icon>
-                                                <AppBarButton.Flyout>
+                                                </Button.Content>
+                                                <Button.Flyout>
                                                     <Flyout FlyoutPresenterStyle="{StaticResource MTCFlyoutStyle}" Placement="Top">
                                                         <ListView
                                                             x:Name="LiveQualityListView"
@@ -938,23 +946,22 @@
                                                             </ListView.ItemTemplate>
                                                         </ListView>
                                                     </Flyout>
-                                                </AppBarButton.Flyout>
-                                                <AppBarButton.KeyboardAccelerators>
+                                                </Button.Flyout>
+                                                <Button.KeyboardAccelerators>
                                                     <KeyboardAccelerator
                                                         Key="Q"
                                                         IsEnabled="True"
                                                         Modifiers="Control" />
-                                                </AppBarButton.KeyboardAccelerators>
-                                            </AppBarButton>
-                                            <AppBarButton
+                                                </Button.KeyboardAccelerators>
+                                            </Button>
+                                            <Button
                                                 x:Name="LivePlayLineButton"
-                                                Style="{StaticResource MTCAppBarButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="18"
+                                                Style="{StaticResource MTCButtonStyle}"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=PlayLine}">
-                                                <AppBarButton.Icon>
+                                                <Button.Content>
                                                     <icons:RegularFluentIcon Symbol="DeviceEq24" />
-                                                </AppBarButton.Icon>
-                                                <AppBarButton.Flyout>
+                                                </Button.Content>
+                                                <Button.Flyout>
                                                     <Flyout FlyoutPresenterStyle="{StaticResource MTCFlyoutStyle}" Placement="Top">
                                                         <ListView
                                                             x:Name="LivePlayLineListView"
@@ -971,95 +978,86 @@
                                                             </ListView.ItemTemplate>
                                                         </ListView>
                                                     </Flyout>
-                                                </AppBarButton.Flyout>
-                                                <AppBarButton.KeyboardAccelerators>
+                                                </Button.Flyout>
+                                                <Button.KeyboardAccelerators>
                                                     <KeyboardAccelerator
                                                         Key="L"
                                                         IsEnabled="True"
                                                         Modifiers="Control" />
-                                                </AppBarButton.KeyboardAccelerators>
-                                            </AppBarButton>
+                                                </Button.KeyboardAccelerators>
+                                            </Button>
                                         </StackPanel>
                                         <StackPanel
                                             x:Name="CenterContaienr"
                                             Grid.ColumnSpan="3"
                                             HorizontalAlignment="Center">
-                                            <AppBarButton
-                                                x:Name="PlayPauseButton"
-                                                Style="{StaticResource MTCAppBarButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="23">
-                                                <AppBarButton.Icon>
+                                            <Button x:Name="PlayPauseButton" Style="{StaticResource MTCButtonStyle}">
+                                                <Button.Content>
                                                     <icons:RegularFluentIcon x:Name="PlayPauseSymbol" Glyph="&#x002B;" />
-                                                </AppBarButton.Icon>
-                                                <AppBarButton.KeyboardAccelerators>
+                                                </Button.Content>
+                                                <Button.KeyboardAccelerators>
                                                     <KeyboardAccelerator Key="Space" IsEnabled="True" />
                                                     <KeyboardAccelerator
                                                         Key="P"
                                                         IsEnabled="True"
                                                         Modifiers="Control" />
-                                                </AppBarButton.KeyboardAccelerators>
-                                            </AppBarButton>
+                                                </Button.KeyboardAccelerators>
+                                            </Button>
                                         </StackPanel>
                                         <StackPanel
                                             x:Name="RightContainer"
                                             Grid.Column="2"
                                             Orientation="Horizontal">
-                                            <AppBarButton
-                                                x:Name="CastButton"
-                                                Style="{StaticResource MTCAppBarButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="11">
-                                                <AppBarButton.Icon>
-                                                    <FontIcon Glyph="&#xEC15;" />
-                                                </AppBarButton.Icon>
-                                            </AppBarButton>
-                                            <AppBarToggleButton
+                                            <Button x:Name="CastButton" Style="{StaticResource MTCButtonStyle}">
+                                                <Button.Content>
+                                                    <icons:RegularFluentIcon Symbol="Cast20" />
+                                                </Button.Content>
+                                            </Button>
+                                            <ToggleButton
                                                 x:Name="CompactOverlayModeButton"
                                                 AutomationProperties.Name="{loc:LocaleLocator Name=CompactOverlayMode}"
-                                                Style="{StaticResource MTCAppBarToggleButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="17"
+                                                Style="{StaticResource MTCToggleButtonStyle}"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=CompactOverlayMode}">
-                                                <AppBarToggleButton.Icon>
+                                                <ToggleButton.Content>
                                                     <icons:RegularFluentIcon FontSize="16" Symbol="ExpandUpRight48" />
-                                                </AppBarToggleButton.Icon>
-                                                <AppBarToggleButton.KeyboardAccelerators>
+                                                </ToggleButton.Content>
+                                                <ToggleButton.KeyboardAccelerators>
                                                     <KeyboardAccelerator
                                                         Key="M"
                                                         IsEnabled="True"
                                                         Modifiers="Control" />
-                                                </AppBarToggleButton.KeyboardAccelerators>
-                                            </AppBarToggleButton>
-                                            <AppBarToggleButton
+                                                </ToggleButton.KeyboardAccelerators>
+                                            </ToggleButton>
+                                            <ToggleButton
                                                 x:Name="FullWindowModeButton"
                                                 AutomationProperties.Name="{loc:LocaleLocator Name=FullWindowMode}"
-                                                Style="{StaticResource MTCAppBarToggleButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="15"
+                                                Style="{StaticResource MTCToggleButtonStyle}"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=FullWindowMode}">
-                                                <AppBarToggleButton.Icon>
+                                                <ToggleButton.Content>
                                                     <icons:RegularFluentIcon FontSize="16" Symbol="AutoFitWidth24" />
-                                                </AppBarToggleButton.Icon>
-                                                <AppBarToggleButton.KeyboardAccelerators>
+                                                </ToggleButton.Content>
+                                                <ToggleButton.KeyboardAccelerators>
                                                     <KeyboardAccelerator Key="F10" IsEnabled="True" />
-                                                </AppBarToggleButton.KeyboardAccelerators>
-                                            </AppBarToggleButton>
-                                            <AppBarToggleButton
+                                                </ToggleButton.KeyboardAccelerators>
+                                            </ToggleButton>
+                                            <ToggleButton
                                                 x:Name="FullScreenModeButton"
                                                 AutomationProperties.Name="{loc:LocaleLocator Name=FullScreenMode}"
-                                                Style="{StaticResource MTCAppBarToggleButtonStyle}"
-                                                MediaTransportControlsHelper.DropoutOrder="16"
+                                                Style="{StaticResource MTCToggleButtonStyle}"
                                                 ToolTipService.ToolTip="{loc:LocaleLocator Name=FullScreenMode}">
-                                                <AppBarToggleButton.Icon>
+                                                <ToggleButton.Content>
                                                     <icons:RegularFluentIcon FontSize="16" Symbol="FullScreenMaximize24" />
-                                                </AppBarToggleButton.Icon>
-                                                <AppBarToggleButton.KeyboardAccelerators>
+                                                </ToggleButton.Content>
+                                                <ToggleButton.KeyboardAccelerators>
                                                     <KeyboardAccelerator Key="F11" IsEnabled="True" />
-                                                </AppBarToggleButton.KeyboardAccelerators>
-                                            </AppBarToggleButton>
+                                                </ToggleButton.KeyboardAccelerators>
+                                            </ToggleButton>
                                         </StackPanel>
                                     </Grid>
                                     <Grid
                                         x:Name="Danmaku_Command_Border"
                                         Grid.Row="1"
-                                        Padding="4,8"
+                                        Padding="4"
                                         BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
                                         BorderThickness="0,1,0,0">
                                         <local:DanmakuBox />

--- a/src/App/Pages/Overlay/PlayerPage.xaml.cs
+++ b/src/App/Pages/Overlay/PlayerPage.xaml.cs
@@ -172,7 +172,6 @@ namespace Richasy.Bili.App.Pages.Overlay
                     {
                         VisualStateManager.GoToState(this, nameof(FullPlayerState), false);
                     }
-
                 }
                 else if (ViewModel.PlayerDisplayMode == PlayerDisplayMode.CompactOverlay)
                 {

--- a/src/App/Pages/PopularPage.xaml
+++ b/src/App/Pages/PopularPage.xaml
@@ -35,7 +35,8 @@
                 x:Name="ContentScrollViewer"
                 Padding="{StaticResource DefaultContainerPadding}"
                 HorizontalScrollMode="Disabled"
-                VerticalScrollBarVisibility="Auto">
+                VerticalScrollBarVisibility="Auto"
+                Visibility="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
                 <controls:VerticalRepeaterView
                     x:Name="VideoView"
                     Margin="0,0,0,12"

--- a/src/App/Pages/RankPage.xaml
+++ b/src/App/Pages/RankPage.xaml
@@ -68,7 +68,8 @@
                             Margin="0,0,0,12"
                             HeaderVisibility="Collapsed"
                             ItemsSource="{x:Bind ViewModel.DisplayVideoCollection}"
-                            MinWideItemHeight="252">
+                            MinWideItemHeight="252"
+                            Visibility="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
                             <controls:VerticalRepeaterView.ItemTemplate>
                                 <DataTemplate x:DataType="uwp:VideoViewModel">
                                     <controls:VideoItem

--- a/src/App/Pages/RecommendPage.xaml
+++ b/src/App/Pages/RecommendPage.xaml
@@ -35,7 +35,8 @@
                 x:Name="ContentScrollViewer"
                 Padding="{StaticResource DefaultContainerPadding}"
                 HorizontalScrollMode="Disabled"
-                VerticalScrollBarVisibility="Auto">
+                VerticalScrollBarVisibility="Auto"
+                Visibility="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
                 <controls:VerticalRepeaterView
                     x:Name="VideoView"
                     Margin="0,0,0,12"


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #136 

在推荐和热门视频页面中，让内容显示控件在初始化时隐藏，以避免布局问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

首页推荐刷新时有几率会出现布局异常

## 新的行为是什么？

在刷新时隐藏内容控件

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

注意到MTC的样式异常，重新调整了MTC的样式
