### PR TITLE
添加分集大会员提示

### DIFF
--- a/src/App/Controls/Player/Related/EpisodeView.xaml
+++ b/src/App/Controls/Player/Related/EpisodeView.xaml
@@ -43,6 +43,21 @@
                                 VerticalAlignment="Center"
                                 CornerRadius="{StaticResource ControlCornerRadius}">
                                 <Image Source="{x:Bind Data.Cover, Converter={StaticResource EpisodeCoverConverter}}" Stretch="UniformToFill" />
+                                <Grid
+                                    x:Name="BadgeContainer"
+                                    Margin="4,4,0,0"
+                                    Padding="6,4"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Top"
+                                    Background="{ThemeResource AccentFillColorTertiaryBrush}"
+                                    CornerRadius="{StaticResource ControlCornerRadius}"
+                                    Visibility="{x:Bind Data.BadgeText, Converter={StaticResource ObjectToVisibilityConverter}}">
+                                    <TextBlock
+                                        Style="{StaticResource CaptionTextBlockStyle}"
+                                        FontSize="10"
+                                        Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                                        Text="{x:Bind Data.BadgeText}" />
+                                </Grid>
                             </Grid>
                             <StackPanel
                                 Grid.Column="1"

--- a/src/App/Pages/Overlay/PlayerPage.xaml.cs
+++ b/src/App/Pages/Overlay/PlayerPage.xaml.cs
@@ -202,7 +202,12 @@ namespace Richasy.Bili.App.Pages.Overlay
         {
             var appView = ApplicationView.GetForCurrentView();
             VisualStateManager.GoToState(this, nameof(StandardPlayerState), false);
-            ViewModel.BiliPlayer.IsFullWindow = false;
+
+            if (ViewModel.BiliPlayer != null)
+            {
+                ViewModel.BiliPlayer.IsFullWindow = false;
+            }
+
             if (appView.ViewMode == ApplicationViewMode.CompactOverlay)
             {
                 await appView.TryEnterViewModeAsync(ApplicationViewMode.Default);

--- a/src/Models/Models.BiliBili/Pgc/PgcDisplayInformation.cs
+++ b/src/Models/Models.BiliBili/Pgc/PgcDisplayInformation.cs
@@ -415,6 +415,12 @@ namespace Richasy.Bili.Models.BiliBili
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "report", Required = Required.Default)]
         public PgcModuleReport Report { get; set; }
+
+        /// <summary>
+        /// 徽章文本.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "badge", Required = Required.Default)]
+        public string BadgeText { get; set; }
     }
 
     /// <summary>

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using FFmpegInterop;
 using Richasy.Bili.Locator.Uwp;
-using Richasy.Bili.Models.App.Constants;
 using Richasy.Bili.Models.BiliBili;
 using Richasy.Bili.Models.Enums;
 using Richasy.Bili.ViewModels.Uwp.Common;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #483 

修复在需要大会员才能播放的分集列表中没有大会员提示的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

需要大会员才能播放的分集没有明显提示

## 新的行为是什么？

在分集封面上添加需要会员的提示

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
