### PR TITLE
调整直播页面布局

### DIFF
--- a/src/App/Pages/LivePage.xaml
+++ b/src/App/Pages/LivePage.xaml
@@ -4,22 +4,14 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Richasy.Bili.App.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:icons="using:Richasy.FluentIcon.Uwp"
     xmlns:loc="using:Richasy.Bili.Locator.Uwp"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:uwp="using:Richasy.Bili.ViewModels.Uwp"
     mc:Ignorable="d">
 
-    <Grid
-        x:Name="RootContainer"
-        Padding="{StaticResource DefaultContainerPadding}"
-        ColumnSpacing="12">
-
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition x:Name="Column2" Width="Auto" />
-        </Grid.ColumnDefinitions>
-
+    <Grid x:Name="RootContainer">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LayoutGroup">
                 <VisualState x:Name="WideState">
@@ -32,61 +24,24 @@
                         <AdaptiveTrigger MinWindowWidth="0" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <Setter Target="RootContainer.ColumnSpacing" Value="0" />
-                        <Setter Target="StandardFollowContainer.Visibility" Value="Collapsed" />
-                        <Setter Target="InlineFollowContainer.Visibility" Value="Visible" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-            <VisualStateGroup x:Name="PaddingGroup">
-                <VisualState x:Name="DefaultPaddingState">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource WideWindowThresholdWidth}" />
-                    </VisualState.StateTriggers>
-                </VisualState>
-                <VisualState x:Name="MediumPaddingState">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource MediumWindowThresholdWidth}" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="RootContainer.Padding" Value="0" />
-                        <Setter Target="RootScrollViewer.Padding" Value="{StaticResource DefaultContainerPadding}" />
-                    </VisualState.Setters>
-                </VisualState>
-                <VisualState x:Name="NarrowPaddingState">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="0" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="RootContainer.Padding" Value="0" />
                         <Setter Target="RootScrollViewer.Padding" Value="{StaticResource NarrowContainerPadding}" />
                         <Setter Target="VideoView.ItemOrientation" Value="Horizontal" />
+                        <Setter Target="FollowListButton.Visibility" Value="Collapsed" />
+                        <Setter Target="InlineFollowContainer.Visibility" Value="Visible" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
 
-        <Grid
-            x:Name="StandardFollowContainer"
-            Grid.Column="1"
-            HorizontalAlignment="Stretch"
-            VerticalAlignment="Stretch">
-            <controls:FollowLiveView
-                x:Name="FollowLiveView"
-                MinWidth="200"
-                ItemOrientation="Horizontal"
-                Visibility="{x:Bind ViewModel.IsShowFollowList, Mode=OneWay}" />
-        </Grid>
-
         <Grid>
             <ScrollViewer
                 x:Name="RootScrollViewer"
-                Padding="0,0,24,0"
+                Padding="{StaticResource DefaultContainerPadding}"
                 HorizontalScrollMode="Disabled"
                 VerticalScrollBarVisibility="Auto">
                 <Grid
                     x:Name="RootGrid"
-                    RowSpacing="12"
+                    RowSpacing="8"
                     Visibility="{x:Bind ViewModel.IsInitializeLoading, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
                     <Grid.RowDefinitions>
                         <RowDefinition x:Name="Row1" Height="Auto" />
@@ -112,18 +67,18 @@
                     <Grid
                         x:Name="FeedsContainer"
                         Grid.Row="2"
-                        Grid.Column="0"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch">
                         <controls:VerticalRepeaterView
                             x:Name="VideoView"
+                            Margin="0,0,0,12"
                             HeaderText="{loc:LocaleLocator Name=Recommend}"
                             ItemsSource="{x:Bind ViewModel.RecommendLiveRoomCollection, Mode=OneWay}"
                             MinWideItemHeight="208"
                             MinWideItemWidth="200"
                             RequestLoadMore="OnVideoViewRequestLoadMoreAsync">
                             <controls:VerticalRepeaterView.AdditionalContent>
-                                <Grid>
+                                <StackPanel Orientation="Horizontal" Spacing="8">
                                     <Button
                                         x:Name="RefreshButton"
                                         VerticalAlignment="Center"
@@ -133,7 +88,37 @@
                                             Symbol="ArrowSyncCircle16"
                                             Text="{loc:LocaleLocator Name=Refresh}" />
                                     </Button>
-                                </Grid>
+                                    <Button
+                                        x:Name="FollowListButton"
+                                        Style="{StaticResource AccentButtonStyle}"
+                                        VerticalAlignment="Center">
+                                        <StackPanel
+                                            Margin="0,1"
+                                            Orientation="Horizontal"
+                                            Spacing="8">
+                                            <icons:RegularFluentIcon
+                                                VerticalAlignment="Center"
+                                                FontSize="14"
+                                                Symbol="EyeShow16" />
+                                            <TextBlock
+                                                VerticalAlignment="Center"
+                                                Text="{loc:LocaleLocator Name=FollowLiveRoom}"
+                                                TextLineBounds="Tight" />
+                                        </StackPanel>
+                                        <Button.Flyout>
+                                            <Flyout>
+                                                <Grid>
+                                                    <controls:FollowLiveView
+                                                        x:Name="FollowLiveView"
+                                                        MinWidth="200"
+                                                        ItemOrientation="Horizontal"
+                                                        Visibility="{x:Bind ViewModel.IsShowFollowList, Mode=OneWay}" />
+                                                    <controls:ErrorPanel Text="{loc:LocaleLocator Name=NoSpecificData}" Visibility="{x:Bind ViewModel.IsShowFollowList, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}" />
+                                                </Grid>
+                                            </Flyout>
+                                        </Button.Flyout>
+                                    </Button>
+                                </StackPanel>
                             </controls:VerticalRepeaterView.AdditionalContent>
                             <controls:VerticalRepeaterView.ItemTemplate>
                                 <DataTemplate x:DataType="uwp:VideoViewModel">


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #265 

调整直播页面布局，在宽屏时隐藏右侧的关注直播间，并改为弹出式

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

直播页面左右两侧分栏显示

## 新的行为是什么？

隐藏宽屏下的关注直播间列表，改为弹出式按钮

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
