### PR TITLE
更改系统字体列表的读取方式以避免崩溃

### DIFF
--- a/src/Utilities/Toolkit/Toolkit.Uwp/FontToolkit.cs
+++ b/src/Utilities/Toolkit/Toolkit.Uwp/FontToolkit.cs
@@ -15,26 +15,13 @@ namespace Richasy.Bili.Toolkit.Uwp
         /// <inheritdoc/>
         public List<string> GetSystemFontList()
         {
-            var defaultLan = "en-us";
             try
             {
-                var fonts = CanvasFontSet.GetSystemFontSet();
-                var result = new List<string>();
-                foreach (var font in fonts.Fonts)
+                var localeList = new List<string>
                 {
-                    font.FamilyNames.TryGetValue(defaultLan, out var fontName);
-                    if (string.IsNullOrEmpty(fontName) && font.FamilyNames.Count > 0)
-                    {
-                        fontName = font.FamilyNames.First().Value;
-                    }
-
-                    if (!string.IsNullOrEmpty(fontName) && !result.Contains(fontName))
-                    {
-                        result.Add(fontName);
-                    }
-                }
-
-                return result;
+                    "zh-cn",
+                };
+                return CanvasTextFormat.GetSystemFontFamilies(localeList).OrderBy(x => x).ToList();
             }
             catch (System.Exception)
             {


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #291

<!-- 在上面的 `修复` 标题后添加要修复的 Issue 编号，比如 “修复 #1234”，这样在 PR 合并后可以直接关闭 Issue -->

<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

<!-- 请描述应用在你修复之前的行为，或者添加 Issue 链接 -->

在部分设备上，Win2D 的 `CanvasFontSet.GetSystemFontSet()` 会抛出无法被 catch 的 `AccessViolationException` ，导致无法获取系统字体列表，进而导致应用崩溃。

## 新的行为是什么？

改用 `CanvasTextFormat.GetSystemFontFamilies()` 获取系统字体列表，避免应用崩溃。

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [ ] 应用成功启动
- [ ] 文件头已经被添加至所有源文件中
- [ ] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->

- 在我的机器上现在可以播放视频而不崩溃了。但是根据 https://github.com/microsoft/Win2D/issues/759#issuecomment-596965763 ，即使是用 `CanvasTextFormat.GetSystemFontFamilies()` 也还是可能在某些机器上遇到异常，不过不是 `AccessViolationException`。