### PR TITLE
修复账户异常导致循环登录的问题

### DIFF
--- a/src/Controller/Controller.Uwp/BiliController.Account.cs
+++ b/src/Controller/Controller.Uwp/BiliController.Account.cs
@@ -37,7 +37,7 @@ namespace Richasy.Bili.Controller.Uwp
         /// <returns><see cref="Task"/>.</returns>
         public async Task RequestMyProfileAsync()
         {
-            if (await _authorizeProvider.IsTokenValidAsync() && IsNetworkAvailable)
+            if (IsNetworkAvailable && await _authorizeProvider.IsTokenValidAsync())
             {
                 try
                 {

--- a/src/ViewModels/ViewModels.Uwp/Account/AccountViewModel/AccountViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Account/AccountViewModel/AccountViewModel.Properties.cs
@@ -38,6 +38,7 @@ namespace Richasy.Bili.ViewModels.Uwp
         private readonly IResourceToolkit _resourceToolkit;
         private readonly INumberToolkit _numberToolkit;
         private MyInfo _myInfo;
+        private int _failedCount;
 
         /// <summary>
         /// <see cref="AccountViewModel"/>的实例.

--- a/src/ViewModels/ViewModels.Uwp/Account/AccountViewModel/AccountViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Account/AccountViewModel/AccountViewModel.cs
@@ -22,7 +22,7 @@ namespace Richasy.Bili.ViewModels.Uwp
         {
             _controller = BiliController.Instance;
             _controller.Logged += OnLoggedAsync;
-            _controller.LoggedFailed += OnLoggedFailed;
+            _controller.LoggedFailed += OnLoggedFailedAsync;
             _controller.LoggedOut += OnLoggedOut;
             _controller.AccountChanged += OnAccountChangedAsync;
             Status = AccountViewModelStatus.Logout;
@@ -110,9 +110,10 @@ namespace Richasy.Bili.ViewModels.Uwp
         {
             this.Status = AccountViewModelStatus.Logout;
             Reset();
+            _failedCount = 0;
         }
 
-        private void OnLoggedFailed(object sender, Exception e)
+        private async void OnLoggedFailedAsync(object sender, Exception e)
         {
             Debug.WriteLine($"Login failed: {e.Message}");
 
@@ -121,6 +122,11 @@ namespace Richasy.Bili.ViewModels.Uwp
             {
                 Reset();
                 this.Status = AccountViewModelStatus.Logout;
+                _failedCount++;
+                if (_failedCount > 1)
+                {
+                    await _controller.SignOutAsync();
+                }
             }
         }
 
@@ -132,6 +138,8 @@ namespace Richasy.Bili.ViewModels.Uwp
                 await GetMyProfileAsync();
                 this.Status = AccountViewModelStatus.Login;
             }
+
+            _failedCount = 0;
         }
 
         private async void OnAccountChangedAsync(object sender, MyInfo e)


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #625 

如果用户在已登录的情况下账户异常（比如修改密码），应用就会不断尝试以本地缓存的账户令牌登录，并不断失败

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

如果用户在已登录的情况下账户异常（比如修改密码），应用就会不断尝试以本地缓存的账户令牌登录，并不断失败

## 新的行为是什么？

设置了失败次数，如果失败超过2次则直接登出，并要求用户重新登录

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
