### PR TITLE
移除登录失败限制

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -1027,7 +1027,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FFmpegInteropX">
-      <Version>0.9.4</Version>
+      <Version>0.9.2</Version>
     </PackageReference>
     <PackageReference Include="HN.Controls.ImageEx.Uwp">
       <Version>1.0.33</Version>

--- a/src/ViewModels/ViewModels.Uwp/Account/AccountViewModel/AccountViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Account/AccountViewModel/AccountViewModel.Properties.cs
@@ -38,7 +38,6 @@ namespace Richasy.Bili.ViewModels.Uwp
         private readonly IResourceToolkit _resourceToolkit;
         private readonly INumberToolkit _numberToolkit;
         private MyInfo _myInfo;
-        private int _failedCount;
 
         /// <summary>
         /// <see cref="AccountViewModel"/>的实例.

--- a/src/ViewModels/ViewModels.Uwp/Account/AccountViewModel/AccountViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Account/AccountViewModel/AccountViewModel.cs
@@ -110,7 +110,6 @@ namespace Richasy.Bili.ViewModels.Uwp
         {
             this.Status = AccountViewModelStatus.Logout;
             Reset();
-            _failedCount = 0;
         }
 
         private async void OnLoggedFailedAsync(object sender, Exception e)
@@ -118,28 +117,22 @@ namespace Richasy.Bili.ViewModels.Uwp
             Debug.WriteLine($"Login failed: {e.Message}");
 
             // 它仅在用户未登录时触发.
-            if (this.Status != AccountViewModelStatus.Login)
+            if (Status != AccountViewModelStatus.Login)
             {
                 Reset();
-                this.Status = AccountViewModelStatus.Logout;
-                _failedCount++;
-                if (_failedCount > 1)
-                {
-                    await _controller.SignOutAsync();
-                }
+                Status = AccountViewModelStatus.Logout;
+                await _controller.SignOutAsync();
             }
         }
 
         private async void OnLoggedAsync(object sender, EventArgs e)
         {
-            if (this.Status != AccountViewModelStatus.Login)
+            if (Status != AccountViewModelStatus.Login)
             {
                 IsConnected = true;
                 await GetMyProfileAsync();
-                this.Status = AccountViewModelStatus.Login;
+                Status = AccountViewModelStatus.Login;
             }
-
-            _failedCount = 0;
         }
 
         private async void OnAccountChangedAsync(object sender, MyInfo e)

--- a/src/ViewModels/ViewModels.Uwp/ViewModels.Uwp.csproj
+++ b/src/ViewModels/ViewModels.Uwp/ViewModels.Uwp.csproj
@@ -132,7 +132,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FFmpegInteropX">
-      <Version>0.9.4</Version>
+      <Version>0.9.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>6.0.0</Version>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Fix #729, #682 

当登录失败后清除本地缓存，进入登出状态

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

用户在修改密码或因为网络问题可能会导致已登录账户的缓存无法清除，导致应用持续尝试登录

## 新的行为是什么？

当应用自动登录失败后，即要求用户重新登录

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
