### PR TITLE
修改4K优先为高画质优先

### DIFF
--- a/src/App/Controls/Settings/PlayerControlSettingSection.xaml
+++ b/src/App/Controls/Settings/PlayerControlSettingSection.xaml
@@ -37,13 +37,13 @@
                 <exp:ExpanderExWrapper Style="{StaticResource WrapperInExpanderContentStyle}">
                     <exp:ExpanderExWrapper.MainContent>
                         <exp:ExpanderExDescriptor
-                            Title="{loc:LocaleLocator Name=Prefer4K}"
-                            Description="{loc:LocaleLocator Name=Prefer4KDescription}"
+                            Title="{loc:LocaleLocator Name=PreferHighQuality}"
+                            Description="{loc:LocaleLocator Name=PreferHighQualityDescription}"
                             IconVisibility="Collapsed"
                             IsAutoHideIcon="False" />
                     </exp:ExpanderExWrapper.MainContent>
                     <exp:ExpanderExWrapper.WrapContent>
-                        <ToggleSwitch Style="{StaticResource RightAlignedCompactToggleSwitchStyle}" IsOn="{x:Bind ViewModel.IsPrefer4K, Mode=TwoWay}" />
+                        <ToggleSwitch Style="{StaticResource RightAlignedCompactToggleSwitchStyle}" IsOn="{x:Bind ViewModel.IsPreferHighQuality, Mode=TwoWay}" />
                     </exp:ExpanderExWrapper.WrapContent>
                 </exp:ExpanderExWrapper>
 

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -455,7 +455,7 @@
     <value>AVC/H.264</value>
   </data>
   <data name="H265" xml:space="preserve">
-    <value>HVEC/H.265</value>
+    <value>HEVC/H.265</value>
   </data>
   <data name="HelpAndSupport" xml:space="preserve">
     <value>帮助 &amp; 支持</value>
@@ -718,6 +718,12 @@
   </data>
   <data name="PreferCodecDescription" xml:space="preserve">
     <value>优先选择该编码的视频流，HEVC/H.265需要额外安装解码器</value>
+  </data>
+  <data name="PreferHighQuality" xml:space="preserve">
+    <value>画质优先</value>
+  </data>
+  <data name="PreferHighQualityDescription" xml:space="preserve">
+    <value>优先播放最高清画质的视频源</value>
   </data>
   <data name="Prelaunch" xml:space="preserve">
     <value>预启动</value>

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -343,6 +343,8 @@ namespace Richasy.Bili.Models.Enums
         PlayPause,
         DoubleClickBehavior,
         DoubleClickBehaviorDescription,
+        PreferHighQuality,
+        PreferHighQualityDescription,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/Models/Models.Enums/App/SettingNames.cs
+++ b/src/Models/Models.Enums/App/SettingNames.cs
@@ -15,7 +15,7 @@ namespace Richasy.Bili.Models.Enums
         IsStartup,
         IsAutoPlayWhenLoaded,
         DefaultPlayerDisplayMode,
-        IsPrefer4K,
+        IsPreferHighQuality,
         PreferCodec,
         SingleFastForwardAndRewindSpan,
         DefaultMTCControlMode,

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -438,11 +438,10 @@ namespace Richasy.Bili.ViewModels.Uwp
                 _settingsToolkit.ReadLocalSetting(SettingNames.DefaultVideoFormat, 64) :
                 CurrentFormat.Quality;
 
-            // 如果用户选择了4K优先，则优先播放4K片源.
-            if (_settingsToolkit.ReadLocalSetting(SettingNames.IsPrefer4K, false) &&
-                FormatCollection.Any(p => p.Data.Quality == 120))
+            // 如果用户选择了画质优先，则优先播放高画质片源.
+            if (_settingsToolkit.ReadLocalSetting(SettingNames.IsPreferHighQuality, false))
             {
-                formatId = 120;
+                formatId = FormatCollection.Max(p => p.Data.Quality);
             }
 
             await ChangeFormatAsync(formatId);

--- a/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.Properties.cs
@@ -95,10 +95,10 @@ namespace Richasy.Bili.ViewModels.Uwp
         public MTCControlMode DefaultMTCControlMode { get; set; }
 
         /// <summary>
-        /// 优先4K.
+        /// 优先高画质.
         /// </summary>
         [Reactive]
-        public bool IsPrefer4K { get; set; }
+        public bool IsPreferHighQuality { get; set; }
 
         /// <summary>
         /// 偏好的解码模式.

--- a/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.cs
@@ -35,7 +35,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             _initializeTheme = AppTheme;
             IsPrelaunch = ReadSetting(SettingNames.IsPrelaunch, true);
             IsAutoPlayWhenLoaded = ReadSetting(SettingNames.IsAutoPlayWhenLoaded, true);
-            IsPrefer4K = ReadSetting(SettingNames.IsPrefer4K, false);
+            IsPreferHighQuality = ReadSetting(SettingNames.IsPreferHighQuality, false);
             SingleFastForwardAndRewindSpan = ReadSetting(SettingNames.SingleFastForwardAndRewindSpan, 30d);
             PreferCodecInit();
             DoubleClickInit();
@@ -70,8 +70,8 @@ namespace Richasy.Bili.ViewModels.Uwp
                 case nameof(DefaultPlayerDisplayMode):
                     WriteSetting(SettingNames.DefaultPlayerDisplayMode, DefaultPlayerDisplayMode);
                     break;
-                case nameof(IsPrefer4K):
-                    WriteSetting(SettingNames.IsPrefer4K, IsPrefer4K);
+                case nameof(IsPreferHighQuality):
+                    WriteSetting(SettingNames.IsPreferHighQuality, IsPreferHighQuality);
                     break;
                 case nameof(PreferCodec):
                     WriteSetting(SettingNames.PreferCodec, PreferCodec);


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #261 

将“4K优先”设置项改为"高画质优先"，更具实用性。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

仅优先播放4K高画质

## 新的行为是什么？

将会选择视频的最高清晰度播放

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
