### PR TITLE
修复按下空格键有时无法播放/暂停的问题

### DIFF
--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.Properties.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.Properties.cs
@@ -65,6 +65,7 @@ namespace Richasy.Bili.App.Controls
         private DispatcherTimer _danmakuTimer;
         private DispatcherTimer _cursorTimer;
         private DispatcherTimer _normalTimer;
+        private DispatcherTimer _focusTimer;
         private DanmakuView _danmakuView;
         private ToggleButton _fullWindowPlayModeButton;
         private ToggleButton _fullScreenPlayModeButton;

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
@@ -40,8 +40,10 @@ namespace Richasy.Bili.App.Controls
             InitializeDanmakuTimer();
             InitializeCursorTimer();
             InitializeNormalTimer();
+            InitializeFocusTimer();
 
             _normalTimer.Start();
+            _focusTimer.Start();
         }
 
         /// <summary>
@@ -406,6 +408,8 @@ namespace Richasy.Bili.App.Controls
                 default:
                     break;
             }
+
+            _playPauseButton.Focus(FocusState.Programmatic);
         }
 
         private void OnDanmakuListAdded(object sender, List<DanmakuElem> e)
@@ -510,6 +514,8 @@ namespace Richasy.Bili.App.Controls
                     _danmakuView.ResumeDanmaku();
                     Hide();
                 }
+
+                _playPauseButton.Focus(FocusState.Programmatic);
             });
         }
 
@@ -545,6 +551,16 @@ namespace Richasy.Bili.App.Controls
                 _normalTimer = new DispatcherTimer();
                 _normalTimer.Interval = TimeSpan.FromSeconds(0.5);
                 _normalTimer.Tick += OnNormalTimerTick;
+            }
+        }
+
+        private void InitializeFocusTimer()
+        {
+            if (_focusTimer == null)
+            {
+                _focusTimer = new DispatcherTimer();
+                _focusTimer.Interval = TimeSpan.FromSeconds(2);
+                _focusTimer.Tick += OnFocusTimerTick;
             }
         }
 
@@ -756,6 +772,14 @@ namespace Richasy.Bili.App.Controls
             else if (_tempMessageHoldSeconds != -1)
             {
                 _tempMessageHoldSeconds += 0.5;
+            }
+        }
+
+        private void OnFocusTimerTick(object sender, object e)
+        {
+            if (ViewModel.PlayerDisplayMode != PlayerDisplayMode.Default)
+            {
+                _playPauseButton.Focus(FocusState.Programmatic);
             }
         }
 

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
@@ -559,7 +559,7 @@ namespace Richasy.Bili.App.Controls
             if (_focusTimer == null)
             {
                 _focusTimer = new DispatcherTimer();
-                _focusTimer.Interval = TimeSpan.FromSeconds(2);
+                _focusTimer.Interval = TimeSpan.FromSeconds(5);
                 _focusTimer.Tick += OnFocusTimerTick;
             }
         }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #683 

1. 在播放器视频状态更改时（缓冲/播放/暂停等）重置播放按钮焦点
2. 在进入全窗口/全屏/小窗播放时，每5s重置一次焦点

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

焦点转移后，按下空格键无法被视作点击播放按钮

## 新的行为是什么？

并不将空格键与播放按钮强关联，而是通过焦点转移的方式，让焦点在绝大多数情况下都会在播放按钮上，同时避免干预正常的键盘导航。

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
