### PR TITLE
修复PGC内容部分字段解析失败的问题

### DIFF
--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
@@ -271,7 +271,7 @@
                                 <VisualState x:Name="MuteState">
                                     <VisualState.Setters>
                                         <Setter Target="AudioMuteSymbol.Symbol" Value="Mute" />
-                                        <Setter Target="VolumeMuteSymbol.Symbol" Value="Mute" />
+                                        <Setter Target="VolumeMuteIcon.Symbol" Value="SpeakerMute20" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -599,7 +599,7 @@
                                                             </Flyout>
                                                         </Button.Flyout>
                                                         <Button.Content>
-                                                            <icons:RegularFluentIcon Symbol="Speaker220" />
+                                                            <icons:RegularFluentIcon x:Name="VolumeMuteIcon" Symbol="Speaker220" />
                                                         </Button.Content>
                                                     </Button>
 

--- a/src/Models/Models.BiliBili/Core/Video/VideoBase.cs
+++ b/src/Models/Models.BiliBili/Core/Video/VideoBase.cs
@@ -20,7 +20,7 @@ namespace Richasy.Bili.Models.BiliBili
         /// 视频发布时间 (Unix时间戳).
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "pubdate", Required = Required.Default)]
-        public int PublishDateTime { get; set; }
+        public long PublishDateTime { get; set; }
 
         /// <summary>
         /// 视频时长 (秒).

--- a/src/Models/Models.BiliBili/Core/VideoStatusInfo.cs
+++ b/src/Models/Models.BiliBili/Core/VideoStatusInfo.cs
@@ -19,37 +19,37 @@ namespace Richasy.Bili.Models.BiliBili
         /// 视频播放数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "view", Required = Required.Default)]
-        public int PlayCount { get; set; }
+        public long PlayCount { get; set; }
 
         /// <summary>
         /// 弹幕数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "danmaku", Required = Required.Default)]
-        public int DanmakuCount { get; set; }
+        public long DanmakuCount { get; set; }
 
         /// <summary>
         /// 视频评论数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "reply", Required = Required.Default)]
-        public int ReplyCount { get; set; }
+        public long ReplyCount { get; set; }
 
         /// <summary>
         /// 视频收藏数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "favorite", Required = Required.Default)]
-        public int FavoriteCount { get; set; }
+        public long FavoriteCount { get; set; }
 
         /// <summary>
         /// 投币数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "coin", Required = Required.Default)]
-        public int CoinCount { get; set; }
+        public long CoinCount { get; set; }
 
         /// <summary>
         /// 分享数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "share", Required = Required.Default)]
-        public int ShareCount { get; set; }
+        public long ShareCount { get; set; }
 
         /// <summary>
         /// 当前排名.
@@ -67,12 +67,12 @@ namespace Richasy.Bili.Models.BiliBili
         /// 点赞数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "like", Required = Required.Default)]
-        public int LikeCount { get; set; }
+        public long LikeCount { get; set; }
 
         /// <summary>
         /// 点踩数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "dislike", Required = Required.Default)]
-        public int DislikeCount { get; set; }
+        public long DislikeCount { get; set; }
     }
 }

--- a/src/Models/Models.BiliBili/Pgc/PgcDisplayInformation.cs
+++ b/src/Models/Models.BiliBili/Pgc/PgcDisplayInformation.cs
@@ -502,25 +502,25 @@ namespace Richasy.Bili.Models.BiliBili
         /// 投币数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "coins", Required = Required.Default)]
-        public int CoinCount { get; set; }
+        public long CoinCount { get; set; }
 
         /// <summary>
         /// 弹幕数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "danmakus", Required = Required.Default)]
-        public int DanmakuCount { get; set; }
+        public long DanmakuCount { get; set; }
 
         /// <summary>
         /// 单集收藏数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "favorite", Required = Required.Default)]
-        public int FavoriteCount { get; set; }
+        public long FavoriteCount { get; set; }
 
         /// <summary>
         /// 系列追番/收藏数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "favorites", Required = Required.Default)]
-        public int SeriesFavoriteCount { get; set; }
+        public long SeriesFavoriteCount { get; set; }
 
         /// <summary>
         /// 追番/收藏显示文本.
@@ -532,7 +532,7 @@ namespace Richasy.Bili.Models.BiliBili
         /// 点赞数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "likes", Required = Required.Default)]
-        public int LikeCount { get; set; }
+        public long LikeCount { get; set; }
 
         /// <summary>
         /// 播放量显示文本.
@@ -544,19 +544,19 @@ namespace Richasy.Bili.Models.BiliBili
         /// 回复数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "reply", Required = Required.Default)]
-        public int ReplyCount { get; set; }
+        public long ReplyCount { get; set; }
 
         /// <summary>
         /// 分享数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "share", Required = Required.Default)]
-        public int ShareCount { get; set; }
+        public long ShareCount { get; set; }
 
         /// <summary>
         /// 播放次数.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "views", Required = Required.Default)]
-        public int PlayCount { get; set; }
+        public long PlayCount { get; set; }
     }
 
     /// <summary>

--- a/src/ViewModels/ViewModels.Uwp/Common/DanmakuViewModel/DanmakuViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/DanmakuViewModel/DanmakuViewModel.Methods.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
+using System.Linq;
 using Richasy.Bili.Models.App.Args;
 
 namespace Richasy.Bili.ViewModels.Uwp.Common
@@ -22,8 +23,9 @@ namespace Richasy.Bili.ViewModels.Uwp.Common
         {
             if (e.VideoId == _videoId && e.PartId == _partId)
             {
-                e.DanmakuList.ForEach(p => _danmakuList.Add(p));
-                DanmakuListAdded?.Invoke(this, e.DanmakuList);
+                var list = e.DanmakuList.Where(p => p.Mode != 7).ToList();
+                list.ForEach(p => _danmakuList.Add(p));
+                DanmakuListAdded?.Invoke(this, list);
             }
         }
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #657 

修复创建番剧类型定义时int类型不足以解析大数字的问题。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

在解析部分番剧时，由于数据类型不匹配会导致解析失败

## 新的行为是什么？

替换可能的字段为long

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

移除了无法解析的高级字幕
