### PR TITLE
修复互动视频选项过长时的UI问题

### DIFF
--- a/src/App/Controls/Player/InteractionChoicePanel.xaml
+++ b/src/App/Controls/Player/InteractionChoicePanel.xaml
@@ -23,7 +23,7 @@
                     ItemsJustification="Center"
                     MinColumnSpacing="12"
                     MinItemHeight="48"
-                    MinItemWidth="200"
+                    MinItemWidth="280"
                     MinRowSpacing="12" />
             </muxc:ItemsRepeater.Layout>
             <muxc:ItemsRepeater.ItemTemplate>
@@ -33,6 +33,7 @@
                         Click="OnChoiceClickAsync"
                         DataContext="{x:Bind}">
                         <Grid
+                            Padding="12,0"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
                             Background="{ThemeResource MediaTransportControlsPanelBackground}"
@@ -42,7 +43,9 @@
                                 VerticalAlignment="Center"
                                 FontSize="20"
                                 FontWeight="Bold"
-                                Text="{x:Bind Option}" />
+                                Text="{x:Bind Option}"
+                                TextTrimming="CharacterEllipsis"
+                                ToolTipService.ToolTip="{x:Bind Option}" />
                         </Grid>
                     </local:CardPanel>
                 </DataTemplate>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #402 

修复互动视频选项过长时，直接进行文本截断的行为

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

选项文本过长时，文本会被直接截断

## 新的行为是什么？

调整选项最小宽度为280，并添加缩略符与文本提示

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
