### PR TITLE
修复PGC内容不能通过年份索引的问题

### DIFF
--- a/src/App/Pages/Overlay/PgcIndexPage.xaml
+++ b/src/App/Pages/Overlay/PgcIndexPage.xaml
@@ -115,6 +115,7 @@
                 ActionContent="{loc:LocaleLocator Name=Refresh}"
                 Text="{x:Bind ViewModel.IndexErrorText, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.IsIndexError, Mode=OneWay}" />
+            <controls:ErrorPanel Text="{loc:LocaleLocator Name=NoSpecificData}" Visibility="{x:Bind ViewModel.IsEmpty, Mode=OneWay}" />
         </Grid>
     </Grid>
 </Page>

--- a/src/ViewModels/ViewModels.Uwp.UnitTests/ViewModels.Uwp.UnitTests.csproj
+++ b/src/ViewModels/ViewModels.Uwp.UnitTests/ViewModels.Uwp.UnitTests.csproj
@@ -41,22 +41,11 @@
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions">
-      <Version>5.10.3</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.12</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.SDK">
-      <Version>16.7.1</Version>
-    </PackageReference>
-    <PackageReference Include="xunit">
-      <Version>2.4.1</Version>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.4.1</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
+    <PackageReference Include="SpecFlow">
+      <Version>3.9.22</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/ViewModels/ViewModels.Uwp/Pgc/PgcViewModelBase.cs
+++ b/src/ViewModels/ViewModels.Uwp/Pgc/PgcViewModelBase.cs
@@ -106,6 +106,12 @@ namespace Richasy.Bili.ViewModels.Uwp
         public bool IsIndexRequested { get; set; }
 
         /// <summary>
+        /// 是否显示为空白.
+        /// </summary>
+        [Reactive]
+        public bool IsEmpty { get; set; }
+
+        /// <summary>
         /// 加载索引.
         /// </summary>
         /// <returns><see cref="Task"/>.</returns>
@@ -192,7 +198,13 @@ namespace Richasy.Bili.ViewModels.Uwp
             {
                 if (condition.SelectedItem != null)
                 {
-                    queryPrameters.Add(condition.Id, condition.SelectedItem.Id);
+                    var id = condition.SelectedItem.Id;
+                    if (condition.Id == "year")
+                    {
+                        id = Uri.EscapeDataString(condition.SelectedItem.Id);
+                    }
+
+                    queryPrameters.Add(condition.Id, id);
                 }
             }
 
@@ -203,10 +215,14 @@ namespace Richasy.Bili.ViewModels.Uwp
         {
             if (e.Type == Type)
             {
-                e.List.ForEach(p => ItemCollection.Add(new SeasonViewModel(p)));
+                if (e.List != null)
+                {
+                    e.List.ForEach(p => ItemCollection.Add(new SeasonViewModel(p)));
+                }
 
                 _isIndexLoadCompleted = !e.HasNext || e.TotalCount <= ItemCollection.Count;
                 _indexPageNumber = e.NextPageNumber;
+                IsEmpty = ItemCollection.Count == 0;
             }
         }
     }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #226 

修复无法通过年份来索引PGC内容的问题。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

使用年份筛选是，索引列表显示空白

## 新的行为是什么？

可以正常按年份来索引

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

对VM的单测项目的引用进行了些许调整
