### PR TITLE
修复帮助页面链接滚动布局错位的问题

### DIFF
--- a/src/App/Pages/HelpPage.xaml
+++ b/src/App/Pages/HelpPage.xaml
@@ -131,26 +131,19 @@
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                 Text="{loc:LocaleLocator Name=RelatedProjects}"
                                 TextTrimming="CharacterEllipsis" />
-                            <ScrollViewer
-                                x:Name="LinkScrollViewer"
+                            <ListView
+                                x:Name="LinkView"
                                 Grid.Row="1"
-                                HorizontalScrollBarVisibility="Hidden"
-                                HorizontalScrollMode="Disabled">
-                                <muxc:ItemsRepeater ItemsSource="{x:Bind ViewModel.LinkCollection, Mode=OneWay}">
-                                    <muxc:ItemsRepeater.Layout>
-                                        <muxc:StackLayout Spacing="4" />
-                                    </muxc:ItemsRepeater.Layout>
-                                    <muxc:ItemsRepeater.ItemTemplate>
-                                        <DataTemplate>
-                                            <HyperlinkButton
-                                                HorizontalAlignment="Stretch"
-                                                HorizontalContentAlignment="Left"
-                                                Content="{Binding Key}"
-                                                NavigateUri="{Binding Value}" />
-                                        </DataTemplate>
-                                    </muxc:ItemsRepeater.ItemTemplate>
-                                </muxc:ItemsRepeater>
-                            </ScrollViewer>
+                                IsItemClickEnabled="True"
+                                ItemClick="OnLinkViewItemClickAsync"
+                                ItemsSource="{x:Bind ViewModel.LinkCollection}"
+                                SelectionMode="None">
+                                <ListView.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Foreground="{ThemeResource AccentTextFillColorSecondaryBrush}" Text="{Binding Key}" />
+                                    </DataTemplate>
+                                </ListView.ItemTemplate>
+                            </ListView>
                         </Grid>
                     </controls:CardPanel>
                 </Grid>

--- a/src/App/Pages/HelpPage.xaml.cs
+++ b/src/App/Pages/HelpPage.xaml.cs
@@ -77,5 +77,11 @@ namespace Richasy.Bili.App.Pages
                 }
             }
         }
+
+        private async void OnLinkViewItemClickAsync(object sender, ItemClickEventArgs e)
+        {
+            var data = e.ClickedItem as Models.App.Other.KeyValue<string>;
+            await Launcher.LaunchUriAsync(new Uri(data.Value));
+        }
     }
 }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #788 

修复帮助页面链接滚动布局错位的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

帮助页面中的超链接在滚动后会变得偏向右侧

## 新的行为是什么？

使用ListView替代ItemsRepeater，修复这种布局问题

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
