### PR TITLE
修复视频信息没有设置成功的问题 #684

### DIFF
--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Dash.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Dash.cs
@@ -86,6 +86,15 @@ namespace Richasy.Bili.ViewModels.Uwp
 
                 var mediaSource = MediaSource.CreateFromAdaptiveMediaSource(soure.MediaSource);
                 _currentPlaybackItem = new MediaPlaybackItem(mediaSource);
+
+                var props = _currentPlaybackItem.GetDisplayProperties();
+                props.Type = Windows.Media.MediaPlaybackType.Video;
+                props.Thumbnail = Windows.Storage.Streams.RandomAccessStreamReference.CreateFromUri(new Uri(CoverUrl + "@100w_100h_1c_100q.jpg"));
+                props.VideoProperties.Title = Title;
+                props.VideoProperties.Subtitle = GetSlimDescription(IsPgc ? Subtitle : Description);
+                props.VideoProperties.Genres.Add(_videoType.ToString());
+                _currentPlaybackItem.ApplyDisplayProperties(props);
+
                 _currentVideoPlayer.Source = _currentPlaybackItem;
 
                 BiliPlayer.SetMediaPlayer(_currentVideoPlayer);

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Dash.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Dash.cs
@@ -86,14 +86,7 @@ namespace Richasy.Bili.ViewModels.Uwp
 
                 var mediaSource = MediaSource.CreateFromAdaptiveMediaSource(soure.MediaSource);
                 _currentPlaybackItem = new MediaPlaybackItem(mediaSource);
-
-                var props = _currentPlaybackItem.GetDisplayProperties();
-                props.Type = Windows.Media.MediaPlaybackType.Video;
-                props.Thumbnail = Windows.Storage.Streams.RandomAccessStreamReference.CreateFromUri(new Uri(CoverUrl + "@100w_100h_1c_100q.jpg"));
-                props.VideoProperties.Title = Title;
-                props.VideoProperties.Subtitle = GetSlimDescription(IsPgc ? Subtitle : Description);
-                props.VideoProperties.Genres.Add(_videoType.ToString());
-                _currentPlaybackItem.ApplyDisplayProperties(props);
+                FillPlaybackProperties(_currentPlaybackItem);
 
                 _currentVideoPlayer.Source = _currentPlaybackItem;
 
@@ -127,6 +120,8 @@ namespace Richasy.Bili.ViewModels.Uwp
             }
 
             _currentPlaybackItem = _interopMSS.CreateMediaPlaybackItem();
+            FillPlaybackProperties(_currentPlaybackItem);
+
             if (_currentVideoPlayer == null)
             {
                 _currentVideoPlayer = InitializeMediaPlayer();
@@ -145,6 +140,17 @@ namespace Richasy.Bili.ViewModels.Uwp
             }
 
             return text;
+        }
+
+        private void FillPlaybackProperties(MediaPlaybackItem playbackItem)
+        {
+            var props = playbackItem.GetDisplayProperties();
+            props.Type = Windows.Media.MediaPlaybackType.Video;
+            props.Thumbnail = Windows.Storage.Streams.RandomAccessStreamReference.CreateFromUri(new Uri(CoverUrl + "@100w_100h_1c_100q.jpg"));
+            props.VideoProperties.Title = Title;
+            props.VideoProperties.Subtitle = GetSlimDescription(IsPgc ? Subtitle : Description);
+            props.VideoProperties.Genres.Add(_videoType.ToString());
+            playbackItem.ApplyDisplayProperties(props);
         }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -796,14 +796,6 @@ namespace Richasy.Bili.ViewModels.Uwp
 
                 session.PlaybackRate = PlaybackRate;
             }
-
-            var props = _currentPlaybackItem.GetDisplayProperties();
-            props.Type = Windows.Media.MediaPlaybackType.Video;
-            props.Thumbnail = Windows.Storage.Streams.RandomAccessStreamReference.CreateFromUri(new Uri(CoverUrl + "@100w_100h_1c_100q.jpg"));
-            props.VideoProperties.Title = Title;
-            props.VideoProperties.Subtitle = GetSlimDescription(IsPgc ? Subtitle : Description);
-            props.VideoProperties.Genres.Add(_videoType.ToString());
-            _currentPlaybackItem.ApplyDisplayProperties(props);
         }
 
         private async void OnMediaPlayerFailedAsync(MediaPlayer sender, MediaPlayerFailedEventArgs args)


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #684 

<!-- 在上面的 `修复` 标题后添加要修复的 Issue 编号，比如 “修复 #1234”，这样在 PR 合并后可以直接关闭 Issue -->

<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

Bug 修复 
功能 
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

如 #684  所示，控制中心并不能正确显示视频信息和缩略图

## 新的行为是什么？

控制中心可以正常显示视频信息和缩略图

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注
简单移了下代码位置。
在将`_currentPlaybackItem`设为`Source`之前就应该设置属性信息，至少在我的win11正式版上该Issue问题能复现，修改后正常。
<!-- 请添加任何你认为有帮助的信息 -->
