### PR TITLE
支持关联视频回退

### DIFF
--- a/src/App/Controls/App/AppTitleBar.xaml
+++ b/src/App/Controls/App/AppTitleBar.xaml
@@ -81,7 +81,7 @@
             <Button
                 x:Name="BackButton"
                 Style="{StaticResource TitleBarButtonStyle}"
-                Click="OnBackButtonClick"
+                Click="OnBackButtonClickAsync"
                 TabIndex="1">
                 <Button.KeyboardAccelerators>
                     <KeyboardAccelerator Key="Back" IsEnabled="{x:Bind ViewModel.IsBackButtonEnabled, Mode=OneWay}" />

--- a/src/App/Controls/App/AppTitleBar.xaml.cs
+++ b/src/App/Controls/App/AppTitleBar.xaml.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using Richasy.Bili.ViewModels.Uwp;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -43,7 +44,7 @@ namespace Richasy.Bili.App.Controls
         /// 尝试回退.
         /// </summary>
         /// <returns>是否调用了返回命令.</returns>
-        public bool TryBack()
+        public async Task<bool> TryBackAsync()
         {
             if (BackButton.Visibility != Visibility.Visible)
             {
@@ -52,8 +53,11 @@ namespace Richasy.Bili.App.Controls
 
             if (ViewModel.IsOpenPlayer)
             {
-                ViewModel.IsOpenPlayer = false;
-                return true;
+                if (await PlayerViewModel.Instance.CheckBackAsync())
+                {
+                    ViewModel.IsOpenPlayer = false;
+                    return true;
+                }
             }
             else if (ViewModel.IsShowOverlay)
             {
@@ -110,9 +114,9 @@ namespace Richasy.Bili.App.Controls
             ViewModel.IsNavigatePaneOpen = !ViewModel.IsNavigatePaneOpen;
         }
 
-        private void OnBackButtonClick(object sender, RoutedEventArgs e)
+        private async void OnBackButtonClickAsync(object sender, RoutedEventArgs e)
         {
-            TryBack();
+            await TryBackAsync();
         }
 
         private void CheckBackButtonVisibility()

--- a/src/App/Pages/RootPage.xaml.cs
+++ b/src/App/Pages/RootPage.xaml.cs
@@ -2,6 +2,7 @@
 
 using System.ComponentModel;
 using System.Linq;
+using System.Threading.Tasks;
 using Richasy.Bili.App.Controls;
 using Richasy.Bili.Models.App.Args;
 using Richasy.Bili.ViewModels.Uwp;
@@ -26,9 +27,9 @@ namespace Richasy.Bili.App.Pages
             this.InitializeComponent();
             this.Loaded += OnLoadedAsync;
             this.CoreViewModel.RequestShowTip += OnRequestShowTip;
-            this.CoreViewModel.RequestBack += OnRequestBack;
+            this.CoreViewModel.RequestBack += OnRequestBackAsync;
             SizeChanged += OnSizeChanged;
-            SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequested;
+            SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequestedAsync;
         }
 
         /// <summary>
@@ -81,7 +82,7 @@ namespace Richasy.Bili.App.Pages
             base.OnPointerReleased(e);
         }
 
-        private bool TryBack()
+        private async Task<bool> TryBackAsync()
         {
             if (HolderContainer.Children.Count > 0)
             {
@@ -94,13 +95,13 @@ namespace Richasy.Bili.App.Pages
             }
             else if (CoreViewModel.IsBackButtonEnabled)
             {
-                return TitleBar.TryBack();
+                return await TitleBar.TryBackAsync();
             }
 
             return false;
         }
 
-        private void OnRequestBack(object sender, System.EventArgs e) => TryBack();
+        private async void OnRequestBackAsync(object sender, System.EventArgs e) => await TryBackAsync();
 
         private async void OnLoadedAsync(object sender, RoutedEventArgs e)
         {
@@ -110,9 +111,9 @@ namespace Richasy.Bili.App.Pages
             await AccountViewModel.Instance.TrySignInAsync(true);
         }
 
-        private void OnBackRequested(object sender, BackRequestedEventArgs e)
+        private async void OnBackRequestedAsync(object sender, BackRequestedEventArgs e)
         {
-            if (TryBack())
+            if (await TryBackAsync())
             {
                 e.Handled = true;
             }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
@@ -29,6 +29,7 @@ namespace Richasy.Bili.ViewModels.Uwp
         private readonly IFileToolkit _fileToolkit;
         private readonly ILoggerModule _logger;
 
+        private readonly List<string> _historyVideoList;
         private readonly FFmpegInteropConfig _liveFFConfig;
 
         private long _videoId;

--- a/src/ViewModels/ViewModels.Uwp/Common/VideoViewModel/VideoViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/VideoViewModel/VideoViewModel.Properties.cs
@@ -105,6 +105,11 @@ namespace Richasy.Bili.ViewModels.Uwp
         /// </summary>
         public string SourceCoverUrl { get; set; }
 
+        /// <summary>
+        /// 是否为关联视频.
+        /// </summary>
+        public bool IsRelated { get; set; }
+
         /// <inheritdoc/>
         public override bool Equals(object obj) => obj is VideoViewModel model && VideoId == model.VideoId;
 

--- a/src/ViewModels/ViewModels.Uwp/Common/VideoViewModel/VideoViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/VideoViewModel/VideoViewModel.cs
@@ -227,6 +227,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             AdditionalText = relate.Rating.ToString();
             LimitCover(relate.Pic);
             Source = relate;
+            IsRelated = true;
             VideoType = relate.Goto.Equals(ServiceConstants.Av, StringComparison.OrdinalIgnoreCase) ?
                 Models.Enums.VideoType.Video : Models.Enums.VideoType.Pgc;
         }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #416 

当用户点击关联视频后，记录前一个视频，并在用户尝试返回时返回上一个视频，而非回到主页

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

不论用户跳转多少次，点击返回按钮都会回到主页。

## 新的行为是什么？

当用户通过关联视频进行跳转时，支持返回到上一视频

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
