### PR TITLE
支持清理本地图片缓存

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -43,6 +43,9 @@
     <Compile Include="Controls\App\TwoLineButton\TwoLineButton.cs" />
     <Compile Include="Controls\App\CenterPopup\CenterPopup.cs" />
     <Compile Include="Controls\App\CenterPopup\CenterPopup.Properties.cs" />
+    <Compile Include="Controls\Settings\CacheSettingSection.xaml.cs">
+      <DependentUpon>CacheSettingSection.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\Danmaku\DanmakuSendOptions.xaml.cs">
       <DependentUpon>DanmakuSendOptions.xaml</DependentUpon>
     </Compile>
@@ -540,6 +543,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Controls\App\TwoLineButton\TwoLineButton.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\Settings\CacheSettingSection.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/App/Controls/Settings/CacheSettingSection.xaml
+++ b/src/App/Controls/Settings/CacheSettingSection.xaml
@@ -1,0 +1,46 @@
+﻿<local:SettingSectionControl
+    x:Class="Richasy.Bili.App.Controls.CacheSettingSection"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:exp="using:Richasy.ExpanderEx.Uwp"
+    xmlns:icons="using:Richasy.FluentIcon.Uwp"
+    xmlns:loc="using:Richasy.Bili.Locator.Uwp"
+    xmlns:local="using:Richasy.Bili.App.Controls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    d:DesignHeight="300"
+    d:DesignWidth="400"
+    mc:Ignorable="d">
+
+    <exp:ExpanderEx>
+        <exp:ExpanderEx.Header>
+            <exp:ExpanderExWrapper>
+                <exp:ExpanderExWrapper.MainContent>
+                    <exp:ExpanderExDescriptor Title="{loc:LocaleLocator Name=ClearCache}" Description="{loc:LocaleLocator Name=ClearCacheDescription}">
+                        <exp:ExpanderExDescriptor.Icon>
+                            <icons:RegularFluentIcon Symbol="FastAcceleration24" />
+                        </exp:ExpanderExDescriptor.Icon>
+                    </exp:ExpanderExDescriptor>
+                </exp:ExpanderExWrapper.MainContent>
+                <exp:ExpanderExWrapper.WrapContent>
+                    <StackPanel Orientation="Horizontal">
+                        <Button
+                            x:Name="ClearButton"
+                            MinWidth="120"
+                            Click="OnClearButtonClickAsync"
+                            Content="{loc:LocaleLocator Name=Clear}" />
+                        <muxc:ProgressRing
+                            x:Name="LoadingRing"
+                            Width="20"
+                            Height="20"
+                            Margin="12,0,0,0"
+                            VerticalAlignment="Center"
+                            IsActive="True"
+                            Visibility="Collapsed" />
+                    </StackPanel>
+                </exp:ExpanderExWrapper.WrapContent>
+            </exp:ExpanderExWrapper>
+        </exp:ExpanderEx.Header>
+    </exp:ExpanderEx>
+</local:SettingSectionControl>

--- a/src/App/Controls/Settings/CacheSettingSection.xaml.cs
+++ b/src/App/Controls/Settings/CacheSettingSection.xaml.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Richasy. All rights reserved.
+
+using System;
+using Richasy.Bili.Locator.Uwp;
+using Richasy.Bili.Models.Enums.App;
+using Richasy.Bili.Toolkit.Interfaces;
+using Richasy.Bili.ViewModels.Uwp;
+using Windows.Storage;
+
+namespace Richasy.Bili.App.Controls
+{
+    /// <summary>
+    /// 缓存设置.
+    /// </summary>
+    public sealed partial class CacheSettingSection : SettingSectionControl
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CacheSettingSection"/> class.
+        /// </summary>
+        public CacheSettingSection() => InitializeComponent();
+
+        private async void OnClearButtonClickAsync(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            var cacheFolder = ApplicationData.Current.LocalCacheFolder;
+            LoadingRing.Visibility = Windows.UI.Xaml.Visibility.Visible;
+            ClearButton.IsEnabled = false;
+            var resourceToolkit = ServiceLocator.Instance.GetService<IResourceToolkit>();
+
+            try
+            {
+                var children = await cacheFolder.GetItemsAsync();
+                foreach (var child in children)
+                {
+                    if (child is StorageFile file)
+                    {
+                        await file.DeleteAsync();
+                    }
+                    else if (child is StorageFolder folder)
+                    {
+                        await folder.DeleteAsync();
+                    }
+                }
+
+                AppViewModel.Instance.ShowTip(resourceToolkit.GetLocaleString(Models.Enums.LanguageNames.CacheCleared), InfoType.Success);
+            }
+            catch
+            {
+            }
+            finally
+            {
+                LoadingRing.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+                ClearButton.IsEnabled = true;
+            }
+        }
+    }
+}

--- a/src/App/Pages/SettingPage.xaml
+++ b/src/App/Pages/SettingPage.xaml
@@ -36,6 +36,7 @@
                 <controls:ThemeSettingSection />
                 <controls:StartupSettingSection />
                 <controls:LoggerSettingSection />
+                <controls:CacheSettingSection />
 
                 <TextBlock
                     Style="{StaticResource BodyTextBlockStyle}"

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -210,6 +210,9 @@
   <data name="BottomDanmaku" xml:space="preserve">
     <value>底部弹幕</value>
   </data>
+  <data name="CacheCleared" xml:space="preserve">
+    <value>已清理缓存</value>
+  </data>
   <data name="Cancel" xml:space="preserve">
     <value>取消</value>
   </data>
@@ -242,6 +245,15 @@
   </data>
   <data name="CleanLogger" xml:space="preserve">
     <value>清除日志记录</value>
+  </data>
+  <data name="Clear" xml:space="preserve">
+    <value>清除</value>
+  </data>
+  <data name="ClearCache" xml:space="preserve">
+    <value>清除缓存</value>
+  </data>
+  <data name="ClearCacheDescription" xml:space="preserve">
+    <value>清理本地的图片缓存以减少应用数据占用</value>
   </data>
   <data name="ClearHistory" xml:space="preserve">
     <value>清空历史记录</value>

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -392,6 +392,10 @@ namespace Richasy.Bili.Models.Enums
         ContinuePlayDescription,
         InitialCheckTitle,
         InitialCheckDescription,
+        ClearCache,
+        ClearCacheDescription,
+        Clear,
+        CacheCleared,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复 #748 

可以在应用内部直接清空缓存文件夹

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

随着应用使用时间的增长，本地图片缓存会逐渐增多，且目前没有直接的方式清理缓存

## 新的行为是什么？

提供一个手动功能入口以便用户清除缓存

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 新组件
  - [x] 对于控件，已将控件放在主项目的 Controls 文件夹内
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->
