### PR TITLE
替换弹幕显隐图标

### DIFF
--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
@@ -537,6 +537,7 @@
                                                         x:Name="ToggleDanmakuBarVisibilityButton"
                                                         AutomationProperties.Name="{loc:LocaleLocator Name=ToggleDanmakuBarVisibility}"
                                                         Style="{StaticResource MTCButtonStyle}"
+                                                        BorderThickness="0,0,1,0"
                                                         ToolTipService.ToolTip="{loc:LocaleLocator Name=ToggleDanmakuBarVisibility}">
                                                         <Button.Content>
                                                             <Grid>

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
@@ -542,11 +542,11 @@
                                                             <Grid>
                                                                 <icons:RegularFluentIcon
                                                                     FontSize="16"
-                                                                    Symbol="ChevronDown16"
+                                                                    Symbol="TextboxMore24"
                                                                     Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsShowDanmakuBar, Converter={StaticResource BoolToVisibilityReverseConverter}}" />
                                                                 <icons:RegularFluentIcon
                                                                     FontSize="16"
-                                                                    Symbol="ChevronUp16"
+                                                                    Symbol="ArrowCollapseAll20"
                                                                     Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsShowDanmakuBar, Converter={StaticResource BoolToVisibilityConverter}}" />
                                                             </Grid>
                                                         </Button.Content>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #538

替换弹幕控制器的显示/隐藏标识图标，并使用按钮右边框作为分割线进一步强调按钮


## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

使用上下箭头表示打开/折叠弹幕控制器

## 新的行为是什么？

使用弹幕+省略号的图标表示弹幕控制器的显示，向上箭头+双横线表示隐藏，并使用按钮右边框作为分割线进一步强调按钮
![image](https://user-images.githubusercontent.com/27713596/159265943-342a1aca-a37d-427f-876e-e15746e66d2d.png)

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
