### PR TITLE
支持右键视频在浏览器中打开

### DIFF
--- a/src/App/Controls/Common/VideoItem.xaml
+++ b/src/App/Controls/Common/VideoItem.xaml
@@ -20,6 +20,11 @@
                         <icons:RegularFluentIcon Symbol="Add16" />
                     </AppBarButton.Icon>
                 </AppBarButton>
+                <AppBarButton Click="OnOpenInBroswerItemClickAsync" Label="{loc:LocaleLocator Name=OpenInBroswer}">
+                    <AppBarButton.Icon>
+                        <icons:RegularFluentIcon Symbol="Globe16" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
             </muxc:CommandBarFlyout.SecondaryCommands>
         </muxc:CommandBarFlyout>
     </UserControl.ContextFlyout>

--- a/src/App/Controls/Common/VideoItem.xaml.cs
+++ b/src/App/Controls/Common/VideoItem.xaml.cs
@@ -3,6 +3,7 @@
 using System;
 using Richasy.Bili.ViewModels.Uwp;
 using Windows.Foundation;
+using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -309,6 +310,25 @@ namespace Richasy.Bili.App.Controls
             {
                 await UserView.Instance.ShowAsync(ViewModel.Publisher);
             }
+        }
+
+        private async void OnOpenInBroswerItemClickAsync(object sender, RoutedEventArgs e)
+        {
+            var uri = string.Empty;
+            if (ViewModel.VideoType == Models.Enums.VideoType.Video)
+            {
+                uri = $"https://www.bilibili.com/video/av{ViewModel.VideoId}";
+            }
+            else if (ViewModel.VideoType == Models.Enums.VideoType.Pgc)
+            {
+                uri = $"https://www.bilibili.com/bangumi/play/{ViewModel.VideoId}";
+            }
+            else if (ViewModel.VideoType == Models.Enums.VideoType.Live)
+            {
+                uri = $"https://live.bilibili.com/{ViewModel.VideoId}";
+            }
+
+            await Launcher.LaunchUriAsync(new Uri(uri));
         }
     }
 }

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -764,6 +764,9 @@
   <data name="OpenFolder" xml:space="preserve">
     <value>打开文件夹</value>
   </data>
+  <data name="OpenInBroswer" xml:space="preserve">
+    <value>在浏览器中打开</value>
+  </data>
   <data name="Orange" xml:space="preserve">
     <value>橘黄色</value>
   </data>

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -235,6 +235,7 @@ namespace Richasy.Bili.Models.Enums
         NoHistoryVideos,
         ClearHistoryWarning,
         AddToViewLater,
+        OpenInBroswer,
         PlayCount,
         DanmakuCount,
         ReplyCount,


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复

支持右键视频条目后选择在浏览器中打开，以提供给用户更多播放视频的选择

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

没有在浏览器中打开视频的功能入口

## 新的行为是什么？

允许用户在浏览器中打开视频

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

目前没有推广到PGC内容和直播内容
