### PR TITLE
Fix ARM64 platform QRCode error.

### DIFF
--- a/Uwp.props
+++ b/Uwp.props
@@ -40,6 +40,7 @@
   <PropertyGroup Condition="'$(Platform)' == 'ARM64'">
     <Prefer32Bit>false</Prefer32Bit>
     <NoLinkerSymbols>true</NoLinkerSymbols>
+    <IlcParameters>/ExtraNutcArguments:"-d2disableloopopt"</IlcParameters>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'x64'">
     <Prefer32Bit>false</Prefer32Bit>


### PR DESCRIPTION
## 修复 #674

修复 ARM64 平台的登录二维码无法识别问题

## PR 类型

这个 PR 的目的是什么？
Bug 修复 

## 当前行为是什么？

ARM64 平台的登录二维码无法识别

## 新的行为是什么？

ARM64 平台的登录二维码可以被正常识别并登录

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [X] 应用成功启动
- [X] ARM64 设备成功扫码登录
- [X] **不**包含破坏式更新

## 备注
别问这个 flag 是什么意思，我也不知道，.NET Native 团队已经确认是个 bug 并且在修复中，这个 flag 是 .NET Native 的同事给的临时解决方案
