### PR TITLE
修复点击关注直播间弹出层未关闭的问题

### DIFF
--- a/src/App/Controls/Live/FollowLiveItem.xaml
+++ b/src/App/Controls/Live/FollowLiveItem.xaml
@@ -24,6 +24,7 @@
                 IsShowReplayCount="False"
                 IsShowViewerCount="True"
                 Orientation="Horizontal"
+                ItemClick="OnItemClick"
                 ViewModel="{x:Bind ViewModel, Mode=OneWay}" />
         </Grid>
         <Grid x:Name="VerticalContainer" Visibility="Collapsed">

--- a/src/App/Controls/Live/FollowLiveItem.xaml.cs
+++ b/src/App/Controls/Live/FollowLiveItem.xaml.cs
@@ -36,6 +36,11 @@ namespace Richasy.Bili.App.Controls
         }
 
         /// <summary>
+        /// 条目被点击时触发.
+        /// </summary>
+        public event EventHandler ItemClick;
+
+        /// <summary>
         /// 视图模型.
         /// </summary>
         public VideoViewModel ViewModel
@@ -86,7 +91,13 @@ namespace Richasy.Bili.App.Controls
 
         private async void OnCardClickAsync(object sender, RoutedEventArgs e)
         {
-            await Launcher.LaunchUriAsync(new Uri((ViewModel.Source as LiveFeedFollowRoom).Link));
+            ItemClick?.Invoke(this, EventArgs.Empty);
+            await PlayerViewModel.Instance.LoadAsync(ViewModel);
+        }
+
+        private void OnItemClick(object sender, VideoViewModel e)
+        {
+            ItemClick?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/src/App/Controls/Live/FollowLiveView.xaml
+++ b/src/App/Controls/Live/FollowLiveView.xaml
@@ -89,6 +89,7 @@
                         <local:FollowLiveItem
                             DataContext="{x:Bind}"
                             Orientation="Horizontal"
+                            ItemClick="OnItemClick"
                             ViewModel="{x:Bind}" />
                     </DataTemplate>
                 </muxc:ItemsRepeater.ItemTemplate>

--- a/src/App/Controls/Live/FollowLiveView.xaml.cs
+++ b/src/App/Controls/Live/FollowLiveView.xaml.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
+using System;
 using Richasy.Bili.ViewModels.Uwp;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -32,6 +33,8 @@ namespace Richasy.Bili.App.Controls
             Current = this;
             Loaded += OnLoaded;
         }
+
+        public event EventHandler ItemClick;
 
         /// <summary>
         /// <see cref="FollowLiveView"/>的实例.
@@ -103,6 +106,11 @@ namespace Richasy.Bili.App.Controls
             {
                 item.Orientation = ItemOrientation;
             }
+        }
+
+        private void OnItemClick(object sender, System.EventArgs e)
+        {
+            ItemClick?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/src/App/Pages/LivePage.xaml
+++ b/src/App/Pages/LivePage.xaml
@@ -106,11 +106,12 @@
                                                 TextLineBounds="Tight" />
                                         </StackPanel>
                                         <Button.Flyout>
-                                            <Flyout>
+                                            <Flyout x:Name="StandardFollowFlyout">
                                                 <Grid>
                                                     <controls:FollowLiveView
                                                         x:Name="FollowLiveView"
                                                         MinWidth="200"
+                                                        ItemClick="OnFollowListViewItemClick"
                                                         ItemOrientation="Horizontal"
                                                         Visibility="{x:Bind ViewModel.IsShowFollowList, Mode=OneWay}" />
                                                     <controls:ErrorPanel Text="{loc:LocaleLocator Name=NoSpecificData}" Visibility="{x:Bind ViewModel.IsShowFollowList, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}" />

--- a/src/App/Pages/LivePage.xaml.cs
+++ b/src/App/Pages/LivePage.xaml.cs
@@ -61,5 +61,10 @@ namespace Richasy.Bili.App.Pages
         {
             await ViewModel.InitializeRequestAsync();
         }
+
+        private void OnFollowListViewItemClick(object sender, EventArgs e)
+        {
+            StandardFollowFlyout.Hide();
+        }
     }
 }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #352

点击关注的直播间后，会关闭展开的关注直播间弹出层

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

点击关注直播间，其所在的弹出层没有关闭

## 新的行为是什么？

点击后关闭弹出层

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

也修复了窄视图下点击关注直播间没有跳转的问题
