### PR TITLE
修复评论详情显示为其它内容的问题

### DIFF
--- a/src/App/Controls/Common/EmotiTextBlock/EmotiTextBlock.cs
+++ b/src/App/Controls/Common/EmotiTextBlock/EmotiTextBlock.cs
@@ -31,6 +31,7 @@ namespace Richasy.Bili.App.Controls
         private RichTextBlock _richBlock;
         private RichTextBlock _flyoutRichBlock;
         private Button _overflowButton;
+        private bool _isOverflowInitialized;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EmotiTextBlock"/> class.
@@ -63,6 +64,7 @@ namespace Richasy.Bili.App.Controls
             _overflowButton = GetTemplateChild("OverflowButton") as Button;
 
             _richBlock.IsTextTrimmedChanged += OnIsTextTrimmedChanged;
+            _overflowButton.Click += OnOverflowButtonClick;
 
             InitializeReplyContent();
             base.OnApplyTemplate();
@@ -71,23 +73,17 @@ namespace Richasy.Bili.App.Controls
         private static void OnReplyInfoChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var instance = d as EmotiTextBlock;
+            instance._isOverflowInitialized = false;
             instance.InitializeReplyContent();
+
+            if (instance._overflowButton != null && instance._richBlock != null)
+            {
+                instance._overflowButton.Visibility = instance._richBlock.IsTextTrimmed ? Visibility.Visible : Visibility.Collapsed;
+            }
         }
 
         private void OnIsTextTrimmedChanged(RichTextBlock sender, IsTextTrimmedChangedEventArgs args)
-        {
-            _overflowButton.Visibility = sender.IsTextTrimmed ? Visibility.Visible : Visibility.Collapsed;
-            if (sender.IsTextTrimmed)
-            {
-                _flyoutRichBlock.Blocks.Clear();
-
-                if (ReplyInfo != null)
-                {
-                    var para = ParseReplyInfo();
-                    _flyoutRichBlock.Blocks.Add(para);
-                }
-            }
-        }
+            => _overflowButton.Visibility = sender.IsTextTrimmed ? Visibility.Visible : Visibility.Collapsed;
 
         private void InitializeReplyContent()
         {
@@ -96,6 +92,20 @@ namespace Richasy.Bili.App.Controls
                 _richBlock.Blocks.Clear();
                 var para = ParseReplyInfo();
                 _richBlock.Blocks.Add(para);
+            }
+        }
+
+        private void OnOverflowButtonClick(object sender, RoutedEventArgs e)
+        {
+            if (!_isOverflowInitialized)
+            {
+                _flyoutRichBlock.Blocks.Clear();
+
+                if (ReplyInfo != null)
+                {
+                    var para = ParseReplyInfo();
+                    _flyoutRichBlock.Blocks.Add(para);
+                }
             }
         }
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #789 

修复因列表虚拟化导致的评论详情Flyout中的内容没有正确更新的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

当评论列表中存在多项折叠评论时，展开的评论详情浮出控件中的内容可能显示的是其它评论的内容

## 新的行为是什么？

修复了这个问题

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
