### PR TITLE
修复重复弹出历史记录的问题

### DIFF
--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -27,6 +27,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             _playerInformation = null;
             _interactionNodeId = 0;
             _interactionPartId = 0;
+            _isFirstShowHistory = true;
             CurrentFormat = null;
             CurrentPgcEpisode = null;
             CurrentVideoPart = null;
@@ -901,9 +902,10 @@ namespace Richasy.Bili.ViewModels.Uwp
                         case MediaPlaybackState.Playing:
                             PlayerStatus = PlayerStatus.Playing;
                             IsPlayInformationError = false;
-                            if (!string.IsNullOrEmpty(HistoryText) && _initializeProgress == TimeSpan.Zero)
+                            if (!string.IsNullOrEmpty(HistoryText) && _initializeProgress == TimeSpan.Zero && _isFirstShowHistory)
                             {
                                 IsShowHistory = true;
+                                _isFirstShowHistory = false;
                             }
 
                             if (sender.PlaybackSession.Position < _initializeProgress)

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
@@ -62,6 +62,8 @@ namespace Richasy.Bili.ViewModels.Uwp
         private bool _isInteractionChanging;
         private InteractionEdgeResponse _interactionDetail;
 
+        private bool _isFirstShowHistory;
+
         /// <summary>
         /// 让直播消息视图滚动到底部.
         /// </summary>

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -49,8 +49,6 @@ namespace Richasy.Bili.ViewModels.Uwp
 
             _liveFFConfig = new FFmpegInteropConfig();
             _liveFFConfig.FFmpegOptions.Add("rtsp-transport", "tcp");
-
-            // _liveFFConfig.FFmpegOptions.Add("user_agent", ServiceConstants.DefaultUserAgentString);
             _liveFFConfig.FFmpegOptions.Add("referer", "https://live.bilibili.com/");
             _liveFFConfig.FFmpegOptions.Add("user-agent", "Mozilla/5.0 BiliDroid/1.12.0 (bbcallen@gmail.com)");
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #549 

修复历史记录提醒重复弹出的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

对于同一视频且拥有历史记录的情况，只要播放状态改变，就会重复弹出历史记录提示

## 新的行为是什么？

仅在视频开始播放时进行提示

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
