### PR TITLE
支持检查上次应用关闭时正在播放的视频

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -42,6 +42,9 @@
     <Compile Include="Controls\Danmaku\DanmakuSendOptions.xaml.cs">
       <DependentUpon>DanmakuSendOptions.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\Dialogs\ContinuePlayDialog.xaml.cs">
+      <DependentUpon>ContinuePlayDialog.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\Dialogs\UpgradeDialog.xaml.cs">
       <DependentUpon>UpgradeDialog.xaml</DependentUpon>
     </Compile>
@@ -129,6 +132,9 @@
     </Compile>
     <Compile Include="Controls\Player\SubtitleConfigPanel.xaml.cs">
       <DependentUpon>SubtitleConfigPanel.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Controls\Settings\InitialCheckSection.xaml.cs">
+      <DependentUpon>InitialCheckSection.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\User\AccountPanel.xaml.cs">
       <DependentUpon>AccountPanel.xaml</DependentUpon>
@@ -537,6 +543,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Controls\Dialogs\ContinuePlayDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Controls\Dialogs\UpgradeDialog.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -642,6 +652,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Controls\Player\SubtitleConfigPanel.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\Settings\InitialCheckSection.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/App/Controls/Dialogs/ContinuePlayDialog.xaml
+++ b/src/App/Controls/Dialogs/ContinuePlayDialog.xaml
@@ -1,0 +1,24 @@
+﻿<ContentDialog
+    x:Class="Richasy.Bili.App.Controls.Dialogs.ContinuePlayDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:loc="using:Richasy.Bili.Locator.Uwp"
+    xmlns:local="using:Richasy.Bili.App.Controls.Dialogs"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Title="{loc:LocaleLocator Name=ContinuePlayTitle}"
+    Style="{StaticResource DefaultContentDialogStyle}"
+    CloseButtonText="{loc:LocaleLocator Name=Cancel}"
+    PrimaryButtonClick="OnContentDialogPrimaryButtonClick"
+    PrimaryButtonStyle="{StaticResource AccentButtonStyle}"
+    PrimaryButtonText="{loc:LocaleLocator Name=Confirm}"
+    CloseButtonClick="OnContentDialogCloseButtonClickAsync"
+    mc:Ignorable="d">
+
+    <StackPanel MaxWidth="300">
+        <TextBlock TextWrapping="Wrap">
+            <Run Text="{loc:LocaleLocator Name=ContinuePlayDescription}" />
+            <Run x:Name="VideoTitle" Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+        </TextBlock>
+    </StackPanel>
+</ContentDialog>

--- a/src/App/Controls/Dialogs/ContinuePlayDialog.xaml.cs
+++ b/src/App/Controls/Dialogs/ContinuePlayDialog.xaml.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Richasy. All rights reserved.
+
+using Richasy.Bili.Locator.Uwp;
+using Richasy.Bili.Toolkit.Interfaces;
+using Richasy.Bili.ViewModels.Uwp;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Richasy.Bili.App.Controls.Dialogs
+{
+    /// <summary>
+    /// 继续播放对话框.
+    /// </summary>
+    public sealed partial class ContinuePlayDialog : ContentDialog
+    {
+        private object _playVM = null;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContinuePlayDialog"/> class.
+        /// </summary>
+        public ContinuePlayDialog()
+        {
+            this.InitializeComponent();
+            this.Loaded += OnLoadedAsync;
+        }
+
+        private async void OnLoadedAsync(object sender, RoutedEventArgs e)
+        {
+            var tool = ServiceLocator.Instance.GetService<ISettingsToolkit>();
+            var title = tool.ReadLocalSetting(Models.Enums.SettingNames.ContinuePlayTitle, string.Empty);
+            _playVM = await PlayerViewModel.Instance.GetInitViewModelFromLocalAsync();
+            if (string.IsNullOrEmpty(title) || _playVM == null)
+            {
+                tool.WriteLocalSetting(Models.Enums.SettingNames.CanContinuePlay, false);
+                tool.DeleteLocalSetting(Models.Enums.SettingNames.ContinuePlayTitle);
+                Hide();
+            }
+
+            VideoTitle.Text = title;
+        }
+
+        private void OnContentDialogPrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+        {
+            AppViewModel.Instance.OpenPlayer(_playVM);
+        }
+
+        private async void OnContentDialogCloseButtonClickAsync(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+        {
+            await PlayerViewModel.Instance.ClearInitViewModelAsync();
+        }
+    }
+}

--- a/src/App/Controls/Settings/InitialCheckSection.xaml
+++ b/src/App/Controls/Settings/InitialCheckSection.xaml
@@ -1,0 +1,31 @@
+﻿<local:SettingSectionControl
+    x:Class="Richasy.Bili.App.Controls.InitialCheckSection"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:exp="using:Richasy.ExpanderEx.Uwp"
+    xmlns:icons="using:Richasy.FluentIcon.Uwp"
+    xmlns:loc="using:Richasy.Bili.Locator.Uwp"
+    xmlns:local="using:Richasy.Bili.App.Controls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    d:DesignHeight="300"
+    d:DesignWidth="400"
+    mc:Ignorable="d">
+
+    <exp:ExpanderEx>
+        <exp:ExpanderEx.Header>
+            <exp:ExpanderExWrapper>
+                <exp:ExpanderExWrapper.MainContent>
+                    <exp:ExpanderExDescriptor Title="{loc:LocaleLocator Name=InitialCheckTitle}" Description="{loc:LocaleLocator Name=InitialCheckDescription}">
+                        <exp:ExpanderExDescriptor.Icon>
+                            <icons:RegularFluentIcon Symbol="AlertUrgent16" />
+                        </exp:ExpanderExDescriptor.Icon>
+                    </exp:ExpanderExDescriptor>
+                </exp:ExpanderExWrapper.MainContent>
+                <exp:ExpanderExWrapper.WrapContent>
+                    <ToggleSwitch Style="{StaticResource RightAlignedCompactToggleSwitchStyle}" IsOn="{x:Bind ViewModel.IsSupportContinuePlay, Mode=TwoWay}" />
+                </exp:ExpanderExWrapper.WrapContent>
+            </exp:ExpanderExWrapper>
+        </exp:ExpanderEx.Header>
+    </exp:ExpanderEx>
+</local:SettingSectionControl>

--- a/src/App/Controls/Settings/InitialCheckSection.xaml.cs
+++ b/src/App/Controls/Settings/InitialCheckSection.xaml.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Richasy. All rights reserved.
+
+namespace Richasy.Bili.App.Controls
+{
+    /// <summary>
+    /// 初始化检查设置.
+    /// </summary>
+    public sealed partial class InitialCheckSection : SettingSectionControl
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InitialCheckSection"/> class.
+        /// </summary>
+        public InitialCheckSection()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/App/Pages/Overlay/PlayerPage.xaml.cs
+++ b/src/App/Pages/Overlay/PlayerPage.xaml.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.ComponentModel;
+using Richasy.Bili.Models.App.Other;
 using Richasy.Bili.Models.Enums;
 using Richasy.Bili.ViewModels.Uwp;
 using Windows.UI.ViewManagement;
@@ -58,6 +59,10 @@ namespace Richasy.Bili.App.Pages.Overlay
                 else if (e.Parameter is SeasonViewModel ssVM)
                 {
                     _navigateVM = ssVM;
+                }
+                else if (e.Parameter is CurrentPlayingRecord record)
+                {
+                    _navigateVM = record;
                 }
 
                 if (IsLoaded)

--- a/src/App/Pages/RootPage.xaml.cs
+++ b/src/App/Pages/RootPage.xaml.cs
@@ -31,6 +31,7 @@ namespace Richasy.Bili.App.Pages
             this.CoreViewModel.RequestShowTip += OnRequestShowTip;
             this.CoreViewModel.RequestBack += OnRequestBackAsync;
             this.CoreViewModel.RequestShowUpdateDialog += OnRequestShowUpdateDialogAsync;
+            CoreViewModel.RequestContinuePlay += OnRequestContinuePlayAsync;
             SizeChanged += OnSizeChanged;
             SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequestedAsync;
         }
@@ -115,6 +116,7 @@ namespace Richasy.Bili.App.Pages
             this.CoreViewModel.PropertyChanged += OnViewModelPropertyChanged;
             this.CoreViewModel.RequestPlay += OnRequestPlay;
             CoreViewModel.InitializePadding();
+            CoreViewModel.CheckContinuePlay();
             await AccountViewModel.Instance.TrySignInAsync(true);
 #if !DEBUG
             await CoreViewModel.CheckUpdateAsync();
@@ -161,5 +163,8 @@ namespace Richasy.Bili.App.Pages
 
         private async void OnRequestShowUpdateDialogAsync(object sender, UpdateEventArgs e)
             => await new UpgradeDialog(e).ShowAsync();
+
+        private async void OnRequestContinuePlayAsync(object sender, EventArgs e) 
+            => await new ContinuePlayDialog().ShowAsync();
     }
 }

--- a/src/App/Pages/SettingPage.xaml
+++ b/src/App/Pages/SettingPage.xaml
@@ -45,6 +45,7 @@
                 <controls:PlayerModeSettingSection />
                 <controls:PlayerControlSettingSection />
                 <controls:MTCSettingSection />
+                <controls:InitialCheckSection />
                 <StackPanel
                     Margin="0,12,0,0"
                     HorizontalAlignment="Left"

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -273,6 +273,12 @@
   <data name="Confirm" xml:space="preserve">
     <value>确认</value>
   </data>
+  <data name="ContinuePlayDescription" xml:space="preserve">
+    <value>上次应用关闭时您仍在播放视频，你可以继续播放该视频：</value>
+  </data>
+  <data name="ContinuePlayTitle" xml:space="preserve">
+    <value>是否继续播放？</value>
+  </data>
   <data name="ContinuePreviousView" xml:space="preserve">
     <value>继续观看</value>
   </data>
@@ -537,6 +543,12 @@
   </data>
   <data name="Index" xml:space="preserve">
     <value>索引</value>
+  </data>
+  <data name="InitialCheckDescription" xml:space="preserve">
+    <value>是否在应用启动时检查上次关闭时正在播放的视频，并提醒继续播放</value>
+  </data>
+  <data name="InitialCheckTitle" xml:space="preserve">
+    <value>初始化检查</value>
   </data>
   <data name="InputCaptchaTip" xml:space="preserve">
     <value>请输入验证码</value>

--- a/src/Models/Models.App/Constants/AppConstants.cs
+++ b/src/Models/Models.App/Constants/AppConstants.cs
@@ -23,6 +23,8 @@ namespace Richasy.Bili.Models.App.Constants
         public const string LinkClickEvent = "LinkClick";
 
         public const string ReplySection = "Reply";
+
+        public const string LastOpenVideoFileName = "LastOpenVideo.json";
 #pragma warning restore SA1600 // Elements should be documented
     }
 }

--- a/src/Models/Models.App/Other/CurrentPlayingRecord.cs
+++ b/src/Models/Models.App/Other/CurrentPlayingRecord.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Richasy. All rights reserved.
+
+using Richasy.Bili.Models.Enums;
+
+namespace Richasy.Bili.Models.App.Other
+{
+    /// <summary>
+    /// 当前正在播放内容的快照.
+    /// </summary>
+    public class CurrentPlayingRecord
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CurrentPlayingRecord"/> class.
+        /// </summary>
+        public CurrentPlayingRecord()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CurrentPlayingRecord"/> class.
+        /// </summary>
+        /// <param name="vid">视频ID.</param>
+        /// <param name="sid">剧集ID.</param>
+        /// <param name="type">视频类型.</param>
+        public CurrentPlayingRecord(string vid, int sid, VideoType type)
+        {
+            VideoId = vid;
+            SeasonId = sid;
+            VideoType = type;
+        }
+
+        /// <summary>
+        /// 视频Id.
+        /// </summary>
+        public string VideoId { get; set; }
+
+        /// <summary>
+        /// 剧集Id.
+        /// </summary>
+        public int SeasonId { get; set; }
+
+        /// <summary>
+        /// 视频类型.
+        /// </summary>
+        public VideoType VideoType { get; set; }
+
+        /// <summary>
+        /// 是否为关联视频.
+        /// </summary>
+        public bool IsRelated { get; set; }
+    }
+}

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -388,6 +388,10 @@ namespace Richasy.Bili.Models.Enums
         IgnoreVersion,
         PreRelease,
         OnlyIndex,
+        ContinuePlayTitle,
+        ContinuePlayDescription,
+        InitialCheckTitle,
+        InitialCheckDescription,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/Models/Models.Enums/App/SettingNames.cs
+++ b/src/Models/Models.Enums/App/SettingNames.cs
@@ -43,6 +43,9 @@ namespace Richasy.Bili.Models.Enums
         IsContinusPlay,
         IgnoreVersion,
         IsOnlyShowIndex,
+        CanContinuePlay,
+        ContinuePlayTitle,
+        SupportContinuePlay,
 #pragma warning disable SA1602 // Enumeration items should be documented
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/AppViewModel/AppViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/AppViewModel/AppViewModel.Properties.cs
@@ -49,6 +49,11 @@ namespace Richasy.Bili.ViewModels.Uwp
         public event EventHandler<UpdateEventArgs> RequestShowUpdateDialog;
 
         /// <summary>
+        /// 请求进行之前的播放.
+        /// </summary>
+        public event EventHandler RequestContinuePlay;
+
+        /// <summary>
         /// <see cref="AppViewModel"/>的单例.
         /// </summary>
         public static AppViewModel Instance { get; } = new Lazy<AppViewModel>(() => new AppViewModel()).Value;

--- a/src/ViewModels/ViewModels.Uwp/Common/AppViewModel/AppViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/AppViewModel/AppViewModel.cs
@@ -189,6 +189,19 @@ namespace Richasy.Bili.ViewModels.Uwp
         public Task CheckUpdateAsync()
             => _controller.CheckUpdateAsync();
 
+        /// <summary>
+        /// 检查是否可以继续播放.
+        /// </summary>
+        public void CheckContinuePlay()
+        {
+            var supportCheck = _settingToolkit.ReadLocalSetting(SettingNames.SupportContinuePlay, true);
+            var canPlay = _settingToolkit.ReadLocalSetting(SettingNames.CanContinuePlay, false);
+            if (supportCheck && canPlay)
+            {
+                RequestContinuePlay?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
         private void OnUpdateReceived(object sender, UpdateEventArgs e) => RequestShowUpdateDialog?.Invoke(this, e);
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Richasy.Bili.Models.App.Constants;
+using Richasy.Bili.Models.App.Other;
 using Richasy.Bili.Models.BiliBili;
 using Richasy.Bili.Models.Enums;
 using Windows.Media.Playback;
@@ -19,7 +20,7 @@ namespace Richasy.Bili.ViewModels.Uwp
     /// </summary>
     public partial class PlayerViewModel
     {
-        private void Reset()
+        private async void ResetAsync()
         {
             _videoDetail = null;
             _pgcDetail = null;
@@ -87,13 +88,14 @@ namespace Richasy.Bili.ViewModels.Uwp
             var preferPlayerMode = _settingsToolkit.ReadLocalSetting(SettingNames.DefaultPlayerDisplayMode, PlayerDisplayMode.Default);
             PlayerDisplayMode = preferPlayerMode;
             Controller.CleanupLiveSocket();
+            await ClearInitViewModelAsync();
         }
 
         private async Task LoadVideoDetailAsync(string videoId, bool isRefresh)
         {
             if (_videoDetail == null || videoId != AvId || isRefresh)
             {
-                Reset();
+                ResetAsync();
                 IsDetailLoading = true;
                 _videoId = Convert.ToInt64(videoId);
                 try
@@ -133,7 +135,7 @@ namespace Richasy.Bili.ViewModels.Uwp
                 seasonId.ToString() != SeasonId ||
                 isRefresh)
             {
-                Reset();
+                ResetAsync();
                 IsPgc = true;
                 IsDetailLoading = true;
                 EpisodeId = episodeId.ToString();
@@ -176,7 +178,7 @@ namespace Richasy.Bili.ViewModels.Uwp
 
         private async Task LoadLiveDetailAsync(int roomId)
         {
-            Reset();
+            ResetAsync();
             IsLive = true;
             IsDetailLoading = true;
             IsShowReply = false;
@@ -964,6 +966,14 @@ namespace Richasy.Bili.ViewModels.Uwp
             IsLikeChecked = false;
             IsFollow = false;
             IsFavoriteChecked = false;
+        }
+
+        private async Task RecordInitViewModelToLocalAsync(string vid, int sid, VideoType type, string title)
+        {
+            var data = new CurrentPlayingRecord(vid, sid, type);
+            await _fileToolkit.WriteLocalDataAsync(AppConstants.LastOpenVideoFileName, data);
+            _settingsToolkit.WriteLocalSetting(SettingNames.CanContinuePlay, true);
+            _settingsToolkit.WriteLocalSetting(SettingNames.ContinuePlayTitle, title);
         }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.Properties.cs
@@ -135,5 +135,11 @@ namespace Richasy.Bili.ViewModels.Uwp
         /// </summary>
         [Reactive]
         public string Version { get; set; }
+
+        /// <summary>
+        /// 是否支持初始检查继续播放.
+        /// </summary>
+        [Reactive]
+        public bool IsSupportContinuePlay { get; set; }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.cs
@@ -40,6 +40,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             DisableP2PCdn = ReadSetting(SettingNames.DisableP2PCdn, false);
             IsContinusPlay = ReadSetting(SettingNames.IsContinusPlay, true);
             SingleFastForwardAndRewindSpan = ReadSetting(SettingNames.SingleFastForwardAndRewindSpan, 30d);
+            IsSupportContinuePlay = ReadSetting(SettingNames.SupportContinuePlay, true);
             PreferCodecInit();
             DoubleClickInit();
             PlayerModeInit();
@@ -92,6 +93,9 @@ namespace Richasy.Bili.ViewModels.Uwp
                     break;
                 case nameof(DefaultMTCControlMode):
                     WriteSetting(SettingNames.DefaultMTCControlMode, DefaultMTCControlMode);
+                    break;
+                case nameof(IsSupportContinuePlay):
+                    WriteSetting(SettingNames.SupportContinuePlay, IsSupportContinuePlay);
                     break;
                 default:
                     break;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #655 

支持检查上次应用关闭时正在播放的视频

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

--

## 新的行为是什么？

当用户从正在播放的视频页中关闭应用时，应用会记录当前正在播放的视频信息，并在用户下次启动应用时提醒用户是否继续观看。
该功能可在设置中关闭

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 新组件
  - [x] 对于控件，已将控件放在主项目的 Controls 文件夹内
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
