### PR TITLE
支持点击评论/视频条目的用户头像显示用户信息

### DIFF
--- a/src/App/Controls/App/CenterPopup/CenterPopup.cs
+++ b/src/App/Controls/App/CenterPopup/CenterPopup.cs
@@ -37,7 +37,7 @@ namespace Richasy.Bili.App.Controls
         public void Hide()
         {
             SystemNavigationManager.GetForCurrentView().BackRequested -= OnBackRequest;
-            ((Window.Current.Content as Frame).Content as RootPage).ClearHolder();
+            ((Window.Current.Content as Frame).Content as RootPage).RemoveFromHolder(this);
             Closed?.Invoke(this, EventArgs.Empty);
         }
 

--- a/src/App/Controls/Common/ReplyItem.xaml
+++ b/src/App/Controls/Common/ReplyItem.xaml
@@ -36,6 +36,7 @@
                         x:Name="UserAvatar"
                         Width="32"
                         Height="32"
+                        Click="OnAvatarClickAsync"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center" />
                 </Grid>

--- a/src/App/Controls/Common/ReplyItem.xaml.cs
+++ b/src/App/Controls/Common/ReplyItem.xaml.cs
@@ -137,5 +137,13 @@ namespace Richasy.Bili.App.Controls
         {
             Click?.Invoke(this, EventArgs.Empty);
         }
+
+        private async void OnAvatarClickAsync(object sender, EventArgs e)
+        {
+            if (Data.Member != null)
+            {
+                await UserView.Instance.ShowAsync(Convert.ToInt32(Data.Member.Mid));
+            }
+        }
     }
 }

--- a/src/App/Controls/Common/VideoItem.xaml
+++ b/src/App/Controls/Common/VideoItem.xaml
@@ -125,6 +125,7 @@
                         Height="36"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
+                        Click="OnAvatarClickAsync"
                         Avatar="{x:Bind ViewModel.Publisher.Avatar, Mode=OneWay}"
                         UserName="{x:Bind ViewModel.Publisher.Name, Mode=OneWay}" />
                 </Grid>

--- a/src/App/Controls/Common/VideoItem.xaml.cs
+++ b/src/App/Controls/Common/VideoItem.xaml.cs
@@ -302,5 +302,13 @@ namespace Richasy.Bili.App.Controls
                 ContextFlyout.Hide();
             }
         }
+
+        private async void OnAvatarClickAsync(object sender, EventArgs e)
+        {
+            if (ViewModel.Publisher != null)
+            {
+                await UserView.Instance.ShowAsync(ViewModel.Publisher);
+            }
+        }
     }
 }

--- a/src/App/Pages/RootPage.xaml.cs
+++ b/src/App/Pages/RootPage.xaml.cs
@@ -71,6 +71,10 @@ namespace Richasy.Bili.App.Pages
         public void RemoveFromHolder(UIElement element)
         {
             HolderContainer.Children.Remove(element);
+            if (HolderContainer.Children.Count == 0)
+            {
+                CoreViewModel.IsBackButtonEnabled = true;
+            }
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

点击评论/视频卡片的用户头像无反应

## 新的行为是什么？

点击评论/视频卡片的用户头像会打开当前用户的投稿列表

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
