### PR TITLE
支持在点赞后一键三连

### DIFF
--- a/src/App/Controls/App/ProgressButton/ProgressButton.cs
+++ b/src/App/Controls/App/ProgressButton/ProgressButton.cs
@@ -201,11 +201,6 @@ namespace Richasy.Bili.App.Controls
 
             if (IsPressed)
             {
-                if (Convert.ToBoolean(IsChecked))
-                {
-                    return;
-                }
-
                 _isHolding = false;
                 _holdingTime = 0d;
                 _timer.Start();

--- a/src/App/Controls/Player/PlayerDashboard.xaml
+++ b/src/App/Controls/Player/PlayerDashboard.xaml
@@ -131,7 +131,7 @@
                 Description="{x:Bind ViewModel.LikeCount, Mode=OneWay}"
                 HoldingCompleted="OnLikeButtonHoldingCompletedAsync"
                 IsChecked="{x:Bind ViewModel.IsLikeChecked, Mode=OneWay}"
-                IsHoldingEnabled="True"
+                IsHoldingEnabled="{x:Bind ViewModel.IsEnableLikeHolding}"
                 ToolTipService.ToolTip="{loc:LocaleLocator Name=Like}">
                 <icons:RegularFluentIcon Symbol="ThumbLike16" />
             </local:ProgressButton>

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -51,6 +51,12 @@ namespace Richasy.Bili.ViewModels.Uwp
             IsPgc = false;
             IsLive = false;
 
+            IsLikeChecked = false;
+            IsCoinChecked = false;
+            IsFollow = false;
+            IsFavoriteChecked = false;
+            IsEnableLikeHolding = true;
+
             PgcSectionCollection.Clear();
             VideoPartCollection.Clear();
             RelatedVideoCollection.Clear();

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
@@ -413,6 +413,12 @@ namespace Richasy.Bili.ViewModels.Uwp
         public bool IsCoinChecked { get; set; }
 
         /// <summary>
+        /// 是否允许长按点赞.
+        /// </summary>
+        [Reactive]
+        public bool IsEnableLikeHolding { get; set; }
+
+        /// <summary>
         /// 收藏按钮是否被选中.
         /// </summary>
         [Reactive]

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -511,6 +511,11 @@ namespace Richasy.Bili.ViewModels.Uwp
                 case nameof(IsDetailError):
                     PlayerDisplayMode = PlayerDisplayMode.Default;
                     break;
+                case nameof(IsLikeChecked):
+                case nameof(IsCoinChecked):
+                case nameof(IsFavoriteChecked):
+                    IsEnableLikeHolding = !IsLikeChecked || !IsCoinChecked || !IsFavoriteChecked;
+                    break;
                 default:
                     break;
             }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #198 

支持在点赞后，即点赞按钮已选择的情况下可以一键三连。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

点赞后，由于按钮已选中，Holding事件不再启用，所以仅点赞的视频不能直接一键三连。

## 新的行为是什么？

在点赞后也可以一键三连。

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->
