### PR TITLE
修复电影本体和PV不能正常切换的问题

### DIFF
--- a/src/App/Controls/Player/Related/PgcSectionView.xaml.cs
+++ b/src/App/Controls/Player/Related/PgcSectionView.xaml.cs
@@ -21,6 +21,7 @@ namespace Richasy.Bili.App.Controls.Player.Related
         {
             var card = sender as CardPanel;
             var data = card.DataContext as PgcEpisodeViewModel;
+            data.Data.IsPV = 1;
             if (!data.Data.Id.ToString().Equals(ViewModel.EpisodeId))
             {
                 await ViewModel.LoadAsync(data.Data);

--- a/src/App/Controls/Player/Related/SeasonView.xaml.cs
+++ b/src/App/Controls/Player/Related/SeasonView.xaml.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
+using System.Threading.Tasks;
 using Richasy.Bili.ViewModels.Uwp;
 using Windows.UI.Xaml;
 
@@ -13,21 +14,20 @@ namespace Richasy.Bili.App.Controls.Player.Related
         /// <summary>
         /// Initializes a new instance of the <see cref="SeasonView"/> class.
         /// </summary>
-        public SeasonView()
-        {
-            this.InitializeComponent();
-        }
+        public SeasonView() => InitializeComponent();
 
         private async void OnSeasonItemClickAsync(object sender, RoutedEventArgs e)
         {
             var card = sender as CardPanel;
             var data = card.DataContext as PgcSeasonViewModel;
-            if (!data.Data.SeasonId.ToString().Equals(ViewModel.SeasonId))
+            if (!data.Data.SeasonId.ToString().Equals(ViewModel.SeasonId) || ViewModel.IsPv)
             {
                 await ViewModel.LoadAsync(data.Data);
             }
             else
             {
+                data.IsSelected = false;
+                await Task.Delay(100);
                 data.IsSelected = true;
             }
         }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -169,8 +169,13 @@ namespace Richasy.Bili.ViewModels.Uwp
             }
             else if (_pgcDetail.UserStatus?.Progress != null)
             {
-                id = _pgcDetail.UserStatus.Progress.LastEpisodeId;
-                _initializeProgress = TimeSpan.FromSeconds(_pgcDetail.UserStatus.Progress.LastTime);
+                var lastId = _pgcDetail.UserStatus.Progress.LastEpisodeId;
+
+                if (EpisodeCollection.Any(p => p.Data.Id == id))
+                {
+                    id = lastId;
+                    _initializeProgress = TimeSpan.FromSeconds(_pgcDetail.UserStatus.Progress.LastTime);
+                }
             }
 
             await ChangePgcEpisodeAsync(id);

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
@@ -110,6 +110,11 @@ namespace Richasy.Bili.ViewModels.Uwp
         public CoreDispatcher Dispatcher { get; set; }
 
         /// <summary>
+        /// 当前是否为PV.
+        /// </summary>
+        public bool IsPv { get; private set; }
+
+        /// <summary>
         /// 详情是否可以加载（用于优化页面跳转的加载时间）.
         /// </summary>
         [Reactive]

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -148,6 +148,7 @@ namespace Richasy.Bili.ViewModels.Uwp
 
             var isReleated = false;
             var type = VideoType.Video;
+            IsPv = false;
 
             CurrentPlayingRecord record = null;
 
@@ -173,6 +174,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             {
                 videoId = episodeData.Id.ToString();
                 seasonId = 0;
+                IsPv = episodeData.IsPV == 1;
                 type = VideoType.Pgc;
             }
             else if (vm is CurrentPlayingRecord r)


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #761 

修复电影本体和PV不能正常切换的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

当用户在观看电影时切换到PV，再点击电影本体就无法再切换回来了，应用会始终加载最后的PV

## 新的行为是什么？

用户可以通过再次点击电影本体切换回电影本身

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
