### PR TITLE
修复直播中断的问题

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -1012,6 +1012,9 @@
     <PackageReference Include="Richasy.FluentIcon.Regular.UWP">
       <Version>1.1.135</Version>
     </PackageReference>
+    <PackageReference Include="Richasy.SYEnginePackage">
+      <Version>1.0.0</Version>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
 using System;
+using System.Diagnostics;
+using FFmpegInterop;
 using Richasy.Bili.Controller.Uwp.Interfaces;
 using Richasy.Bili.Locator.Uwp;
 using Richasy.Bili.Models.App.Constants;
@@ -19,7 +21,7 @@ namespace Richasy.Bili.App
     /// <summary>
     /// Provide application-specific behaviors to supplement the default application classes.
     /// </summary>
-    public sealed partial class App : Application
+    public sealed partial class App : Application, ILogProvider
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="App"/> class.
@@ -32,6 +34,15 @@ namespace Richasy.Bili.App
             _ = AppViewModel.Instance;
             ServiceLocator.Instance.GetService<IAppToolkit>()
                                    .InitializeTheme();
+
+            FFmpegInteropLogging.SetLogLevel(LogLevel.Error);
+            FFmpegInteropLogging.SetLogProvider(this);
+        }
+
+        /// <inheritdoc/>
+        public void Log(LogLevel level, string message)
+        {
+            Debug.WriteLine($"{level} | {message}");
         }
 
         /// <summary>
@@ -57,6 +68,7 @@ namespace Richasy.Bili.App
         {
             var appView = ApplicationView.GetForCurrentView();
             appView.SetPreferredMinSize(new Size(AppConstants.AppMinWidth, AppConstants.AppMinHeight));
+            _ = SYEngine.Core.Initialize();
 
             // Do not repeat app initialization when the Window already has content,
             // just ensure that the window is active

--- a/src/Models/Models.App/Constants/ServiceConstants.cs
+++ b/src/Models/Models.App/Constants/ServiceConstants.cs
@@ -164,6 +164,10 @@ namespace Richasy.Bili.Models.App.Constants
             public const string LikeTime = "like_time";
             public const string AtTime = "at_time";
             public const string ReplyTime = "reply_time";
+            public const string Protocol = "protocal";
+            public const string Codec = "codec";
+            public const string PType = "ptype";
+            public const string Format = "format";
         }
 
         public static class Sort

--- a/src/ViewModels/ViewModels.Uwp.UnitTests/Properties/UnitTestApp.rd.xml
+++ b/src/ViewModels/ViewModels.Uwp.UnitTests/Properties/UnitTestApp.rd.xml
@@ -21,7 +21,6 @@
             An Assembly element with Name="*Application*" applies to all assemblies in
             the application package. The asterisks are not wildcards.
         -->
-        <Assembly Name="*Application*" Dynamic="Required All" />
         <!-- Add your application specific runtime directives here. -->
 
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #159 #66 

修复直播中断的问题。

调查记录：

直播相关的代码参考逍遥橙子的实现，部分API做了更新，但一直存在直播断流的问题，不得已做了自动切换线路。

经过详细的代码比对和接口数据分析，我发现大部分传回的直播地址都是flv，而MediaPlayer对FLV格式的支持是有限的，少部分直播可以正常播放，原因是正在播放的线路是m3u8格式的。

对于FLV的支持，SYEngine可以解决这个问题，但是现有的nuget包不支持ARM64，我想这也造成了在上一个版本的哔哩中会在ARM64设备闪退的问题。

遂自己编译源码并重新打包，以支持ARM64，在引入这个包后，问题得到解决，直播可以持续播放，而不是放6秒就停止。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

部分直播在播放6秒后就会停止播放

## 新的行为是什么？

直播可以持续播放

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

修改VM单测项目的rd.xml文件
