### PR TITLE
修复窄视图下关注直播间无法点击的问题

### DIFF
--- a/src/App/Controls/Live/FollowLiveItem.xaml
+++ b/src/App/Controls/Live/FollowLiveItem.xaml
@@ -23,12 +23,12 @@
                 IsShowPlayCount="False"
                 IsShowReplayCount="False"
                 IsShowViewerCount="True"
-                Orientation="Horizontal"
                 ItemClick="OnItemClick"
+                Orientation="Horizontal"
                 ViewModel="{x:Bind ViewModel, Mode=OneWay}" />
         </Grid>
         <Grid x:Name="VerticalContainer" Visibility="Collapsed">
-            <local:CardPanel Width="120" Click="OnCardClickAsync">
+            <local:CardPanel Width="120" Click="OnCardClick">
                 <Grid Padding="12" RowSpacing="12">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -38,6 +38,7 @@
                     <local:UserAvatar
                         Width="52"
                         Height="52"
+                        HorizontalAlignment="Center"
                         Avatar="{x:Bind ViewModel.Publisher.Avatar, Mode=OneWay}"
                         DecodeSize="40"
                         UserName="{x:Bind ViewModel.Publisher.Name, Mode=OneWay}" />

--- a/src/App/Controls/Live/FollowLiveItem.xaml.cs
+++ b/src/App/Controls/Live/FollowLiveItem.xaml.cs
@@ -66,9 +66,7 @@ namespace Richasy.Bili.App.Controls
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)
-        {
-            CheckOrientation();
-        }
+            => CheckOrientation();
 
         private void CheckOrientation()
         {
@@ -87,15 +85,13 @@ namespace Richasy.Bili.App.Controls
             }
         }
 
-        private async void OnCardClickAsync(object sender, RoutedEventArgs e)
+        private void OnCardClick(object sender, RoutedEventArgs e)
         {
             ItemClick?.Invoke(this, EventArgs.Empty);
-            await PlayerViewModel.Instance.LoadAsync(ViewModel);
+            AppViewModel.Instance.OpenPlayer(ViewModel);
         }
 
         private void OnItemClick(object sender, VideoViewModel e)
-        {
-            ItemClick?.Invoke(this, EventArgs.Empty);
-        }
+            => ItemClick?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/App/Controls/Live/FollowLiveView.xaml
+++ b/src/App/Controls/Live/FollowLiveView.xaml
@@ -57,18 +57,6 @@
                 FontSize="16"
                 Text="{loc:LocaleLocator Name=FollowLiveRoom}"
                 TextTrimming="CharacterEllipsis" />
-
-            <!--<Button
-                x:Name="SeeAllButton"
-                Grid.Column="1"
-                VerticalAlignment="Center">
-                <StackPanel Orientation="Horizontal" Spacing="4">
-                    <local:IconTextBlock
-                        Spacing="8"
-                        Symbol="List16"
-                        Text="{loc:LocaleLocator Name=SeeAll}" />
-                </StackPanel>
-            </Button>-->
         </Grid>
 
 
@@ -88,8 +76,8 @@
                     <DataTemplate x:DataType="uwp:VideoViewModel">
                         <local:FollowLiveItem
                             DataContext="{x:Bind}"
-                            Orientation="Horizontal"
                             ItemClick="OnItemClick"
+                            Orientation="Horizontal"
                             ViewModel="{x:Bind}" />
                     </DataTemplate>
                 </muxc:ItemsRepeater.ItemTemplate>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #880 

修复窄视图下关注直播间无法点击的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

在窄视图下点击关注的直播间后，页面没有跳转，但是直播已经开始播放

## 新的行为是什么？

点击后正常跳转播放页面

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
