### PR TITLE
添加更多BBDown可配置项

### DIFF
--- a/src/App/Controls/Player/DownloadOptionsPanel.xaml
+++ b/src/App/Controls/Player/DownloadOptionsPanel.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:icon="using:Richasy.FluentIcon.Uwp"
     xmlns:loc="using:Richasy.Bili.Locator.Uwp"
     xmlns:local="using:Richasy.Bili.App.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -18,6 +19,7 @@
             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
             Text="{loc:LocaleLocator Name=DownloadTip}"
             TextWrapping="Wrap" />
+        <HyperlinkButton Content="BBDown" NavigateUri="https://github.com/nilaoda/BBDown" />
         <ComboBox
             x:Name="InterfaceComboBox"
             HorizontalAlignment="Stretch"
@@ -47,16 +49,31 @@
             <ComboBoxItem Content="{loc:LocaleLocator Name=OnlyAudio}" Tag="Audio" />
             <ComboBoxItem Content="{loc:LocaleLocator Name=OnlySubtitle}" Tag="Subtitle" />
         </ComboBox>
-        <ToggleSwitch
-            x:Name="UseMp4BoxSwitch"
-            HorizontalAlignment="Left"
-            Header="{loc:LocaleLocator Name=UseMp4Box}"
-            IsOn="{x:Bind ViewModel.UseMp4Box, Mode=TwoWay}" />
-        <ToggleSwitch
-            x:Name="UseMultiThreadSwitch"
-            HorizontalAlignment="Left"
-            Header="{loc:LocaleLocator Name=UseMultiThread}"
-            IsOn="{x:Bind ViewModel.UseMultiThread, Mode=TwoWay}" />
+        <StackPanel Spacing="8">
+            <TextBlock HorizontalAlignment="Left" Text="{loc:LocaleLocator Name=DownloadFolder}" />
+            <Grid ColumnSpacing="8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBox
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Center"
+                    IsReadOnly="True"
+                    PlaceholderText="{loc:LocaleLocator Name=NoSpecifiedDownloadPath}"
+                    Text="{x:Bind ViewModel.DownloadFolder, Mode=OneWay}" />
+                <Button
+                    x:Name="OpenFolderButton"
+                    AutomationProperties.Name="{loc:LocaleLocator Name=ChooseDownloadFolder}"
+                    Grid.Column="1"
+                    Width="40"
+                    VerticalAlignment="Center"
+                    Click="OnOpenFolderButtonClickAsync"
+                    ToolTipService.ToolTip="{loc:LocaleLocator Name=ChooseDownloadFolder}">
+                    <icon:RegularFluentIcon Symbol="Folder16" />
+                </Button>
+            </Grid>
+        </StackPanel>
         <StackPanel Spacing="8" Visibility="{x:Bind ViewModel.IsShowPart, Mode=OneWay}">
             <TextBlock Text="{loc:LocaleLocator Name=Parts}" />
             <ScrollViewer
@@ -89,6 +106,46 @@
                 </muxc:ItemsRepeater>
             </ScrollViewer>
         </StackPanel>
+        <muxc:Expander
+            HorizontalAlignment="Stretch"
+            HorizontalContentAlignment="Stretch"
+            Header="{loc:LocaleLocator Name=AdvancedOptions}">
+            <StackPanel
+                Padding="12,4"
+                HorizontalAlignment="Stretch"
+                Spacing="8">
+                <ToggleSwitch
+                    x:Name="InteractionQualitySwitch"
+                    HorizontalAlignment="Left"
+                    Header="{loc:LocaleLocator Name=InteractionQuality}"
+                    IsOn="{x:Bind ViewModel.UseInteractionQuality, Mode=TwoWay}" />
+                <ToggleSwitch
+                    x:Name="DownloadDanmakuSwitch"
+                    HorizontalAlignment="Left"
+                    Header="{loc:LocaleLocator Name=DownloadDanmaku}"
+                    IsOn="{x:Bind ViewModel.DownloadDanmaku, Mode=TwoWay}" />
+                <ToggleSwitch
+                    x:Name="PartPrefixSwitch"
+                    HorizontalAlignment="Left"
+                    Header="{loc:LocaleLocator Name=PartPrefix}"
+                    IsOn="{x:Bind ViewModel.UsePartPerfix, Mode=TwoWay}" />
+                <ToggleSwitch
+                    x:Name="QualitySuffixSwitch"
+                    HorizontalAlignment="Left"
+                    Header="{loc:LocaleLocator Name=QualitySuffix}"
+                    IsOn="{x:Bind ViewModel.UseQualitySuffix, Mode=TwoWay}" />
+                <ToggleSwitch
+                    x:Name="UseMp4BoxSwitch"
+                    HorizontalAlignment="Left"
+                    Header="{loc:LocaleLocator Name=UseMp4Box}"
+                    IsOn="{x:Bind ViewModel.UseMp4Box, Mode=TwoWay}" />
+                <ToggleSwitch
+                    x:Name="UseMultiThreadSwitch"
+                    HorizontalAlignment="Left"
+                    Header="{loc:LocaleLocator Name=UseMultiThread}"
+                    IsOn="{x:Bind ViewModel.UseMultiThread, Mode=TwoWay}" />
+            </StackPanel>
+        </muxc:Expander>
         <Button
             Style="{StaticResource AccentButtonStyle}"
             Margin="0,4,0,0"

--- a/src/App/Controls/Player/DownloadOptionsPanel.xaml
+++ b/src/App/Controls/Player/DownloadOptionsPanel.xaml
@@ -76,35 +76,30 @@
         </StackPanel>
         <StackPanel Spacing="8" Visibility="{x:Bind ViewModel.IsShowPart, Mode=OneWay}">
             <TextBlock Text="{loc:LocaleLocator Name=Parts}" />
-            <ScrollViewer
-                MaxHeight="132"
-                HorizontalScrollMode="Disabled"
-                VerticalScrollBarVisibility="Hidden">
-                <muxc:ItemsRepeater ItemsSource="{x:Bind ViewModel.TotalPartCollection, Mode=OneWay}">
-                    <muxc:ItemsRepeater.ItemTemplate>
-                        <DataTemplate x:DataType="uwp:NumberPartViewModel">
-                            <local:CardPanel
-                                IsChecked="{x:Bind IsSelected, Mode=TwoWay}"
-                                IsEnableCheck="True"
-                                IsEnableHoverAnimation="False"
-                                IsEnableShadow="False">
-                                <TextBlock
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    FontWeight="Bold"
-                                    Text="{x:Bind Data, Mode=OneWay}" />
-                            </local:CardPanel>
-                        </DataTemplate>
-                    </muxc:ItemsRepeater.ItemTemplate>
-                    <muxc:ItemsRepeater.Layout>
-                        <muxc:UniformGridLayout
-                            MinColumnSpacing="4"
-                            MinItemHeight="40"
-                            MinItemWidth="40"
-                            MinRowSpacing="4" />
-                    </muxc:ItemsRepeater.Layout>
-                </muxc:ItemsRepeater>
-            </ScrollViewer>
+            <muxc:ItemsRepeater ItemsSource="{x:Bind ViewModel.TotalPartCollection, Mode=OneWay}">
+                <muxc:ItemsRepeater.ItemTemplate>
+                    <DataTemplate x:DataType="uwp:NumberPartViewModel">
+                        <local:CardPanel
+                            IsChecked="{x:Bind IsSelected, Mode=TwoWay}"
+                            IsEnableCheck="True"
+                            IsEnableHoverAnimation="False"
+                            IsEnableShadow="False">
+                            <TextBlock
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                FontWeight="Bold"
+                                Text="{x:Bind Data, Mode=OneWay}" />
+                        </local:CardPanel>
+                    </DataTemplate>
+                </muxc:ItemsRepeater.ItemTemplate>
+                <muxc:ItemsRepeater.Layout>
+                    <muxc:UniformGridLayout
+                        MinColumnSpacing="4"
+                        MinItemHeight="40"
+                        MinItemWidth="40"
+                        MinRowSpacing="4" />
+                </muxc:ItemsRepeater.Layout>
+            </muxc:ItemsRepeater>
         </StackPanel>
         <muxc:Expander
             HorizontalAlignment="Stretch"

--- a/src/App/Controls/Player/DownloadOptionsPanel.xaml.cs
+++ b/src/App/Controls/Player/DownloadOptionsPanel.xaml.cs
@@ -187,5 +187,8 @@ namespace Richasy.Bili.App.Controls
                     break;
             }
         }
+
+        private async void OnOpenFolderButtonClickAsync(object sender, RoutedEventArgs e)
+            => await ViewModel.SetDownloadFolderAsync();
     }
 }

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -135,6 +135,9 @@
   <data name="AddViewLaterSucceseded" xml:space="preserve">
     <value>视频已添加至稍后再看</value>
   </data>
+  <data name="AdvancedOptions" xml:space="preserve">
+    <value>高级选项</value>
+  </data>
   <data name="Alias" xml:space="preserve">
     <value>别名</value>
   </data>
@@ -236,6 +239,9 @@
   </data>
   <data name="ChooseCoinNumber" xml:space="preserve">
     <value>打算投几个币？</value>
+  </data>
+  <data name="ChooseDownloadFolder" xml:space="preserve">
+    <value>选择下载文件夹</value>
   </data>
   <data name="ChooseFavorite" xml:space="preserve">
     <value>选择收藏夹</value>
@@ -407,6 +413,12 @@
   </data>
   <data name="Download" xml:space="preserve">
     <value>下载</value>
+  </data>
+  <data name="DownloadDanmaku" xml:space="preserve">
+    <value>下载弹幕</value>
+  </data>
+  <data name="DownloadFolder" xml:space="preserve">
+    <value>下载文件夹</value>
   </data>
   <data name="DownloadTip" xml:space="preserve">
     <value>应用本身不提供下载功能，但支持生成 BBDown 命令，具体的使用方法参见 帮助&amp;支持</value>
@@ -580,6 +592,9 @@
   <data name="InteractionEnd" xml:space="preserve">
     <value>互动视频结束，可点击左上角“🏘”按钮返回开头</value>
   </data>
+  <data name="InteractionQuality" xml:space="preserve">
+    <value>交互式清晰度选择</value>
+  </data>
   <data name="InterfaceType" xml:space="preserve">
     <value>接口类型</value>
   </data>
@@ -737,6 +752,9 @@
   <data name="NoSpecificData" xml:space="preserve">
     <value>没有找到指定的数据</value>
   </data>
+  <data name="NoSpecifiedDownloadPath" xml:space="preserve">
+    <value>没有指定的下载文件夹</value>
+  </data>
   <data name="NoStroke" xml:space="preserve">
     <value>无描边</value>
   </data>
@@ -790,6 +808,9 @@
   </data>
   <data name="PartitionRequestFailed" xml:space="preserve">
     <value>分区请求失败</value>
+  </data>
+  <data name="PartPrefix" xml:space="preserve">
+    <value>加入分P前缀</value>
   </data>
   <data name="Parts" xml:space="preserve">
     <value>分集</value>
@@ -901,6 +922,9 @@
   </data>
   <data name="Quality" xml:space="preserve">
     <value>清晰度</value>
+  </data>
+  <data name="QualitySuffix" xml:space="preserve">
+    <value>加入清晰度后缀</value>
   </data>
   <data name="Rank" xml:space="preserve">
     <value>排行榜</value>

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -359,6 +359,10 @@ namespace Richasy.Bili.Models.Enums
         UseMp4Box,
         UseMultiThread,
         GenerateCommand,
+        DownloadDanmaku,
+        PartPrefix,
+        QualitySuffix,
+        DownloadFolder,
         DownloadTip,
         AtLeastChooseOnePart,
         ToggleDanmakuBarVisibility,
@@ -404,6 +408,10 @@ namespace Richasy.Bili.Models.Enums
         RequestSearchResultFailed,
         ExitSearch,
         NoUserVideoSearchResult,
+        NoSpecifiedDownloadPath,
+        ChooseDownloadFolder,
+        AdvancedOptions,
+        InteractionQuality,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/Models/Models.Enums/App/SettingNames.cs
+++ b/src/Models/Models.Enums/App/SettingNames.cs
@@ -46,6 +46,21 @@ namespace Richasy.Bili.Models.Enums
         CanContinuePlay,
         ContinuePlayTitle,
         SupportContinuePlay,
+        Download_UseMp4Box,
+        Download_OnlyHevc,
+        Download_OnlyAvc,
+        Download_OnlyAudio,
+        Download_OnlyVideo,
+        Download_OnlySubtitle,
+        Download_UseMultiThread,
+        Download_UseAppInterface,
+        Download_UseTvInterface,
+        Download_UseInternationalInterface,
+        Download_DownloadDanmaku,
+        Download_DownloadFolder,
+        Download_UsePartPerfix,
+        Download_UseQualitySuffix,
+        Download_UseInteractionQuality,
 #pragma warning disable SA1602 // Enumeration items should be documented
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/DownloadViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/DownloadViewModel.cs
@@ -5,9 +5,13 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
+using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 using Richasy.Bili.Lib.Interfaces;
 using Richasy.Bili.Locator.Uwp;
+using Richasy.Bili.Models.Enums;
+using Richasy.Bili.Toolkit.Interfaces;
+using Windows.Storage.Pickers;
 
 namespace Richasy.Bili.ViewModels.Uwp
 {
@@ -16,14 +20,62 @@ namespace Richasy.Bili.ViewModels.Uwp
     /// </summary>
     public class DownloadViewModel : ViewModelBase
     {
+        private readonly ISettingsToolkit _settingsToolkit;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DownloadViewModel"/> class.
         /// </summary>
         protected DownloadViewModel()
         {
-            UseMultiThread = true;
-            UseAppInterface = true;
             TotalPartCollection = new ObservableCollection<NumberPartViewModel>();
+            ServiceLocator.Instance.LoadService(out _settingsToolkit);
+
+            UseMp4Box = ReadSetting(SettingNames.Download_UseMp4Box, false);
+            OnlyHevc = ReadSetting(SettingNames.Download_OnlyHevc, false);
+            OnlyAvc = ReadSetting(SettingNames.Download_OnlyAvc, false);
+            OnlyAudio = ReadSetting(SettingNames.Download_OnlyAudio, false);
+            OnlyVideo = ReadSetting(SettingNames.Download_OnlyVideo, false);
+            OnlySubtitle = ReadSetting(SettingNames.Download_OnlySubtitle, false);
+            UseMultiThread = ReadSetting(SettingNames.Download_UseMultiThread, true);
+            UseAppInterface = ReadSetting(SettingNames.Download_UseAppInterface, true);
+            UseTvInterface = ReadSetting(SettingNames.Download_UseTvInterface, false);
+            UseInternationalInterface = ReadSetting(SettingNames.Download_UseInternationalInterface, false);
+            DownloadDanmaku = ReadSetting(SettingNames.Download_DownloadDanmaku, false);
+            DownloadFolder = ReadSetting(SettingNames.Download_DownloadFolder, string.Empty);
+            UsePartPerfix = ReadSetting(SettingNames.Download_UsePartPerfix, true);
+            UseQualitySuffix = ReadSetting(SettingNames.Download_UseQualitySuffix, false);
+            UseInteractionQuality = ReadSetting(SettingNames.Download_UseInteractionQuality, false);
+
+            this.WhenAnyValue(x => x.UseMp4Box)
+                .Subscribe(x => WriteSetting(SettingNames.Download_UseMp4Box, x));
+            this.WhenAnyValue(x => x.OnlyVideo)
+                .Subscribe(x => WriteSetting(SettingNames.Download_OnlyVideo, x));
+            this.WhenAnyValue(x => x.OnlyAudio)
+                .Subscribe(x => WriteSetting(SettingNames.Download_OnlyAudio, x));
+            this.WhenAnyValue(x => x.OnlyAvc)
+                .Subscribe(x => WriteSetting(SettingNames.Download_OnlyAvc, x));
+            this.WhenAnyValue(x => x.OnlyHevc)
+                .Subscribe(x => WriteSetting(SettingNames.Download_OnlyHevc, x));
+            this.WhenAnyValue(x => x.OnlySubtitle)
+                .Subscribe(x => WriteSetting(SettingNames.Download_OnlySubtitle, x));
+            this.WhenAnyValue(x => x.UseAppInterface)
+                .Subscribe(x => WriteSetting(SettingNames.Download_UseAppInterface, x));
+            this.WhenAnyValue(x => x.UseInternationalInterface)
+                .Subscribe(x => WriteSetting(SettingNames.Download_UseInternationalInterface, x));
+            this.WhenAnyValue(x => x.UseMultiThread)
+                .Subscribe(x => WriteSetting(SettingNames.Download_UseMultiThread, x));
+            this.WhenAnyValue(x => x.UsePartPerfix)
+                .Subscribe(x => WriteSetting(SettingNames.Download_UsePartPerfix, x));
+            this.WhenAnyValue(x => x.UseQualitySuffix)
+                .Subscribe(x => WriteSetting(SettingNames.Download_UseQualitySuffix, x));
+            this.WhenAnyValue(x => x.UseTvInterface)
+                .Subscribe(x => WriteSetting(SettingNames.Download_UseTvInterface, x));
+            this.WhenAnyValue(x => x.DownloadDanmaku)
+                .Subscribe(x => WriteSetting(SettingNames.Download_DownloadDanmaku, x));
+            this.WhenAnyValue(x => x.DownloadFolder)
+                .Subscribe(x => WriteSetting(SettingNames.Download_DownloadFolder, x));
+            this.WhenAnyValue(x => x.UseInteractionQuality)
+                .Subscribe(x => WriteSetting(SettingNames.Download_UseInteractionQuality, x));
         }
 
         /// <summary>
@@ -97,6 +149,36 @@ namespace Richasy.Bili.ViewModels.Uwp
         public bool UseInternationalInterface { get; set; }
 
         /// <summary>
+        /// 是否下载弹幕.
+        /// </summary>
+        [Reactive]
+        public bool DownloadDanmaku { get; set; }
+
+        /// <summary>
+        /// 下载文件夹.
+        /// </summary>
+        [Reactive]
+        public string DownloadFolder { get; set; }
+
+        /// <summary>
+        /// 使用分P前缀.
+        /// </summary>
+        [Reactive]
+        public bool UsePartPerfix { get; set; }
+
+        /// <summary>
+        /// 使用分P后缀.
+        /// </summary>
+        [Reactive]
+        public bool UseQualitySuffix { get; set; }
+
+        /// <summary>
+        /// 使用交互式清晰度选择.
+        /// </summary>
+        [Reactive]
+        public bool UseInteractionQuality { get; set; }
+
+        /// <summary>
         /// 全部分P集合.
         /// </summary>
         [Reactive]
@@ -123,6 +205,21 @@ namespace Richasy.Bili.ViewModels.Uwp
             }
 
             IsShowPart = TotalPartCollection.Count > 1;
+        }
+
+        /// <summary>
+        /// 设置下载文件夹.
+        /// </summary>
+        /// <returns><see cref="Task"/>.</returns>
+        public async Task SetDownloadFolderAsync()
+        {
+            var folderPicker = new FolderPicker();
+            folderPicker.SuggestedStartLocation = PickerLocationId.VideosLibrary;
+            var folder = await folderPicker.PickSingleFolderAsync().AsTask();
+            if (folder != null)
+            {
+                DownloadFolder = folder.Path;
+            }
         }
 
         /// <summary>
@@ -179,6 +276,32 @@ namespace Richasy.Bili.ViewModels.Uwp
                 list.Add("-mt");
             }
 
+            if (DownloadDanmaku)
+            {
+                list.Add("-dd");
+            }
+
+            if (!string.IsNullOrEmpty(DownloadFolder))
+            {
+                list.Add("--work-dir");
+                list.Add($"\"{DownloadFolder}\"");
+            }
+
+            if (!UsePartPerfix)
+            {
+                list.Add("--no-part-prefix");
+            }
+
+            if (UseQualitySuffix)
+            {
+                list.Add("--add-dfn-subfix");
+            }
+
+            if (UseInteractionQuality)
+            {
+                list.Add("-ia");
+            }
+
             var selectedPages = TotalPartCollection.Where(p => p.IsSelected).Select(p => p.Data).ToList();
             if (selectedPages.Count > 0)
             {
@@ -204,5 +327,11 @@ namespace Richasy.Bili.ViewModels.Uwp
 
             return string.Join(' ', list);
         }
+
+        private void WriteSetting<T>(SettingNames name, T value)
+            => _settingsToolkit.WriteLocalSetting(name, value);
+
+        private T ReadSetting<T>(SettingNames name, T defaultValue)
+            => _settingsToolkit.ReadLocalSetting(name, defaultValue);
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/DownloadViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/DownloadViewModel.cs
@@ -181,8 +181,7 @@ namespace Richasy.Bili.ViewModels.Uwp
         /// <summary>
         /// 全部分P集合.
         /// </summary>
-        [Reactive]
-        public ObservableCollection<NumberPartViewModel> TotalPartCollection { get; set; }
+        public ObservableCollection<NumberPartViewModel> TotalPartCollection { get; }
 
         /// <summary>
         /// 是否显示分P.

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -615,6 +615,7 @@ namespace Richasy.Bili.ViewModels.Uwp
         public void InitDownload()
         {
             var para = string.Empty;
+            var partList = new List<int>();
             if (IsPgc)
             {
                 if (CurrentPgcEpisode != null)
@@ -625,6 +626,8 @@ namespace Richasy.Bili.ViewModels.Uwp
                 {
                     para = $"ss{_pgcDetail.SeasonId}";
                 }
+
+                partList = EpisodeCollection.Select((_, index) => index + 1).ToList();
             }
             else if (!IsLive)
             {
@@ -636,9 +639,11 @@ namespace Richasy.Bili.ViewModels.Uwp
                 {
                     para = $"av{AvId}";
                 }
+
+                partList = VideoPartCollection.Select((_, index) => index + 1).ToList();
             }
 
-            DownloadViewModel.Instance.Load(para, VideoPartCollection.Select((p, index) => index + 1).ToList());
+            DownloadViewModel.Instance.Load(para, partList);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 修复

适配 BBDown 1.4.8 新增的部分功能：

1. 允许自定义下载目录
2. 支持交互清晰度选择开关
3. 支持下载弹幕开关
4. 支持分P前缀开关
5. 支持清晰度后缀开关

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

只能进行部分BBDown功能配置

## 新的行为是什么？

可以提供更多的配置项

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
