### PR TITLE
修复PGC内容中错误的用户显示

### DIFF
--- a/src/App/Controls/Player/DownloadOptionsPanel.xaml.cs
+++ b/src/App/Controls/Player/DownloadOptionsPanel.xaml.cs
@@ -145,7 +145,7 @@ namespace Richasy.Bili.App.Controls
         {
             var resourceToolkit = ServiceLocator.Instance.GetService<IResourceToolkit>();
             var appVM = AppViewModel.Instance;
-            if (ViewModel.TotalPartCollection.Where(p => p.IsSelected).Count() == 0)
+            if (ViewModel.TotalPartCollection.Where(p => p.IsSelected).Count() == 0 && ViewModel.TotalPartCollection.Count > 1)
             {
                 appVM.ShowTip(resourceToolkit.GetLocaleString(Models.Enums.LanguageNames.AtLeastChooseOnePart), Models.Enums.App.InfoType.Warning);
                 return;

--- a/src/App/Controls/Player/PlayerDescriptor.xaml
+++ b/src/App/Controls/Player/PlayerDescriptor.xaml
@@ -21,7 +21,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Grid>
+        <Grid Visibility="{x:Bind ViewModel.IsPgc, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
             <StackPanel
                 x:Name="SinglePublisherContainer"
                 Margin="0,0,0,12"


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #399 

修复PGC内容中显示用户信息的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

在PGC内容中显示了用户信息

## 新的行为是什么？

不在PGC内容中显示用户信息（它只针对视频或直播）

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
