### PR TITLE
支持固定UP主到首页

### DIFF
--- a/src/App/Controls/App/RootNavigationView.xaml
+++ b/src/App/Controls/App/RootNavigationView.xaml
@@ -2,6 +2,7 @@
     x:Class="Richasy.Bili.App.Controls.RootNavigationView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:app="using:Richasy.Bili.Models.App"
     xmlns:converter="using:Richasy.Bili.App.Resources.Converter"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:ext="using:Richasy.Bili.App.Resources.Extension"
@@ -160,6 +161,46 @@
                         Visibility="{x:Bind ViewModel.IsShowOverlay, Mode=OneWay}" />
                 </Grid>
             </muxc:NavigationView.Content>
+
+            <!-- 用于展示固定的UP主 -->
+            <muxc:NavigationView.PaneCustomContent>
+                <StackPanel Spacing="4" Visibility="{x:Bind _accountViewModel.IsShowFixedPublisher, Mode=OneWay}">
+                    <muxc:NavigationViewItemHeader Content="{loc:LocaleLocator Name=FixedPublishers}" />
+                    <muxc:ItemsRepeater ItemsSource="{x:Bind _accountViewModel.FixedPublisherCollection}">
+                        <muxc:ItemsRepeater.Layout>
+                            <muxc:StackLayout />
+                        </muxc:ItemsRepeater.Layout>
+                        <muxc:ItemsRepeater.ItemTemplate>
+                            <DataTemplate x:DataType="app:FixedPublisher">
+                                <Button
+                                    Margin="4,0"
+                                    Padding="12,8"
+                                    HorizontalAlignment="Stretch"
+                                    HorizontalContentAlignment="Left"
+                                    Background="Transparent"
+                                    BorderThickness="0"
+                                    Click="OnFixedPublisherClickAsync"
+                                    DataContext="{x:Bind}"
+                                    ToolTipService.ToolTip="{x:Bind UserName}">
+                                    <StackPanel Orientation="Horizontal" Spacing="12">
+                                        <muxc:PersonPicture
+                                            Width="20"
+                                            Height="20"
+                                            VerticalAlignment="Center"
+                                            DisplayName="{x:Bind UserName}"
+                                            ProfilePicture="{x:Bind AvatarPath}" />
+                                        <TextBlock
+                                            VerticalAlignment="Center"
+                                            Text="{x:Bind UserName}"
+                                            TextTrimming="CharacterEllipsis" />
+                                    </StackPanel>
+                                </Button>
+                            </DataTemplate>
+                        </muxc:ItemsRepeater.ItemTemplate>
+                    </muxc:ItemsRepeater>
+                </StackPanel>
+
+            </muxc:NavigationView.PaneCustomContent>
 
             <muxc:NavigationView.FooterMenuItems>
                 <muxc:NavigationViewItem ext:NavigationExtension.PageId="Help" Content="{loc:LocaleLocator Name=HelpAndSupport}">

--- a/src/App/Controls/App/RootNavigationView.xaml.cs
+++ b/src/App/Controls/App/RootNavigationView.xaml.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Richasy.Bili.App.Pages;
 using Richasy.Bili.App.Pages.Overlay;
 using Richasy.Bili.App.Resources.Extension;
+using Richasy.Bili.Models.App;
 using Richasy.Bili.Models.Enums;
 using Richasy.Bili.ViewModels.Uwp;
 using Windows.UI.Xaml;
@@ -24,6 +25,8 @@ namespace Richasy.Bili.App.Controls
         /// </summary>
         public static readonly DependencyProperty ViewModelProperty =
             DependencyProperty.Register(nameof(ViewModel), typeof(AppViewModel), typeof(RootNavigationView), new PropertyMetadata(AppViewModel.Instance));
+
+        private readonly AccountViewModel _accountViewModel = AccountViewModel.Instance;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RootNavigationView"/> class.
@@ -62,9 +65,7 @@ namespace Richasy.Bili.App.Controls
         }
 
         private void OnRequestOverlayNavigation(object sender, object e)
-        {
-            CheckOverlayContentNavigation(e);
-        }
+            => CheckOverlayContentNavigation(e);
 
         private void OnAppViewModelPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
@@ -242,8 +243,12 @@ namespace Richasy.Bili.App.Controls
         }
 
         private void OnMainFrameNavigated(object sender, Windows.UI.Xaml.Navigation.NavigationEventArgs e)
+            => RefreshButton.Visibility = MainFrame.Content is IRefreshPage ? Visibility.Visible : Visibility.Collapsed;
+
+        private async void OnFixedPublisherClickAsync(object sender, RoutedEventArgs e)
         {
-            RefreshButton.Visibility = MainFrame.Content is IRefreshPage ? Visibility.Visible : Visibility.Collapsed;
+            var context = (sender as FrameworkElement).DataContext as FixedPublisher;
+            await UserView.Instance.ShowAsync(Convert.ToInt32(context.UserId));
         }
     }
 }

--- a/src/App/Controls/User/UserAvatar.xaml.cs
+++ b/src/App/Controls/User/UserAvatar.xaml.cs
@@ -84,8 +84,6 @@ namespace Richasy.Bili.App.Controls
         }
 
         private void OnClick(object sender, RoutedEventArgs e)
-        {
-            Click?.Invoke(this, EventArgs.Empty);
-        }
+            => Click?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/App/Controls/User/UserView.xaml
+++ b/src/App/Controls/User/UserView.xaml
@@ -44,7 +44,11 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
-                    <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Grid Grid.ColumnSpan="2">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition />
                             <ColumnDefinition />
@@ -87,6 +91,22 @@
                             Click="OnFollowButtonClickAsync"
                             Content="{loc:LocaleLocator Name=Followed}"
                             Visibility="{x:Bind ViewModel.IsFollow, Mode=OneWay}" />
+                    </Grid>
+                    <Grid
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        Margin="8,0,0,0"
+                        Visibility="{x:Bind ViewModel.CanFixPublisher, Mode=OneWay}">
+                        <Button
+                            MinWidth="120"
+                            Click="OnFixButtonClickAsync"
+                            Content="{loc:LocaleLocator Name=FixPublisher}"
+                            Visibility="{x:Bind ViewModel.IsPublisherFixed, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}" />
+                        <Button
+                            MinWidth="120"
+                            Click="OnFixButtonClickAsync"
+                            Content="{loc:LocaleLocator Name=UnfixPublisher}"
+                            Visibility="{x:Bind ViewModel.IsPublisherFixed, Mode=OneWay}" />
                     </Grid>
                 </Grid>
             </Grid>

--- a/src/App/Controls/User/UserView.xaml.cs
+++ b/src/App/Controls/User/UserView.xaml.cs
@@ -4,7 +4,6 @@ using System;
 using System.Threading.Tasks;
 using Richasy.Bili.ViewModels.Uwp;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
 
 namespace Richasy.Bili.App.Controls
 {
@@ -89,24 +88,15 @@ namespace Richasy.Bili.App.Controls
         }
 
         private async void OnRefreshButtonClickAsync(object sender, RoutedEventArgs e)
-        {
-            await ViewModel.InitializeUserDetailAsync();
-        }
+            => await ViewModel.InitializeUserDetailAsync();
 
         private async void OnVideoViewRequestLoadMoreAsync(object sender, System.EventArgs e)
-        {
-            await ViewModel.DeltaRequestVideoAsync();
-        }
+            => await ViewModel.DeltaRequestVideoAsync();
 
-        private void OnVideoItemClick(object sender, VideoViewModel e)
-        {
-            this.Container.Hide();
-        }
+        private void OnVideoItemClick(object sender, VideoViewModel e) => Container.Hide();
 
         private async void OnFollowButtonClickAsync(object sender, RoutedEventArgs e)
-        {
-            await ViewModel.ToggleFollowStateAsync();
-        }
+            => await ViewModel.ToggleFollowStateAsync();
 
         private async void OnFansButtonClickAsync(object sender, RoutedEventArgs e)
         {
@@ -121,8 +111,9 @@ namespace Richasy.Bili.App.Controls
         }
 
         private void OnClosed(object sender, System.EventArgs e)
-        {
-            ViewModel.Deactive();
-        }
+            => ViewModel.Deactive();
+
+        private async void OnFixButtonClickAsync(object sender, RoutedEventArgs e)
+            => await ViewModel.ToggleFixStateAsync();
     }
 }

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -475,6 +475,12 @@
   <data name="FilterByTotalDuration" xml:space="preserve">
     <value>全部时长</value>
   </data>
+  <data name="FixedPublishers" xml:space="preserve">
+    <value>固定的UP</value>
+  </data>
+  <data name="FixPublisher" xml:space="preserve">
+    <value>固定UP</value>
+  </data>
   <data name="Flv" xml:space="preserve">
     <value>流媒体/FLV</value>
   </data>
@@ -1207,6 +1213,9 @@
   </data>
   <data name="UnFavoriteWarning" xml:space="preserve">
     <value>是否不再关注该收藏夹？</value>
+  </data>
+  <data name="UnfixPublisher" xml:space="preserve">
+    <value>取消固定UP</value>
   </data>
   <data name="UnknownError" xml:space="preserve">
     <value>未知错误发生了</value>

--- a/src/Controller/Controller.Uwp/BiliController.Partition.cs
+++ b/src/Controller/Controller.Uwp/BiliController.Partition.cs
@@ -52,9 +52,12 @@ namespace Richasy.Bili.Controller.Uwp
                 data = cacheData.Data;
             }
 
-            foreach (var partion in data)
+            if (data != null)
             {
-                partion.Children.Insert(0, null);
+                foreach (var partion in data)
+                {
+                    partion.Children.Insert(0, null);
+                }
             }
 
             return data;

--- a/src/Models/Models.App/Constants/AppConstants.cs
+++ b/src/Models/Models.App/Constants/AppConstants.cs
@@ -25,6 +25,8 @@ namespace Richasy.Bili.Models.App.Constants
         public const string ReplySection = "Reply";
 
         public const string LastOpenVideoFileName = "LastOpenVideo.json";
+        public const string FixedPublisherFolderName = "Fixed publisher";
+        public const string FixedPublisherFileName = "User-{0}.json";
 #pragma warning restore SA1600 // Elements should be documented
     }
 }

--- a/src/Models/Models.App/Other/FixedPublisher.cs
+++ b/src/Models/Models.App/Other/FixedPublisher.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Richasy. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace Richasy.Bili.Models.App
+{
+    /// <summary>
+    /// 固定的UP主.
+    /// </summary>
+    public class FixedPublisher
+    {
+        /// <summary>
+        /// 用户名.
+        /// </summary>
+        public string UserName { get; set; }
+
+        /// <summary>
+        /// 用户头像.
+        /// </summary>
+        public string AvatarPath { get; set; }
+
+        /// <summary>
+        /// 用户Id.
+        /// </summary>
+        public string UserId { get; set; }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) => obj is FixedPublisher publisher && UserId == publisher.UserId;
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => 2139390487 + EqualityComparer<string>.Default.GetHashCode(UserId);
+    }
+}

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -397,6 +397,9 @@ namespace Richasy.Bili.Models.Enums
         Clear,
         CacheCleared,
         BackToHome,
+        FixedPublishers,
+        FixPublisher,
+        UnfixPublisher,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Account/AccountViewModel/AccountViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Account/AccountViewModel/AccountViewModel.Properties.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
 using System;
+using System.Collections.ObjectModel;
 using ReactiveUI.Fody.Helpers;
 using Richasy.Bili.Controller.Uwp;
+using Richasy.Bili.Models.App;
 using Richasy.Bili.Models.BiliBili;
 using Richasy.Bili.Toolkit.Interfaces;
 
@@ -37,6 +39,7 @@ namespace Richasy.Bili.ViewModels.Uwp
         private readonly BiliController _controller;
         private readonly IResourceToolkit _resourceToolkit;
         private readonly INumberToolkit _numberToolkit;
+        private readonly IFileToolkit _fileToolkit;
         private MyInfo _myInfo;
 
         /// <summary>
@@ -48,6 +51,11 @@ namespace Richasy.Bili.ViewModels.Uwp
         /// 登录用户Id.
         /// </summary>
         public int? Mid => _myInfo?.Mid;
+
+        /// <summary>
+        /// 固定UP主集合.
+        /// </summary>
+        public ObservableCollection<FixedPublisher> FixedPublisherCollection { get; }
 
         /// <summary>
         /// 当前视图模型状态.
@@ -120,5 +128,11 @@ namespace Richasy.Bili.ViewModels.Uwp
         /// </summary>
         [Reactive]
         public bool IsShowUnreadMessage { get; set; }
+
+        /// <summary>
+        /// 是否显示固定的UP主.
+        /// </summary>
+        [Reactive]
+        public bool IsShowFixedPublisher { get; set; }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Account/UserViewModel/UserViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Account/UserViewModel/UserViewModel.Properties.cs
@@ -96,8 +96,19 @@ namespace Richasy.Bili.ViewModels.Uwp
         /// <summary>
         /// 投稿视频集合.
         /// </summary>
+        public ObservableCollection<VideoViewModel> VideoCollection { get; }
+
+        /// <summary>
+        /// 用户是否已被固定，<c>true</c> 意味着显示固定按钮，<c>false</c> 意味着显示取消固定按钮.
+        /// </summary>
         [Reactive]
-        public ObservableCollection<VideoViewModel> VideoCollection { get; set; }
+        public bool IsPublisherFixed { get; set; }
+
+        /// <summary>
+        /// 是否可以显示固定用户相关的操作（意味着用户是否已经登录）.
+        /// </summary>
+        [Reactive]
+        public bool CanFixPublisher { get; set; }
 
         /// <inheritdoc/>
         public override bool Equals(object obj) => obj is UserViewModel model && Id == model.Id;

--- a/src/ViewModels/ViewModels.Uwp/Account/UserViewModel/UserViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Account/UserViewModel/UserViewModel.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Bilibili.App.View.V1;
 using Richasy.Bili.Locator.Uwp;
+using Richasy.Bili.Models.App;
 using Richasy.Bili.Models.App.Args;
 using Richasy.Bili.Models.BiliBili;
 using Richasy.Bili.Models.Enums;
@@ -100,6 +101,11 @@ namespace Richasy.Bili.ViewModels.Uwp
             : this()
         {
             Id = userId;
+            CanFixPublisher = AccountViewModel.Instance.IsConnected && AccountViewModel.Instance.Mid != null;
+            if (CanFixPublisher)
+            {
+                IsPublisherFixed = AccountViewModel.Instance.FixedPublisherCollection.Any(p => p.UserId == userId.ToString());
+            }
         }
 
         /// <summary>
@@ -195,6 +201,31 @@ namespace Richasy.Bili.ViewModels.Uwp
             }
 
             _isFollowRequesting = false;
+        }
+
+        /// <summary>
+        /// 切换固定状态.
+        /// </summary>
+        /// <returns><see cref="Task"/>.</returns>
+        public async Task ToggleFixStateAsync()
+        {
+            if (IsPublisherFixed)
+            {
+                await AccountViewModel.Instance.RemoveFixedPublisherAsync(Id.ToString());
+            }
+            else
+            {
+                var p = new FixedPublisher
+                {
+                    UserId = Id.ToString(),
+                    AvatarPath = Avatar,
+                    UserName = Name,
+                };
+
+                await AccountViewModel.Instance.AddFixedPublisherAsync(p);
+            }
+
+            IsPublisherFixed = !IsPublisherFixed;
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复

添加了一个新的功能，允许用户将自己喜欢的UP主固定到首页上，以便快速打开用户详情以查看其视频。

功能入口：
![image](https://user-images.githubusercontent.com/27713596/156291108-8ac4b135-15ca-475d-a058-97575f979983.png)

位置显示：
![image](https://user-images.githubusercontent.com/27713596/156291155-ef8ce785-a41b-419c-94fc-7ed806c46098.png)

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

用户查看自己关注的用户需要点击多次才行

## 新的行为是什么？

通过将需要密切关注的UP固定在首页，可以便捷地打开用户面板

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 新组件
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

该数据是存在本地的，当用户卸载应用时，相关数据会被清除
