### PR TITLE
修复弹幕速度跳变的问题

### DIFF
--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
@@ -446,7 +446,7 @@ namespace Richasy.Bili.App.Controls
             }
             else if (e.PropertyName == nameof(DanmakuViewModel.DanmakuSpeed))
             {
-                _danmakuView.DanmakuDuration = Convert.ToInt32(2.1 - DanmakuViewModel.DanmakuSpeed) * 10;
+                _danmakuView.DanmakuDuration = Convert.ToInt32((2.1 - DanmakuViewModel.DanmakuSpeed) * 10);
             }
         }
 

--- a/src/ViewModels/ViewModels.Uwp/Common/DanmakuViewModel/DanmakuViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/DanmakuViewModel/DanmakuViewModel.Properties.cs
@@ -72,7 +72,7 @@ namespace Richasy.Bili.ViewModels.Uwp.Common
         public double DanmakuArea { get; set; }
 
         /// <summary>
-        /// 弹幕显示区域.
+        /// 弹幕速度.
         /// </summary>
         [Reactive]
         public double DanmakuSpeed { get; set; }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #791 

修复弹幕速度从 1.5 -> 1.6 时速度骤快的问题。
问题原因在于在进行速度表达式类型转换时错误地将*10放在了括号外面，导致四舍五入的结果被放大了10倍

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

弹幕速度从1.5到1.6时速度骤快

## 新的行为是什么？

速度逐值加快

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
