### PR TITLE
添加分集索引视图

### DIFF
--- a/src/App/Controls/Player/Related/EpisodeView.xaml
+++ b/src/App/Controls/Player/Related/EpisodeView.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Richasy.Bili.App.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:loc="using:Richasy.Bili.Locator.Uwp"
     xmlns:local="using:Richasy.Bili.App.Controls.Player.Related"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
@@ -12,74 +13,134 @@
     d:DesignWidth="400"
     mc:Ignorable="d">
 
-    <ScrollViewer
-        HorizontalScrollMode="Disabled"
-        VerticalScrollBarVisibility="Hidden"
-        VerticalScrollMode="{x:Bind VerticalScrollMode, Mode=OneWay}">
-        <controls:VerticalRepeaterView
-            EnableDetectParentScrollViewer="False"
-            HeaderVisibility="Collapsed"
-            ItemOrientation="Horizontal"
-            ItemsSource="{x:Bind ViewModel.EpisodeCollection}">
-            <controls:VerticalRepeaterView.ItemTemplate>
-                <DataTemplate x:DataType="uwp:PgcEpisodeViewModel">
-                    <controls:CardPanel
-                        Click="OnEpisodeItemClickAsync"
-                        DataContext="{x:Bind}"
-                        IsChecked="{x:Bind IsSelected, Mode=OneWay}"
-                        IsEnableCheck="True"
-                        IsEnableHoverAnimation="False">
-                        <Grid
-                            Padding="12"
-                            HorizontalAlignment="Stretch"
-                            ColumnSpacing="12">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <Grid
-                                Width="96"
-                                Height="64"
-                                VerticalAlignment="Center"
-                                CornerRadius="{StaticResource ControlCornerRadius}">
-                                <Image Source="{x:Bind Data.Cover, Converter={StaticResource EpisodeCoverConverter}}" Stretch="UniformToFill" />
+    <Grid RowSpacing="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock
+                VerticalAlignment="Center"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Text="{loc:LocaleLocator Name=OnlyIndex}"
+                TextTrimming="CharacterEllipsis" />
+            <ToggleSwitch
+                x:Name="OnlyIndexSwitch"
+                Grid.Column="1"
+                MinWidth="0"
+                MinHeight="0"
+                VerticalAlignment="Center"
+                IsOn="{x:Bind ViewModel.IsOnlyShowIndex, Mode=TwoWay}" />
+        </Grid>
+        <ScrollViewer
+            Grid.Row="1"
+            HorizontalScrollMode="Disabled"
+            VerticalScrollBarVisibility="Hidden"
+            VerticalScrollMode="{x:Bind VerticalScrollMode, Mode=OneWay}">
+            <Grid>
+                <controls:VerticalRepeaterView
+                    EnableDetectParentScrollViewer="False"
+                    HeaderVisibility="Collapsed"
+                    ItemOrientation="Horizontal"
+                    ItemsSource="{x:Bind ViewModel.EpisodeCollection}"
+                    Visibility="{x:Bind ViewModel.IsOnlyShowIndex, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
+                    <controls:VerticalRepeaterView.ItemTemplate>
+                        <DataTemplate x:DataType="uwp:PgcEpisodeViewModel">
+                            <controls:CardPanel
+                                Click="OnEpisodeItemClickAsync"
+                                DataContext="{x:Bind}"
+                                IsChecked="{x:Bind IsSelected, Mode=OneWay}"
+                                IsEnableCheck="True"
+                                IsEnableHoverAnimation="False">
                                 <Grid
-                                    x:Name="BadgeContainer"
-                                    Margin="4,4,0,0"
-                                    Padding="6,4"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Top"
-                                    Background="{ThemeResource AccentFillColorTertiaryBrush}"
-                                    CornerRadius="{StaticResource ControlCornerRadius}"
-                                    Visibility="{x:Bind Data.BadgeText, Converter={StaticResource ObjectToVisibilityConverter}}">
-                                    <TextBlock
-                                        Style="{StaticResource CaptionTextBlockStyle}"
-                                        FontSize="10"
-                                        Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
-                                        Text="{x:Bind Data.BadgeText}" />
+                                    Padding="12"
+                                    HorizontalAlignment="Stretch"
+                                    ColumnSpacing="12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <Grid
+                                        Width="96"
+                                        Height="64"
+                                        VerticalAlignment="Center"
+                                        CornerRadius="{StaticResource ControlCornerRadius}">
+                                        <Image Source="{x:Bind Data.Cover, Converter={StaticResource EpisodeCoverConverter}}" Stretch="UniformToFill" />
+                                        <Grid
+                                            x:Name="BadgeContainer"
+                                            Margin="4,4,0,0"
+                                            Padding="6,4"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Top"
+                                            Background="{ThemeResource AccentFillColorTertiaryBrush}"
+                                            CornerRadius="{StaticResource ControlCornerRadius}"
+                                            Visibility="{x:Bind Data.BadgeText, Converter={StaticResource ObjectToVisibilityConverter}}">
+                                            <TextBlock
+                                                Style="{StaticResource CaptionTextBlockStyle}"
+                                                FontSize="10"
+                                                Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                                                Text="{x:Bind Data.BadgeText}" />
+                                        </Grid>
+                                    </Grid>
+                                    <StackPanel
+                                        Grid.Column="1"
+                                        VerticalAlignment="Center"
+                                        Spacing="4">
+                                        <TextBlock
+                                            Style="{StaticResource BodyTextBlockStyle}"
+                                            FontWeight="Bold"
+                                            Text="{x:Bind Data, Converter={StaticResource EpisodeTitleConverter}}" />
+                                        <TextBlock
+                                            Style="{StaticResource CaptionTextBlockStyle}"
+                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                            Text="{x:Bind Data.Duration, Converter={StaticResource MillisecondsDurationConverter}}" />
+                                        <TextBlock
+                                            Style="{StaticResource CaptionTextBlockStyle}"
+                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                            Text="{x:Bind Data.Subtitle}" />
+                                    </StackPanel>
                                 </Grid>
-                            </Grid>
-                            <StackPanel
-                                Grid.Column="1"
-                                VerticalAlignment="Center"
-                                Spacing="4">
-                                <TextBlock
-                                    Style="{StaticResource BodyTextBlockStyle}"
-                                    FontWeight="Bold"
-                                    Text="{x:Bind Data, Converter={StaticResource EpisodeTitleConverter}}" />
-                                <TextBlock
-                                    Style="{StaticResource CaptionTextBlockStyle}"
-                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    Text="{x:Bind Data.Duration, Converter={StaticResource MillisecondsDurationConverter}}" />
-                                <TextBlock
-                                    Style="{StaticResource CaptionTextBlockStyle}"
-                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    Text="{x:Bind Data.Subtitle}" />
-                            </StackPanel>
-                        </Grid>
-                    </controls:CardPanel>
-                </DataTemplate>
-            </controls:VerticalRepeaterView.ItemTemplate>
-        </controls:VerticalRepeaterView>
-    </ScrollViewer>
+                            </controls:CardPanel>
+                        </DataTemplate>
+                    </controls:VerticalRepeaterView.ItemTemplate>
+                </controls:VerticalRepeaterView>
+                <muxc:ItemsRepeater ItemsSource="{x:Bind ViewModel.EpisodeCollection, Mode=OneWay}" Visibility="{x:Bind ViewModel.IsOnlyShowIndex, Mode=OneWay}">
+                    <muxc:ItemsRepeater.Layout>
+                        <muxc:UniformGridLayout
+                            ItemsStretch="Fill"
+                            MinColumnSpacing="8"
+                            MinItemHeight="48"
+                            MinItemWidth="48"
+                            MinRowSpacing="8" />
+                    </muxc:ItemsRepeater.Layout>
+                    <muxc:ItemsRepeater.ItemTemplate>
+                        <DataTemplate x:DataType="uwp:PgcEpisodeViewModel">
+                            <controls:CardPanel
+                                AutomationProperties.Name="{x:Bind Data.LongTitle}"
+                                Click="OnEpisodeItemClickAsync"
+                                DataContext="{x:Bind}"
+                                IsChecked="{x:Bind IsSelected, Mode=OneWay}"
+                                IsEnableCheck="True"
+                                IsEnableHoverAnimation="False"
+                                IsEnableShadow="False"
+                                ToolTipService.ToolTip="{x:Bind Data.LongTitle}">
+                                <Grid>
+                                    <TextBlock
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        FontWeight="Bold"
+                                        Text="{x:Bind Data.Index, Mode=OneWay}" />
+                                </Grid>
+                            </controls:CardPanel>
+                        </DataTemplate>
+                    </muxc:ItemsRepeater.ItemTemplate>
+                </muxc:ItemsRepeater>
+            </Grid>
+        </ScrollViewer>
+    </Grid>
+
 </controls:PlayerComponent>

--- a/src/App/Controls/Player/Related/VideoPartView.xaml
+++ b/src/App/Controls/Player/Related/VideoPartView.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Richasy.Bili.App.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:loc="using:Richasy.Bili.Locator.Uwp"
     xmlns:local="using:Richasy.Bili.App.Controls.Player.Related"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
@@ -12,48 +13,107 @@
     d:DesignWidth="400"
     mc:Ignorable="d">
 
-    <ScrollViewer
-        HorizontalScrollMode="Disabled"
-        VerticalScrollBarVisibility="Hidden"
-        VerticalScrollMode="{x:Bind VerticalScrollMode, Mode=OneWay}">
-        <controls:VerticalRepeaterView
-            EnableDetectParentScrollViewer="False"
-            HeaderVisibility="Collapsed"
-            ItemOrientation="Horizontal"
-            ItemsSource="{x:Bind ViewModel.VideoPartCollection}">
-            <controls:VerticalRepeaterView.ItemTemplate>
-                <DataTemplate x:DataType="uwp:VideoPartViewModel">
-                    <controls:CardPanel
-                        Click="OnPartItemClickAsync"
-                        DataContext="{x:Bind}"
-                        IsChecked="{x:Bind IsSelected, Mode=OneWay}"
-                        IsEnableCheck="True"
-                        IsEnableHoverAnimation="False">
-                        <Grid Padding="12">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="36" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock
-                                VerticalAlignment="Center"
-                                FontWeight="Bold"
-                                Text="{x:Bind Data.Page.Page_}" />
-                            <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                                <TextBlock
-                                    Style="{StaticResource BodyTextBlockStyle}"
-                                    FontWeight="Bold"
-                                    Text="{x:Bind Data.Page.Part}" />
-                                <TextBlock
-                                    Style="{StaticResource CaptionTextBlockStyle}"
-                                    Margin="0,4,0,0"
-                                    FontWeight="Bold"
-                                    Text="{x:Bind Data.Page.Desc}"
-                                    Visibility="{x:Bind Data.Page.Desc, Converter={StaticResource ObjectToVisibilityConverter}}" />
-                            </StackPanel>
-                        </Grid>
-                    </controls:CardPanel>
-                </DataTemplate>
-            </controls:VerticalRepeaterView.ItemTemplate>
-        </controls:VerticalRepeaterView>
-    </ScrollViewer>
+    <Grid RowSpacing="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock
+                VerticalAlignment="Center"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Text="{loc:LocaleLocator Name=OnlyIndex}"
+                TextTrimming="CharacterEllipsis" />
+            <ToggleSwitch
+                x:Name="OnlyIndexSwitch"
+                Grid.Column="1"
+                MinWidth="0"
+                MinHeight="0"
+                VerticalAlignment="Center"
+                IsOn="{x:Bind ViewModel.IsOnlyShowIndex, Mode=TwoWay}" />
+        </Grid>
+        <ScrollViewer
+            Grid.Row="1"
+            HorizontalScrollMode="Disabled"
+            VerticalScrollBarVisibility="Hidden"
+            VerticalScrollMode="{x:Bind VerticalScrollMode, Mode=OneWay}">
+            <Grid>
+                <controls:VerticalRepeaterView
+                    EnableDetectParentScrollViewer="False"
+                    HeaderVisibility="Collapsed"
+                    ItemOrientation="Horizontal"
+                    ItemsSource="{x:Bind ViewModel.VideoPartCollection}"
+                    Visibility="{x:Bind ViewModel.IsOnlyShowIndex, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
+                    <controls:VerticalRepeaterView.ItemTemplate>
+                        <DataTemplate x:DataType="uwp:VideoPartViewModel">
+                            <controls:CardPanel
+                                Click="OnPartItemClickAsync"
+                                DataContext="{x:Bind}"
+                                IsChecked="{x:Bind IsSelected, Mode=OneWay}"
+                                IsEnableCheck="True"
+                                IsEnableHoverAnimation="False">
+                                <Grid Padding="12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="36" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock
+                                        VerticalAlignment="Center"
+                                        FontWeight="Bold"
+                                        Text="{x:Bind Data.Page.Page_}" />
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                        <TextBlock
+                                            Style="{StaticResource BodyTextBlockStyle}"
+                                            FontWeight="Bold"
+                                            Text="{x:Bind Data.Page.Part}" />
+                                        <TextBlock
+                                            Style="{StaticResource CaptionTextBlockStyle}"
+                                            Margin="0,4,0,0"
+                                            FontWeight="Bold"
+                                            Text="{x:Bind Data.Page.Desc}"
+                                            Visibility="{x:Bind Data.Page.Desc, Converter={StaticResource ObjectToVisibilityConverter}}" />
+                                    </StackPanel>
+                                </Grid>
+                            </controls:CardPanel>
+                        </DataTemplate>
+                    </controls:VerticalRepeaterView.ItemTemplate>
+                </controls:VerticalRepeaterView>
+                <muxc:ItemsRepeater ItemsSource="{x:Bind ViewModel.VideoPartCollection, Mode=OneWay}" Visibility="{x:Bind ViewModel.IsOnlyShowIndex, Mode=OneWay}">
+                    <muxc:ItemsRepeater.Layout>
+                        <muxc:UniformGridLayout
+                            ItemsStretch="Fill"
+                            MinColumnSpacing="8"
+                            MinItemHeight="48"
+                            MinItemWidth="48"
+                            MinRowSpacing="8" />
+                    </muxc:ItemsRepeater.Layout>
+                    <muxc:ItemsRepeater.ItemTemplate>
+                        <DataTemplate x:DataType="uwp:VideoPartViewModel">
+                            <controls:CardPanel
+                                AutomationProperties.Name="{x:Bind Data.Page.Part}"
+                                Click="OnPartItemClickAsync"
+                                DataContext="{x:Bind}"
+                                IsChecked="{x:Bind IsSelected, Mode=OneWay}"
+                                IsEnableCheck="True"
+                                IsEnableHoverAnimation="False"
+                                IsEnableShadow="False"
+                                ToolTipService.ToolTip="{x:Bind Data.Page.Part}">
+                                <Grid>
+                                    <TextBlock
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        FontWeight="Bold"
+                                        Text="{x:Bind Data.Page.Page_, Mode=OneWay}" />
+                                </Grid>
+                            </controls:CardPanel>
+                        </DataTemplate>
+                    </muxc:ItemsRepeater.ItemTemplate>
+                </muxc:ItemsRepeater>
+            </Grid>
+        </ScrollViewer>
+    </Grid>
 </controls:PlayerComponent>

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -716,6 +716,9 @@
   <data name="OnlyAudio" xml:space="preserve">
     <value>仅音频</value>
   </data>
+  <data name="OnlyIndex" xml:space="preserve">
+    <value>仅显示序号</value>
+  </data>
   <data name="OnlySubtitle" xml:space="preserve">
     <value>仅字幕</value>
   </data>

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -387,6 +387,7 @@ namespace Richasy.Bili.Models.Enums
         OpenDownloadPage,
         IgnoreVersion,
         PreRelease,
+        OnlyIndex,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/Models/Models.Enums/App/SettingNames.cs
+++ b/src/Models/Models.Enums/App/SettingNames.cs
@@ -42,6 +42,7 @@ namespace Richasy.Bili.Models.Enums
         DisableP2PCdn,
         IsContinusPlay,
         IgnoreVersion,
+        IsOnlyShowIndex,
 #pragma warning disable SA1602 // Enumeration items should be documented
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
@@ -704,6 +704,12 @@ namespace Richasy.Bili.ViewModels.Uwp
         public bool IsShowInteractionEnd { get; set; }
 
         /// <summary>
+        /// 是否仅显示分集索引.
+        /// </summary>
+        [Reactive]
+        public bool IsOnlyShowIndex { get; set; }
+
+        /// <summary>
         /// 索引列表.
         /// </summary>
         [Reactive]

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -62,6 +62,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             CanShowSubtitle = _settingsToolkit.ReadLocalSetting(SettingNames.CanShowSubtitle, true);
             Volume = _settingsToolkit.ReadLocalSetting(SettingNames.Volume, 100d);
             PlaybackRate = _settingsToolkit.ReadLocalSetting(SettingNames.PlaybackRate, 1d);
+            IsOnlyShowIndex = _settingsToolkit.ReadLocalSetting(SettingNames.IsOnlyShowIndex, false);
             InitializeTimer();
             this.PropertyChanged += OnPropertyChanged;
             LiveDanmakuCollection.CollectionChanged += OnLiveDanmakuCollectionChanged;
@@ -679,6 +680,9 @@ namespace Richasy.Bili.ViewModels.Uwp
                     }
 
                     _settingsToolkit.WriteLocalSetting(SettingNames.PlaybackRate, PlaybackRate);
+                    break;
+                case nameof(IsOnlyShowIndex):
+                    _settingsToolkit.WriteLocalSetting(SettingNames.IsOnlyShowIndex, IsOnlyShowIndex);
                     break;
                 default:
                     break;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #326 

添加分集索引视图以便在分集较多时显示更多的内容

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

以列表形式显示分集，对于分集较多的视频来说查阅效率太低

## 新的行为是什么？

添加索引视图，可以一屏浏览上百分集

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 新组件
  - [x] 对于控件，已将控件放在主项目的 Controls 文件夹内
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

![Uploading image.png…]()
