### PR TITLE
调整直播线路优先级并在进入直播间时重置长连接

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -14,7 +14,7 @@ jobs:
 
     env:
       SigningCertificate: App_TemporaryKey.pfx
-      App_Path: .\src\App\App.csproj
+      Solution_Path: .\Bili.UWP.sln
       UWP_Project_Directory: src\App
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -46,31 +46,31 @@ jobs:
         $manifest.save(".\$env:UWP_Project_Directory\Package.appxmanifest")
         
     - name: Build x86
-      run: msbuild $env:App_Path /p:Platform=x86 /p:AppxBundlePlatforms="x86" /p:AppxPackageDir=C:\Package\x86 /p:PackageCertificateKeyFile=$env:SigningCertificate /restore
+      run: msbuild $env:Solution_Path /p:Platform=x86 /p:AppxBundlePlatforms="x86" /p:AppxPackageDir=C:\Package\x86 /p:PackageCertificateKeyFile=$env:SigningCertificate /restore
       env:
         BuildMode: SideloadOnly
         Configuration: Release
         
     - name: Build x64
-      run: msbuild $env:App_Path /p:Platform=x64 /p:AppxBundlePlatforms="x64" /p:AppxPackageDir=C:\Package\x64 /p:PackageCertificateKeyFile=$env:SigningCertificate /restore
+      run: msbuild $env:Solution_Path /p:Platform=x64 /p:AppxBundlePlatforms="x64" /p:AppxPackageDir=C:\Package\x64 /p:PackageCertificateKeyFile=$env:SigningCertificate /restore
       env:
         BuildMode: SideloadOnly
         Configuration: Release
         
     - name: Build ARM64
-      run: msbuild $env:App_Path /p:Platform=ARM64 /p:AppxBundlePlatforms="ARM64" /p:AppxPackageDir=C:\Package\ARM64 /p:PackageCertificateKeyFile=$env:SigningCertificate /restore
+      run: msbuild $env:Solution_Path /p:Platform=ARM64 /p:AppxBundlePlatforms="ARM64" /p:AppxPackageDir=C:\Package\ARM64 /p:PackageCertificateKeyFile=$env:SigningCertificate /restore
       env:
         BuildMode: SideloadOnly
         Configuration: Release
    
     - name: Create x86 archive
-      run: Compress-Archive -Path C:\Package\x86 -DestinationPath C:\Package\Bili.Uwp_${{github.event.inputs.version}}_x86.zip
+      run: Compress-Archive -Path C:\Package\x86\App_${{github.event.inputs.version}}_Test -DestinationPath C:\Package\Bili.Uwp_${{github.event.inputs.version}}_x86.zip
       
     - name: Create x64 archive
-      run: Compress-Archive -Path C:\Package\x64 -DestinationPath C:\Package\Bili.Uwp_${{github.event.inputs.version}}_x64.zip
+      run: Compress-Archive -Path C:\Package\x64\App_${{github.event.inputs.version}}_Test -DestinationPath C:\Package\Bili.Uwp_${{github.event.inputs.version}}_x64.zip
       
     - name: Create ARM64 archive
-      run: Compress-Archive -Path C:\Package\ARM64 -DestinationPath C:\Package\Bili.Uwp_${{github.event.inputs.version}}_ARM64.zip
+      run: Compress-Archive -Path C:\Package\ARM64\App_${{github.event.inputs.version}}_Test -DestinationPath C:\Package\Bili.Uwp_${{github.event.inputs.version}}_ARM64.zip
 
     - name: Update x86 release asset
       id: upload-release-asset-x86

--- a/src/Controller/Controller.Uwp/BiliController.Live.cs
+++ b/src/Controller/Controller.Uwp/BiliController.Live.cs
@@ -127,6 +127,22 @@ namespace Richasy.Bili.Controller.Uwp
         public Task<bool> SendLiveDanmakuAsync(int roomId, string text, string color, bool isStandardSize, DanmakuLocation location)
              => _liveProvider.SendMessageAsync(roomId, text, color, isStandardSize, location);
 
+        /// <summary>
+        /// 清理直播长连接.
+        /// </summary>
+        public void CleanupLiveSocket()
+        {
+            if (_liveCancellationToken != null)
+            {
+                _liveCancellationToken.Cancel();
+            }
+
+            _liveCancellationToken = new CancellationTokenSource();
+
+            _isLiveSocketConnected = false;
+            _liveWebSocket?.Stop(System.Net.WebSockets.WebSocketCloseStatus.NormalClosure, string.Empty);
+        }
+
         private void InitializeLiveSocket()
         {
             CleanupLiveSocket();
@@ -138,19 +154,6 @@ namespace Richasy.Bili.Controller.Uwp
                 _liveWebSocket.DisconnectionHappened.Subscribe(info => OnLiveSocketDisconnected(info));
                 _liveWebSocket.MessageReceived.Subscribe(msg => OnLiveSocketMessageReceived(msg));
             }
-        }
-
-        private void CleanupLiveSocket()
-        {
-            if (_liveCancellationToken != null)
-            {
-                _liveCancellationToken.Cancel();
-            }
-
-            _liveCancellationToken = new CancellationTokenSource();
-
-            _isLiveSocketConnected = false;
-            _liveWebSocket?.Stop(System.Net.WebSockets.WebSocketCloseStatus.NormalClosure, string.Empty);
         }
 
         private void ConnectLiveSocket()

--- a/src/Lib/Lib.Uwp/HttpProvider/HttpProvider.Extension.cs
+++ b/src/Lib/Lib.Uwp/HttpProvider/HttpProvider.Extension.cs
@@ -91,11 +91,12 @@ namespace Richasy.Bili.Lib.Uwp
 
         private void InitHttpClient()
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
             _cookieContainer = new CookieContainer();
             var handler = new HttpClientHandler
             {
-                AllowAutoRedirect = false,
-                AutomaticDecompression = DecompressionMethods.None,
+                AllowAutoRedirect = true,
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.None,
                 UseCookies = true,
                 CookieContainer = _cookieContainer,
             };

--- a/src/Models/Models.BiliBili/Live/LivePlayInformation.cs
+++ b/src/Models/Models.BiliBili/Live/LivePlayInformation.cs
@@ -18,6 +18,12 @@ namespace Richasy.Bili.Models.BiliBili
         public int CurrentQuality { get; set; }
 
         /// <summary>
+        /// 当前播放清晰度（网络标识）.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "current_qn", Required = Required.Default)]
+        public int CurrentQuality2 { get; set; }
+
+        /// <summary>
         /// 支持的播放清晰度.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "accept_quality", Required = Required.Default)]

--- a/src/ViewModels/ViewModels.Uwp/Common/LivePlayLineViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/LivePlayLineViewModel.cs
@@ -14,9 +14,14 @@ namespace Richasy.Bili.ViewModels.Uwp
         /// </summary>
         /// <param name="data">播放线路数据.</param>
         /// <param name="isSelected">是否被选中.</param>
-        public LivePlayLineViewModel(LivePlayLine data, bool isSelected = false)
+        /// <param name="sid">会话标识Id.</param>
+        public LivePlayLineViewModel(LivePlayLine data, bool isSelected = false, string sid = null)
             : base(data, isSelected)
         {
+            if (!data.Url.Contains("sid") && !string.IsNullOrEmpty(sid))
+            {
+                data.Url += $"&sid={sid}";
+            }
         }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Dash.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Dash.cs
@@ -115,6 +115,12 @@ namespace Richasy.Bili.ViewModels.Uwp
         {
             try
             {
+                if (_interopMSS != null)
+                {
+                    _interopMSS.Dispose();
+                    _interopMSS = null;
+                }
+
                 _interopMSS = await FFmpegInteropMSS.CreateFromUriAsync(url, _liveFFConfig);
             }
             catch (Exception)

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Dash.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Dash.cs
@@ -90,16 +90,8 @@ namespace Richasy.Bili.ViewModels.Uwp
                 }
 
                 var mediaSource = MediaSource.CreateFromAdaptiveMediaSource(soure.MediaSource);
-                var playbackItem = new MediaPlaybackItem(mediaSource);
-                _currentVideoPlayer.Source = playbackItem;
-
-                var props = playbackItem.GetDisplayProperties();
-                props.Type = Windows.Media.MediaPlaybackType.Video;
-                props.Thumbnail = Windows.Storage.Streams.RandomAccessStreamReference.CreateFromUri(new Uri(CoverUrl + "@100w_100h_1c_100q.jpg"));
-                props.VideoProperties.Title = Title;
-                props.VideoProperties.Subtitle = GetSlimDescription(IsPgc ? Subtitle : Description);
-                props.VideoProperties.Genres.Add(_videoType.ToString());
-                playbackItem.ApplyDisplayProperties(props);
+                _currentPlaybackItem = new MediaPlaybackItem(mediaSource);
+                _currentVideoPlayer.Source = _currentPlaybackItem;
 
                 BiliPlayer.SetMediaPlayer(_currentVideoPlayer);
                 MediaPlayerUpdated?.Invoke(this, EventArgs.Empty);
@@ -130,21 +122,13 @@ namespace Richasy.Bili.ViewModels.Uwp
                 return;
             }
 
-            var playbackItem = _interopMSS.CreateMediaPlaybackItem();
-
-            var props = playbackItem.GetDisplayProperties();
-            props.Type = Windows.Media.MediaPlaybackType.Video;
-            props.Thumbnail = Windows.Storage.Streams.RandomAccessStreamReference.CreateFromUri(new Uri(CoverUrl + "@100w_100h_1c_100q.jpg"));
-            props.VideoProperties.Title = Title;
-            props.VideoProperties.Subtitle = GetSlimDescription(string.IsNullOrEmpty(Subtitle) ? Subtitle : Description);
-            props.VideoProperties.Genres.Add(_videoType.ToString());
-            playbackItem.ApplyDisplayProperties(props);
+            _currentPlaybackItem = _interopMSS.CreateMediaPlaybackItem();
             if (_currentVideoPlayer == null)
             {
                 _currentVideoPlayer = InitializeMediaPlayer();
             }
 
-            _currentVideoPlayer.Source = playbackItem;
+            _currentVideoPlayer.Source = _currentPlaybackItem;
             BiliPlayer.SetMediaPlayer(_currentVideoPlayer);
             MediaPlayerUpdated?.Invoke(this, EventArgs.Empty);
         }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -65,6 +65,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             ReplyModuleViewModel.Instance.SetInformation(0, Models.Enums.Bili.ReplyType.None);
             var preferPlayerMode = _settingsToolkit.ReadLocalSetting(SettingNames.DefaultPlayerDisplayMode, PlayerDisplayMode.Default);
             PlayerDisplayMode = preferPlayerMode;
+            Controller.CleanupLiveSocket();
         }
 
         private async Task LoadVideoDetailAsync(string videoId, bool isRefresh)
@@ -465,7 +466,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             var currentQuality = LiveQualityCollection.Where(p => p.IsSelected).FirstOrDefault();
             if (currentQuality == null)
             {
-                currentQuality = LiveQualityCollection.First();
+                currentQuality = LiveQualityCollection.Where(p => p.Data.Quality == livePlayInfo.CurrentQuality2).FirstOrDefault() ?? LiveQualityCollection.First();
             }
 
             CurrentLiveQuality = currentQuality.Data;

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -173,7 +173,7 @@ namespace Richasy.Bili.ViewModels.Uwp
 
                 await InitializeUserRelationAsync();
                 await Controller.ConnectToLiveRoomAsync(roomId);
-                await ChangeLiveQualityAsync(0);
+                await ChangeLiveQualityAsync(4);
                 await Controller.SendLiveHeartBeatAsync();
             }
         }
@@ -461,8 +461,6 @@ namespace Richasy.Bili.ViewModels.Uwp
                 }
             }
 
-            livePlayInfo.PlayLines.ForEach(p => LivePlayLineCollection.Add(new LivePlayLineViewModel(p)));
-
             var currentQuality = LiveQualityCollection.Where(p => p.IsSelected).FirstOrDefault();
             if (currentQuality == null)
             {
@@ -470,6 +468,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             }
 
             CurrentLiveQuality = currentQuality.Data;
+            livePlayInfo.PlayLines.ForEach(p => LivePlayLineCollection.Add(new LivePlayLineViewModel(p)));
 
             if (CurrentPlayLine != null)
             {
@@ -482,7 +481,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             }
             else
             {
-                CurrentPlayLine = LivePlayLineCollection.First().Data;
+                CurrentPlayLine = LivePlayLineCollection.Where(p => p.Data.Url.Contains("sid")).FirstOrDefault()?.Data ?? LivePlayLineCollection.First().Data;
             }
 
             if (CurrentPlayLine == null)

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -661,6 +661,14 @@ namespace Richasy.Bili.ViewModels.Uwp
             {
                 _interopMSS.PlaybackSession = session;
             }
+
+            var props = _currentPlaybackItem.GetDisplayProperties();
+            props.Type = Windows.Media.MediaPlaybackType.Video;
+            props.Thumbnail = Windows.Storage.Streams.RandomAccessStreamReference.CreateFromUri(new Uri(CoverUrl + "@100w_100h_1c_100q.jpg"));
+            props.VideoProperties.Title = Title;
+            props.VideoProperties.Subtitle = GetSlimDescription(IsPgc ? Subtitle : Description);
+            props.VideoProperties.Genres.Add(_videoType.ToString());
+            _currentPlaybackItem.ApplyDisplayProperties(props);
         }
 
         private async void OnMediaPlayerFailedAsync(MediaPlayer sender, MediaPlayerFailedEventArgs args)

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -616,6 +616,7 @@ namespace Richasy.Bili.ViewModels.Uwp
         private MediaPlayer InitializeMediaPlayer()
         {
             var player = new MediaPlayer();
+            player.MediaOpened += OnMediaPlayerOpened;
             player.CurrentStateChanged += OnMediaPlayerCurrentStateChangedAsync;
             player.MediaEnded += OnMediaPlayerEndedAsync;
             player.MediaFailed += OnMediaPlayerFailedAsync;
@@ -651,6 +652,15 @@ namespace Richasy.Bili.ViewModels.Uwp
             {
                 Volume = sender.Volume;
             });
+        }
+
+        private void OnMediaPlayerOpened(MediaPlayer sender, object args)
+        {
+            var session = sender.PlaybackSession;
+            if (session != null && IsLive && _interopMSS != null)
+            {
+                _interopMSS.PlaybackSession = session;
+            }
         }
 
         private async void OnMediaPlayerFailedAsync(MediaPlayer sender, MediaPlayerFailedEventArgs args)

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -172,7 +172,7 @@ namespace Richasy.Bili.ViewModels.Uwp
 
                 await InitializeUserRelationAsync();
                 await Controller.ConnectToLiveRoomAsync(roomId);
-                await ChangeLiveQualityAsync(4);
+                await ChangeLiveQualityAsync(0);
                 await Controller.SendLiveHeartBeatAsync();
             }
         }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
@@ -41,6 +41,7 @@ namespace Richasy.Bili.ViewModels.Uwp
         private VideoType _videoType;
         private TimeSpan _initializeProgress;
         private FFmpegInteropMSS _interopMSS;
+        private MediaPlaybackItem _currentPlaybackItem;
 
         private DashItem _currentAudio;
         private DashItem _currentVideo;

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -47,6 +47,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             _liveFFConfig.FFmpegOptions.Add("rtsp_transport", "tcp");
             _liveFFConfig.FFmpegOptions.Add("user_agent", "Mozilla/5.0 BiliDroid/1.12.0 (bbcallen@gmail.com)");
             _liveFFConfig.FFmpegOptions.Add("referer", "https://live.bilibili.com/");
+            _liveFFConfig.VideoDecoderMode = VideoDecoderMode.ForceSystemDecoder;
 
             ServiceLocator.Instance.LoadService(out _numberToolkit)
                                    .LoadService(out _resourceToolkit)
@@ -60,6 +61,8 @@ namespace Richasy.Bili.ViewModels.Uwp
             LiveDanmakuCollection.CollectionChanged += OnLiveDanmakuCollectionChanged;
             Controller.LiveMessageReceived += OnLiveMessageReceivedAsync;
             Controller.LoggedOut += OnUserLoggedOut;
+
+            SYEngine.Core.Initialize();
         }
 
         /// <summary>
@@ -322,7 +325,17 @@ namespace Richasy.Bili.ViewModels.Uwp
         public async Task ChangeLiveQualityAsync(int quality)
         {
             var playInfo = await Controller.GetLivePlayInformationAsync(Convert.ToInt32(RoomId), quality);
-            await InitializeLivePlayInformationAsync(playInfo);
+
+            if (playInfo != null)
+            {
+                await InitializeLivePlayInformationAsync(playInfo);
+            }
+            else
+            {
+                IsPlayInformationError = true;
+                PlayInformationErrorText = _resourceToolkit.GetLocaleString(LanguageNames.RequestLivePlayInformationFailed);
+                CurrentLiveQuality = LiveQualityCollection.FirstOrDefault()?.Data;
+            }
         }
 
         /// <summary>

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -45,7 +45,7 @@ namespace Richasy.Bili.ViewModels.Uwp
 
             _liveFFConfig = new FFmpegInteropConfig();
             _liveFFConfig.FFmpegOptions.Add("rtsp_transport", "tcp");
-            _liveFFConfig.FFmpegOptions.Add("user_agent", "Mozilla/5.0 BiliDroid/1.12.0 (bbcallen@gmail.com)");
+            _liveFFConfig.FFmpegOptions.Add("user_agent", "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36");
             _liveFFConfig.FFmpegOptions.Add("referer", "https://live.bilibili.com/");
             _liveFFConfig.VideoDecoderMode = VideoDecoderMode.ForceSystemDecoder;
 

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -9,11 +9,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using FFmpegInterop;
 using Richasy.Bili.Locator.Uwp;
+using Richasy.Bili.Models.App.Constants;
 using Richasy.Bili.Models.BiliBili;
 using Richasy.Bili.Models.Enums;
 using Richasy.Bili.ViewModels.Uwp.Common;
 using Windows.ApplicationModel.DataTransfer;
-using Windows.Media.Playback;
 using Windows.Storage.Streams;
 using Windows.UI.Xaml.Controls;
 
@@ -45,9 +45,8 @@ namespace Richasy.Bili.ViewModels.Uwp
 
             _liveFFConfig = new FFmpegInteropConfig();
             _liveFFConfig.FFmpegOptions.Add("rtsp_transport", "tcp");
-            _liveFFConfig.FFmpegOptions.Add("user_agent", "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36");
+            _liveFFConfig.FFmpegOptions.Add("user_agent", ServiceConstants.DefaultUserAgentString);
             _liveFFConfig.FFmpegOptions.Add("referer", "https://live.bilibili.com/");
-            _liveFFConfig.VideoDecoderMode = VideoDecoderMode.ForceSystemDecoder;
 
             ServiceLocator.Instance.LoadService(out _numberToolkit)
                                    .LoadService(out _resourceToolkit)
@@ -370,13 +369,13 @@ namespace Richasy.Bili.ViewModels.Uwp
                     _currentVideoPlayer.Pause();
                 }
 
-                if (_currentVideoPlayer.Source != null)
+                if (_currentPlaybackItem != null)
                 {
-                    (_currentVideoPlayer.Source as MediaPlaybackItem).Source.Dispose();
+                    _currentPlaybackItem.Source.Dispose();
+                    _currentPlaybackItem = null;
                 }
 
-                _currentVideoPlayer.Dispose();
-                _currentVideoPlayer = null;
+                _currentVideoPlayer.Source = null;
             }
 
             _lastReportProgress = TimeSpan.Zero;

--- a/src/ViewModels/ViewModels.Uwp/ViewModels.Uwp.csproj
+++ b/src/ViewModels/ViewModels.Uwp/ViewModels.Uwp.csproj
@@ -145,6 +145,9 @@
     <PackageReference Include="ReactiveUI.Fody">
       <Version>14.3.1</Version>
     </PackageReference>
+    <PackageReference Include="Richasy.SYEnginePackage">
+      <Version>1.0.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Controller\Controller.Uwp\Controller.Uwp.csproj">


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #245 

优先播放包含sid的线路，可以保证不断流

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

仍存在一定程度的直播断连问题，且进入两个以上的直播间后，信息流没有刷新

## 新的行为是什么？

优先选择可以流畅播放的线路，在进入直播间前清理Socket，以使得聊天流可以正常加载

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

目前的判断条件是直播线路地址是否包含sid，经测试，包含sid的线路可以流畅播放，不会断连
