### PR TITLE
修复播放器背景色的问题

### DIFF
--- a/src/App/Controls/Player/BiliPlayer/BiliPlayer.xaml
+++ b/src/App/Controls/Player/BiliPlayer/BiliPlayer.xaml
@@ -1,17 +1,14 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:hn="using:HN.Controls"
-    xmlns:icons="using:Richasy.FluentIcon.Uwp"
-    xmlns:local="using:Richasy.Bili.App.Controls"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Controls">
+    xmlns:local="using:Richasy.Bili.App.Controls">
 
     <Style TargetType="local:BiliPlayer">
         <Setter Property="CornerRadius" Value="{StaticResource OverlayCornerRadius}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:BiliPlayer">
-                    <Grid>
+                    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" CornerRadius="{TemplateBinding CornerRadius}">
                         <Grid
                             x:Name="PlayerContainer"
                             CornerRadius="{TemplateBinding CornerRadius}"
@@ -37,39 +34,12 @@
                         <Grid
                             x:Name="LoadingContainer"
                             CornerRadius="{StaticResource OverlayCornerRadius}"
-                            Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsPlayInformationLoading}">
-                            <hn:ImageEx
+                            Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsPlayInformationLoading, Converter={StaticResource BoolToVisibilityConverter}}">
+                            <local:CommonImageEx
                                 x:Name="CoverImage"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
-                                LazyLoadingEnabled="True"
-                                RetryCount="2"
-                                RetryDelay="0:0:5"
-                                Source="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.CoverUrl}"
-                                Stretch="UniformToFill">
-                                <hn:ImageEx.LoadingTemplate>
-                                    <DataTemplate>
-                                        <Grid>
-                                            <muxc:ProgressRing
-                                                Style="{StaticResource PageProgressRingStyle}"
-                                                Width="40"
-                                                Height="40" />
-                                        </Grid>
-                                    </DataTemplate>
-                                </hn:ImageEx.LoadingTemplate>
-                                <hn:ImageEx.FailedTemplate>
-                                    <DataTemplate>
-                                        <Grid Background="{ThemeResource SystemControlForegroundBaseMediumBrush}" Opacity="0.5">
-                                            <icons:RegularFluentIcon
-                                                HorizontalAlignment="Center"
-                                                VerticalAlignment="Center"
-                                                FontSize="80"
-                                                Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
-                                                Symbol="Image28" />
-                                        </Grid>
-                                    </DataTemplate>
-                                </hn:ImageEx.FailedTemplate>
-                            </hn:ImageEx>
+                                ImageUrl="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.CoverUrl}"
+                                RetryCount="1"
+                                Stretch="UniformToFill" />
                         </Grid>
                     </Grid>
                 </ControlTemplate>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #257 

修复切换清晰度时，缺失播放器背景色致使底层元素暴露的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

切换清晰度时会显示下层元素

## 新的行为是什么？

添加了一个背景色以盖住下层元素

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
