### PR TITLE
修复直播断连的问题

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -12,7 +12,7 @@
     <DisableStackTraceMetadata>true</DisableStackTraceMetadata>
     <DisableExceptionMessages>true</DisableExceptionMessages>
     <DefaultLanguage>zh-CN</DefaultLanguage>
-    <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <Use64BitCompiler>true</Use64BitCompiler>
     <ShortcutGenericAnalysis>true</ShortcutGenericAnalysis>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>

--- a/src/App/Controls/Player/BiliPlayer/BiliPlayer.cs
+++ b/src/App/Controls/Player/BiliPlayer/BiliPlayer.cs
@@ -23,8 +23,7 @@ namespace Richasy.Bili.App.Controls
             if (ViewModel.BiliPlayer == null)
             {
                 var mediaPlayerElement = GetTemplateChild("MediaPlayerElement") as MediaPlayerElement;
-                var mediaElement = GetTemplateChild("MediaElement") as MediaElement;
-                ViewModel.ApplyMediaControl(mediaPlayerElement, mediaElement);
+                ViewModel.ApplyMediaControl(mediaPlayerElement);
             }
         }
     }

--- a/src/App/Controls/Player/BiliPlayer/BiliPlayer.xaml
+++ b/src/App/Controls/Player/BiliPlayer/BiliPlayer.xaml
@@ -18,8 +18,7 @@
                                 x:Name="MediaPlayerElement"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Stretch"
-                                AreTransportControlsEnabled="True"
-                                Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsClassicPlayer, Converter={StaticResource BoolToVisibilityReverseConverter}}">
+                                AreTransportControlsEnabled="True">
                                 <MediaPlayerElement.TransportControls>
                                     <local:BiliPlayerTransportControls
                                         x:Name="MTC"
@@ -30,22 +29,6 @@
                                         IsPlaybackRateEnabled="True" />
                                 </MediaPlayerElement.TransportControls>
                             </MediaPlayerElement>
-                            <MediaElement
-                                x:Name="MediaElement"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
-                                AreTransportControlsEnabled="True"
-                                Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsClassicPlayer, Converter={StaticResource BoolToVisibilityConverter}}">
-                                <MediaElement.TransportControls>
-                                    <local:BiliPlayerTransportControls
-                                        x:Name="ClassicMTC"
-                                        IsCompactOverlayButtonVisible="True"
-                                        IsCompactOverlayEnabled="True"
-                                        IsFullWindowButtonVisible="False"
-                                        IsPlaybackRateButtonVisible="True"
-                                        IsPlaybackRateEnabled="True" />
-                                </MediaElement.TransportControls>
-                            </MediaElement>
                         </Grid>
 
                         <Grid

--- a/src/Lib/Lib.Uwp/AuthorizeProvider/AuthorizeProvider.cs
+++ b/src/Lib/Lib.Uwp/AuthorizeProvider/AuthorizeProvider.cs
@@ -78,6 +78,7 @@ namespace Richasy.Bili.Lib.Uwp
             else if (clientType == RequestClientType.Web)
             {
                 queryParameters.Add(ServiceConstants.Query.AppKey, ServiceConstants.Keys.WebKey);
+                queryParameters.Add(ServiceConstants.Query.Platform, "web");
                 queryParameters.Add(ServiceConstants.Query.TimeStamp, GetNowMilliSeconds().ToString());
             }
             else

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Dash.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Dash.cs
@@ -88,50 +88,7 @@ namespace Richasy.Bili.ViewModels.Uwp
                 _currentPlaybackItem = new MediaPlaybackItem(mediaSource);
                 _currentVideoPlayer.Source = _currentPlaybackItem;
 
-                IsClassicPlayer = false;
                 BiliPlayer.SetMediaPlayer(_currentVideoPlayer);
-                MediaPlayerUpdated?.Invoke(this, EventArgs.Empty);
-            }
-            catch (Exception)
-            {
-                IsPlayInformationError = true;
-                PlayInformationErrorText = _resourceToolkit.GetLocaleString(Models.Enums.LanguageNames.RequestVideoFailed);
-            }
-        }
-
-        private async Task InitializeFlvVideoAsync()
-        {
-            try
-            {
-                var playList = new SYEngine.Playlist(SYEngine.PlaylistTypes.NetworkHttp);
-                var config = default(SYEngine.PlaylistNetworkConfigs);
-                config.DownloadRetryOnFail = true;
-                config.HttpCookie = string.Empty;
-                config.UniqueId = string.Empty;
-                config.HttpUserAgent = ServiceConstants.DefaultUserAgentString;
-                if (IsPgc && CurrentPgcEpisode != null)
-                {
-                    config.HttpReferer = $"https://www.bilibili.com/bangumi/play/ep{CurrentPgcEpisode.Id}";
-                }
-                else
-                {
-                    config.HttpReferer = string.Empty;
-                }
-
-                playList.NetworkConfigs = config;
-                foreach (var item in _flvList)
-                {
-                    playList.Append(item.Url, item.Size, float.Parse((item.Length / 1000.0).ToString()));
-                }
-
-                if (ClassicPlayer != null)
-                {
-                    _initializeProgress = ClassicPlayer.Position;
-                }
-
-                IsClassicPlayer = true;
-                ClassicPlayer.AutoPlay = IsAutoPlay;
-                ClassicPlayer.Source = await playList.SaveAndGetFileUriAsync();
                 MediaPlayerUpdated?.Invoke(this, EventArgs.Empty);
             }
             catch (Exception)

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
@@ -48,7 +48,6 @@ namespace Richasy.Bili.ViewModels.Uwp
 
         private List<DashItem> _audioList;
         private List<DashItem> _videoList;
-        private List<FlvItem> _flvList;
         private List<SubtitleItem> _subtitleList;
 
         private MediaPlayer _currentVideoPlayer;
@@ -106,12 +105,6 @@ namespace Richasy.Bili.ViewModels.Uwp
         /// 调度器.
         /// </summary>
         public CoreDispatcher Dispatcher { get; set; }
-
-        /// <summary>
-        /// 是否使用经典播放器.
-        /// </summary>
-        [Reactive]
-        public bool IsClassicPlayer { get; set; }
 
         /// <summary>
         /// 详情是否可以加载（用于优化页面跳转的加载时间）.


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #368 #305 

使用Web接口的播放数据以避免直播断连

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

部分直播间的线路存在播放时间短，易断连的情况

## 新的行为是什么？

通过使用Web端接口，绕开一些流量限制，从而完整流畅地播放直播

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

移除了MediaElement，并调整应用最低要求版本为1809
