### PR TITLE
完善直播消息滚动机制

### DIFF
--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
@@ -1057,7 +1057,7 @@
                                     <Grid
                                         x:Name="Danmaku_Command_Border"
                                         Grid.Row="1"
-                                        Padding="4"
+                                        Padding="4,4,8,4"
                                         BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
                                         BorderThickness="0,1,0,0">
                                         <local:DanmakuBox />

--- a/src/App/Controls/Player/Related/LiveMessageView.xaml
+++ b/src/App/Controls/Player/Related/LiveMessageView.xaml
@@ -36,6 +36,7 @@
         <ScrollViewer
             x:Name="ScrollViewer"
             HorizontalScrollMode="Disabled"
+            ViewChanged="OnViewChanged"
             VerticalScrollBarVisibility="Auto">
             <Grid>
                 <Grid x:Name="StandardContainer">

--- a/src/App/Controls/Player/Related/LiveMessageView.xaml.cs
+++ b/src/App/Controls/Player/Related/LiveMessageView.xaml.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
 using System;
+using System.Threading.Tasks;
 
 namespace Richasy.Bili.App.Controls.Player.Related
 {
@@ -15,12 +16,23 @@ namespace Richasy.Bili.App.Controls.Player.Related
         public LiveMessageView()
         {
             this.InitializeComponent();
-            ViewModel.RequestLiveMessageScrollToBottom += OnRequestLiveMessageScrollToBottom;
+            ViewModel.RequestLiveMessageScrollToBottom += OnRequestLiveMessageScrollToBottomAsync;
         }
 
-        private void OnRequestLiveMessageScrollToBottom(object sender, EventArgs e)
+        private async void OnRequestLiveMessageScrollToBottomAsync(object sender, EventArgs e)
         {
-            ScrollViewer.ChangeView(0, (ScrollViewer.ExtentHeight + ScrollViewer.ScrollableHeight) * 2, 1);
+            await Task.Delay(100);
+            ScrollViewer.ChangeView(0, double.MaxValue, 1);
+        }
+
+        private void OnViewChanged(object sender, Windows.UI.Xaml.Controls.ScrollViewerViewChangedEventArgs e)
+        {
+            if (!e.IsIntermediate)
+            {
+                // 这里的逻辑是，如果滚动到了底部，则表示允许视图自动滚动，
+                // 如果不在底部，表示用户自己滚动了视图，此时则不再自动滚动.
+                ViewModel.IsLiveMessageAutoScroll = ScrollViewer.VerticalOffset + ScrollViewer.ViewportHeight >= ScrollViewer.ExtentHeight - 50;
+            }
         }
     }
 }

--- a/src/App/Controls/Player/Related/LiveMessageView.xaml.cs
+++ b/src/App/Controls/Player/Related/LiveMessageView.xaml.cs
@@ -21,7 +21,7 @@ namespace Richasy.Bili.App.Controls.Player.Related
 
         private async void OnRequestLiveMessageScrollToBottomAsync(object sender, EventArgs e)
         {
-            await Task.Delay(100);
+            await Task.Delay(50);
             ScrollViewer.ChangeView(0, double.MaxValue, 1);
         }
 

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Live.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Live.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
 using System;
+using System.Collections.ObjectModel;
+using System.Linq;
 using Richasy.Bili.Models.App.Args;
 using Richasy.Bili.Models.BiliBili;
 using Richasy.Bili.Models.Enums;
@@ -25,6 +27,11 @@ namespace Richasy.Bili.ViewModels.Uwp
                     var data = e.Data as LiveDanmakuMessage;
                     LiveDanmakuCollection.Add(data);
                     NewLiveDanmakuAdded?.Invoke(this, data);
+                    if (LiveDanmakuCollection.Count > 1000)
+                    {
+                        var saveMessages = LiveDanmakuCollection.ToList().Skip(600);
+                        LiveDanmakuCollection = new ObservableCollection<LiveDanmakuMessage>(saveMessages);
+                    }
                 }
             });
         }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -42,6 +42,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             IsPlayInformationError = false;
             IsCurrentEpisodeInPgcSection = false;
             IsShowEmptyLiveMessage = true;
+            IsLiveMessageAutoScroll = true;
             CurrentPlayLine = null;
             CurrentLiveQuality = null;
             _audioList.Clear();

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
@@ -609,6 +609,12 @@ namespace Richasy.Bili.ViewModels.Uwp
         [Reactive]
         public string LivePartition { get; set; }
 
+        /// <summary>
+        /// 直播消息是否自动滚动.
+        /// </summary>
+        [Reactive]
+        public bool IsLiveMessageAutoScroll { get; set; }
+
         private BiliController Controller { get; } = BiliController.Instance;
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -511,7 +511,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             var count = LiveDanmakuCollection.Count;
             IsShowEmptyLiveMessage = count == 0;
 
-            if (count > 0)
+            if (count > 0 && IsLiveMessageAutoScroll)
             {
                 RequestLiveMessageScrollToBottom?.Invoke(this, EventArgs.Empty);
             }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #186 

当用户参与直播消息滚动时，取消有新消息自动滚动到底部的机制。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

不论用户是否手动滚动消息列表，列表都会在有新消息时自动滚动到底部。

## 新的行为是什么？

当用户参与滚动时，则固定在当前滚动到的位置，不再自动滚动到底部，除非用户将列表滚动至底部。

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
