### PR TITLE
修复用户创建的收藏夹加载错误的问题

### DIFF
--- a/src/Controller/Controller.Uwp/BiliController.Account.cs
+++ b/src/Controller/Controller.Uwp/BiliController.Account.cs
@@ -405,14 +405,15 @@ namespace Richasy.Bili.Controller.Uwp
         /// </summary>
         /// <param name="userId">用户Id.</param>
         /// <param name="pageNumber">页码.</param>
+        /// <param name="isCreated">是否是该用户创建的收藏夹.</param>
         /// <returns>列表信息.</returns>
-        public async Task<FavoriteMediaList> GetFavoriteFolderListAsync(int userId, int pageNumber)
+        public async Task<FavoriteMediaList> GetFavoriteFolderListAsync(int userId, int pageNumber, bool isCreated = false)
         {
             ThrowWhenNetworkUnavaliable();
 
             try
             {
-                var response = await _accountProvider.GetFavoriteFolderListAsync(userId, pageNumber);
+                var response = await _accountProvider.GetFavoriteFolderListAsync(userId, pageNumber, isCreated);
                 return response;
             }
             catch (Exception ex)

--- a/src/Lib/Lib.Interfaces/IAccountProvider.cs
+++ b/src/Lib/Lib.Interfaces/IAccountProvider.cs
@@ -151,8 +151,9 @@ namespace Richasy.Bili.Lib.Interfaces
         /// </summary>
         /// <param name="userId">用户Id.</param>
         /// <param name="pageNumber">页码.</param>
+        /// <param name="isCreated">是否是该用户创建的收藏夹.</param>
         /// <returns>视频收藏夹列表响应.</returns>
-        Task<FavoriteMediaList> GetFavoriteFolderListAsync(int userId, int pageNumber);
+        Task<FavoriteMediaList> GetFavoriteFolderListAsync(int userId, int pageNumber, bool isCreated);
 
         /// <summary>
         /// 获取追番列表.

--- a/src/Lib/Lib.Uwp/AccountProvider/AccountProvider.cs
+++ b/src/Lib/Lib.Uwp/AccountProvider/AccountProvider.cs
@@ -300,7 +300,7 @@ namespace Richasy.Bili.Lib.Uwp
         }
 
         /// <inheritdoc/>
-        public async Task<FavoriteMediaList> GetFavoriteFolderListAsync(int userId, int pageNumber)
+        public async Task<FavoriteMediaList> GetFavoriteFolderListAsync(int userId, int pageNumber, bool isCreated)
         {
             var queryParameters = new Dictionary<string, string>
             {
@@ -309,7 +309,8 @@ namespace Richasy.Bili.Lib.Uwp
                 { Query.PageNumber, pageNumber.ToString() },
             };
 
-            var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Get, Account.VideoFavoriteFolderDelta, queryParameters, needToken: true);
+            var url = isCreated ? Account.CreatedVideoFavoriteFolderDelta : Account.CollectedVideoFavoriteFolderDelta;
+            var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Get, url, queryParameters, needToken: true);
             var response = await _httpProvider.SendAsync(request);
             var result = await _httpProvider.ParseAsync<ServerResponse<FavoriteMediaList>>(response);
             return result.Data;

--- a/src/Models/Models.App/Constants/ApiConstants.cs
+++ b/src/Models/Models.App/Constants/ApiConstants.cs
@@ -153,9 +153,14 @@ namespace Richasy.Bili.Models.App.Constants
             public const string VideoFavoriteDelta = _apiBase + "/x/v3/fav/resource/list";
 
             /// <summary>
-            /// 获取视频收藏夹分类的增量信息.
+            /// 获取用户收集的视频收藏夹分类的增量信息.
             /// </summary>
-            public const string VideoFavoriteFolderDelta = _apiBase + "/x/v3/fav/folder/collected/list";
+            public const string CollectedVideoFavoriteFolderDelta = _apiBase + "/x/v3/fav/folder/collected/list";
+
+            /// <summary>
+            /// 获取用户创建的视频收藏夹分类的增量信息.
+            /// </summary>
+            public const string CreatedVideoFavoriteFolderDelta = _apiBase + "/x/v3/fav/folder/created/list";
 
             /// <summary>
             /// 获取动漫收藏信息.

--- a/src/ViewModels/ViewModels.Uwp/Account/FavoriteVideoFolderViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Account/FavoriteVideoFolderViewModel.cs
@@ -19,6 +19,7 @@ namespace Richasy.Bili.ViewModels.Uwp
         /// Initializes a new instance of the <see cref="FavoriteVideoFolderViewModel"/> class.
         /// </summary>
         /// <param name="folder">收藏夹分类.</param>
+        /// <param name="isCreated">是否是用户创建的.</param>
         public FavoriteVideoFolderViewModel(FavoriteFolder folder)
         {
             Name = folder.Name;
@@ -73,6 +74,12 @@ namespace Richasy.Bili.ViewModels.Uwp
         public bool IsShowEmpty { get; set; }
 
         /// <summary>
+        /// 是否是该用户创建的.
+        /// </summary>
+        [Reactive]
+        public bool IsCreated { get; set; }
+
+        /// <summary>
         /// 加载更多.
         /// </summary>
         /// <returns><see cref="Task"/>.</returns>
@@ -83,7 +90,7 @@ namespace Richasy.Bili.ViewModels.Uwp
                 IsDeltaLoading = true;
                 try
                 {
-                    var response = await BiliController.Instance.GetFavoriteFolderListAsync(AccountViewModel.Instance.Mid.Value, _pageNumber);
+                    var response = await BiliController.Instance.GetFavoriteFolderListAsync(AccountViewModel.Instance.Mid.Value, _pageNumber, IsMine);
                     HandleMediaList(response);
                 }
                 catch (System.Exception)


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #252 

因为在使用API的时候出了些问题，没有在用户加载更多自己创建的收藏夹时切换到“created”

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

在用户加载更多自己创建的收藏夹时请求到了收集收藏夹里

## 新的行为是什么？

让行为正常

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
