### PR TITLE
播放速率功能调整

### DIFF
--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
@@ -652,10 +652,10 @@
                                                                         <Slider
                                                                             x:Name="RateSlider"
                                                                             Width="200"
-                                                                            Maximum="3"
+                                                                            Maximum="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.MaxPlaybackRate, Mode=OneWay}"
                                                                             Minimum="0.5"
-                                                                            StepFrequency="0.1"
-                                                                            TickFrequency="0.1"
+                                                                            StepFrequency="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.PlaybackRateStep, Mode=OneWay}"
+                                                                            TickFrequency="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.PlaybackRateStep, Mode=OneWay}"
                                                                             TickPlacement="Outside"
                                                                             Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.PlaybackRate, Mode=TwoWay}" />
                                                                     </StackPanel>

--- a/src/App/Controls/Settings/PlayerControlSettingSection.xaml
+++ b/src/App/Controls/Settings/PlayerControlSettingSection.xaml
@@ -128,6 +128,21 @@
                 <exp:ExpanderExWrapper Style="{StaticResource WrapperInExpanderContentStyle}">
                     <exp:ExpanderExWrapper.MainContent>
                         <exp:ExpanderExDescriptor
+                            Title="{loc:LocaleLocator Name=PlaybackRateEnhancement}"
+                            Description="{loc:LocaleLocator Name=PlaybackRateEnhancementDescription}"
+                            IconVisibility="Collapsed"
+                            IsAutoHideIcon="False" />
+                    </exp:ExpanderExWrapper.MainContent>
+                    <exp:ExpanderExWrapper.WrapContent>
+                        <ToggleSwitch Style="{StaticResource RightAlignedCompactToggleSwitchStyle}" IsOn="{x:Bind ViewModel.PlaybackRateEnhancement, Mode=TwoWay}" />
+                    </exp:ExpanderExWrapper.WrapContent>
+                </exp:ExpanderExWrapper>
+
+                <exp:ExpanderExItemSeparator />
+
+                <exp:ExpanderExWrapper Style="{StaticResource WrapperInExpanderContentStyle}">
+                    <exp:ExpanderExWrapper.MainContent>
+                        <exp:ExpanderExDescriptor
                             Title="{loc:LocaleLocator Name=DoubleClickBehavior}"
                             Description="{loc:LocaleLocator Name=DoubleClickBehaviorDescription}"
                             IconVisibility="Collapsed"

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -883,6 +883,12 @@ BV号以 BV 开头，是一串英文数字混合的编号， 如 BV1JL4y1875w</v
   <data name="PlaybackRate" xml:space="preserve">
     <value>播放速率</value>
   </data>
+  <data name="PlaybackRateEnhancement" xml:space="preserve">
+    <value>播放速率增强 (实验)</value>
+  </data>
+  <data name="PlaybackRateEnhancementDescription" xml:space="preserve">
+    <value>开启后，播放速率最高支持6倍速，步幅增加为0.2，但较高的速率可能导致视频卡帧，请谨慎调整</value>
+  </data>
   <data name="PlayCount" xml:space="preserve">
     <value>播放量</value>
   </data>

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -433,6 +433,8 @@ namespace Richasy.Bili.Models.Enums
         CopyToClipboardAfterScreenshot,
         OpenFileAfterScreenshot,
         Av1,
+        PlaybackRateEnhancement,
+        PlaybackRateEnhancementDescription,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/Models/Models.Enums/App/SettingNames.cs
+++ b/src/Models/Models.Enums/App/SettingNames.cs
@@ -64,6 +64,7 @@ namespace Richasy.Bili.Models.Enums
         CanSaveScreenshot,
         OpenScreenshotAfterSave,
         CopyScreenshotAfterSave,
+        PlaybackRateEnhancement,
 #pragma warning disable SA1602 // Enumeration items should be documented
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -980,5 +980,13 @@ namespace Richasy.Bili.ViewModels.Uwp
             _settingsToolkit.WriteLocalSetting(SettingNames.CanContinuePlay, true);
             _settingsToolkit.WriteLocalSetting(SettingNames.ContinuePlayTitle, title);
         }
+
+        private void InitializePlaybackRateProperties()
+        {
+            var isEnhancement = _settingsToolkit.ReadLocalSetting(SettingNames.PlaybackRateEnhancement, false);
+            MaxPlaybackRate = isEnhancement ? 6d : 3d;
+            PlaybackRateStep = isEnhancement ? 0.2 : 0.1;
+            PlaybackRate = 1d;
+        }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
@@ -745,6 +745,18 @@ namespace Richasy.Bili.ViewModels.Uwp
         public bool IsNextEpisodeButtonEnabled { get; set; }
 
         /// <summary>
+        /// 最大播放倍率.
+        /// </summary>
+        [Reactive]
+        public double MaxPlaybackRate { get; set; }
+
+        /// <summary>
+        /// 播放倍率步幅.
+        /// </summary>
+        [Reactive]
+        public double PlaybackRateStep { get; set; }
+
+        /// <summary>
         /// 选项集合.
         /// </summary>
         [Reactive]

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -208,6 +208,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             IsDetailCanLoaded = true;
             DanmakuViewModel.Instance.Reset();
             IsPlayInformationError = false;
+            InitializePlaybackRateProperties();
 
             if (!isReleated)
             {

--- a/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.Properties.cs
@@ -131,6 +131,12 @@ namespace Richasy.Bili.ViewModels.Uwp
         public double SingleFastForwardAndRewindSpan { get; set; }
 
         /// <summary>
+        /// 是否开启播放速率增强.
+        /// </summary>
+        [Reactive]
+        public bool PlaybackRateEnhancement { get; set; }
+
+        /// <summary>
         /// 应用版本.
         /// </summary>
         [Reactive]

--- a/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.cs
@@ -43,6 +43,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             IsSupportContinuePlay = ReadSetting(SettingNames.SupportContinuePlay, true);
             IsCopyScreenshot = ReadSetting(SettingNames.CopyScreenshotAfterSave, true);
             IsOpenScreenshotFile = ReadSetting(SettingNames.OpenScreenshotAfterSave, false);
+            PlaybackRateEnhancement = ReadSetting(SettingNames.PlaybackRateEnhancement, false);
             PreferCodecInit();
             DoubleClickInit();
             PlayerModeInit();
@@ -104,6 +105,9 @@ namespace Richasy.Bili.ViewModels.Uwp
                     break;
                 case nameof(IsOpenScreenshotFile):
                     WriteSetting(SettingNames.OpenScreenshotAfterSave, IsOpenScreenshotFile);
+                    break;
+                case nameof(PlaybackRateEnhancement):
+                    WriteSetting(SettingNames.PlaybackRateEnhancement, PlaybackRateEnhancement);
                     break;
                 default:
                     break;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #820

1. 打开一个新视频时，重置播放速率为1；同时在播放分P时，延续上一视频的播放速率。
2. 在设置中提供一个实验性功能，开启 `播放速率增强` 后，播放速率上限将提升至6倍速
![image](https://user-images.githubusercontent.com/27713596/159031157-16744195-48ae-4f11-a12d-0a00a9eeb400.png)

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

播放速率是全局设置，会延续到下一个视频中。

播放速率最大支持3倍速。

## 新的行为是什么？

1. 打开一个新视频时，重置播放速率为1；同时在播放分P时，延续上一视频的播放速率。
2. 开启 `播放速率增强` 后，播放速率上限将提升至6倍速

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 新组件
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
