### PR TITLE
添加全局播放速率设置

### DIFF
--- a/src/App/Controls/Settings/PlayerControlSettingSection.xaml
+++ b/src/App/Controls/Settings/PlayerControlSettingSection.xaml
@@ -143,6 +143,21 @@
                 <exp:ExpanderExWrapper Style="{StaticResource WrapperInExpanderContentStyle}">
                     <exp:ExpanderExWrapper.MainContent>
                         <exp:ExpanderExDescriptor
+                            Title="{loc:LocaleLocator Name=GlobalPlaybackRate}"
+                            Description="{loc:LocaleLocator Name=GlobalPlaybackRateDescription}"
+                            IconVisibility="Collapsed"
+                            IsAutoHideIcon="False" />
+                    </exp:ExpanderExWrapper.MainContent>
+                    <exp:ExpanderExWrapper.WrapContent>
+                        <ToggleSwitch Style="{StaticResource RightAlignedCompactToggleSwitchStyle}" IsOn="{x:Bind ViewModel.GlobalPlaybackRate, Mode=TwoWay}" />
+                    </exp:ExpanderExWrapper.WrapContent>
+                </exp:ExpanderExWrapper>
+
+                <exp:ExpanderExItemSeparator />
+
+                <exp:ExpanderExWrapper Style="{StaticResource WrapperInExpanderContentStyle}">
+                    <exp:ExpanderExWrapper.MainContent>
+                        <exp:ExpanderExDescriptor
                             Title="{loc:LocaleLocator Name=DoubleClickBehavior}"
                             Description="{loc:LocaleLocator Name=DoubleClickBehaviorDescription}"
                             IconVisibility="Collapsed"

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -577,7 +577,7 @@ BV号以 BV 开头，是一串英文数字混合的编号， 如 BV1JL4y1875w</v
     <value>全局播放速率</value>
   </data>
   <data name="GlobalPlaybackRateDescription" xml:space="preserve">
-    <value>启用后，所有视频共用一个播放速率，直到应用重启</value>
+    <value>启用后，所有视频共用一个播放速率</value>
   </data>
   <data name="Grass" xml:space="preserve">
     <value>草绿色</value>

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -573,6 +573,12 @@ BV号以 BV 开头，是一串英文数字混合的编号， 如 BV1JL4y1875w</v
   <data name="Generic" xml:space="preserve">
     <value>通用</value>
   </data>
+  <data name="GlobalPlaybackRate" xml:space="preserve">
+    <value>全局播放速率</value>
+  </data>
+  <data name="GlobalPlaybackRateDescription" xml:space="preserve">
+    <value>启用后，所有视频共用一个播放速率，直到应用重启</value>
+  </data>
   <data name="Grass" xml:space="preserve">
     <value>草绿色</value>
   </data>

--- a/src/App/Themes/Generic.xaml
+++ b/src/App/Themes/Generic.xaml
@@ -1,17 +1,17 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///Controls/Banner/BannerItem/BannerItem.xaml" />
         <ResourceDictionary Source="ms-appx:///Controls/App/CardPanel/CardPanel.xaml" />
         <ResourceDictionary Source="ms-appx:///Controls/App/OffsetButton/OffsetButton.xaml" />
         <ResourceDictionary Source="ms-appx:///Controls/App/BubbleView/BubbleView.xaml" />
         <ResourceDictionary Source="ms-appx:///Controls/App/ProgressButton/ProgressButton.xaml" />
-        <ResourceDictionary Source="ms-appx:///Controls/Player/BiliPlayer/BiliPlayer.xaml" />
-        <ResourceDictionary Source="ms-appx:///Controls/Danmaku/DanmakuView/DanmakuView.xaml" />
         <ResourceDictionary Source="ms-appx:///Controls/App/TwoLineButton/TwoLineButton.xaml" />
         <ResourceDictionary Source="ms-appx:///Controls/App/CenterPopup/CenterPopup.xaml" />
         <ResourceDictionary Source="ms-appx:///Controls/App/IconTextBlock/IconTextBlock.xaml" />
+        <ResourceDictionary Source="ms-appx:///Controls/App/CommonImageEx/CommonImageEx.xaml" />
+        <ResourceDictionary Source="ms-appx:///Controls/Banner/BannerItem/BannerItem.xaml" />
         <ResourceDictionary Source="ms-appx:///Controls/Common/EmotiTextBlock/EmotiTextBlock.xaml" />
         <ResourceDictionary Source="ms-appx:///Controls/Common/VerticalRepeaterView/VerticalRepeaterView.xaml" />
-        <ResourceDictionary Source="ms-appx:///Controls/App/CommonImageEx/CommonImageEx.xaml" />
+        <ResourceDictionary Source="ms-appx:///Controls/Danmaku/DanmakuView/DanmakuView.xaml" />
+        <ResourceDictionary Source="ms-appx:///Controls/Player/BiliPlayer/BiliPlayer.xaml" />
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -435,6 +435,8 @@ namespace Richasy.Bili.Models.Enums
         Av1,
         PlaybackRateEnhancement,
         PlaybackRateEnhancementDescription,
+        GlobalPlaybackRate,
+        GlobalPlaybackRateDescription,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/Models/Models.Enums/App/SettingNames.cs
+++ b/src/Models/Models.Enums/App/SettingNames.cs
@@ -65,6 +65,7 @@ namespace Richasy.Bili.Models.Enums
         OpenScreenshotAfterSave,
         CopyScreenshotAfterSave,
         PlaybackRateEnhancement,
+        GlobalPlaybackRate,
 #pragma warning disable SA1602 // Enumeration items should be documented
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -994,7 +994,12 @@ namespace Richasy.Bili.ViewModels.Uwp
             var isEnhancement = _settingsToolkit.ReadLocalSetting(SettingNames.PlaybackRateEnhancement, false);
             MaxPlaybackRate = isEnhancement ? 6d : 3d;
             PlaybackRateStep = isEnhancement ? 0.2 : 0.1;
-            PlaybackRate = 1d;
+
+            var isGlobal = _settingsToolkit.ReadLocalSetting(SettingNames.GlobalPlaybackRate, false);
+            if (!isGlobal)
+            {
+                PlaybackRate = 1d;
+            }
         }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -66,7 +66,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             PlaybackRate = _settingsToolkit.ReadLocalSetting(SettingNames.PlaybackRate, 1d);
             IsOnlyShowIndex = _settingsToolkit.ReadLocalSetting(SettingNames.IsOnlyShowIndex, false);
             InitializeTimer();
-            this.PropertyChanged += OnPropertyChanged;
+            PropertyChanged += OnPropertyChanged;
             LiveDanmakuCollection.CollectionChanged += OnLiveDanmakuCollectionChanged;
             Controller.LiveMessageReceived += OnLiveMessageReceivedAsync;
             Controller.LoggedOut += OnUserLoggedOut;

--- a/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.Properties.cs
@@ -137,6 +137,12 @@ namespace Richasy.Bili.ViewModels.Uwp
         public bool PlaybackRateEnhancement { get; set; }
 
         /// <summary>
+        /// 是否开启全局播放速率.
+        /// </summary>
+        [Reactive]
+        public bool GlobalPlaybackRate { get; set; }
+
+        /// <summary>
         /// 应用版本.
         /// </summary>
         [Reactive]

--- a/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/SettingViewModel/SettingViewModel.cs
@@ -44,6 +44,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             IsCopyScreenshot = ReadSetting(SettingNames.CopyScreenshotAfterSave, true);
             IsOpenScreenshotFile = ReadSetting(SettingNames.OpenScreenshotAfterSave, false);
             PlaybackRateEnhancement = ReadSetting(SettingNames.PlaybackRateEnhancement, false);
+            GlobalPlaybackRate = ReadSetting(SettingNames.GlobalPlaybackRate, false);
             PreferCodecInit();
             DoubleClickInit();
             PlayerModeInit();
@@ -108,6 +109,9 @@ namespace Richasy.Bili.ViewModels.Uwp
                     break;
                 case nameof(PlaybackRateEnhancement):
                     WriteSetting(SettingNames.PlaybackRateEnhancement, PlaybackRateEnhancement);
+                    break;
+                case nameof(GlobalPlaybackRate):
+                    WriteSetting(SettingNames.GlobalPlaybackRate, GlobalPlaybackRate);
                     break;
                 default:
                     break;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #849 

添加新的设置用以开启全局播放速率，该设置默认关闭

![image](https://user-images.githubusercontent.com/27713596/159244846-022a5142-8cdc-456d-89d2-561e2e4390cc.png)

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

遵循默认的播放速率延续策略，打开一个新的视频时重置播放速率为1

## 新的行为是什么？

支持用户自行设置是否使用全局播放速率，用以在多个视频中使用相同的播放速率

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
