### PR TITLE
支持鼠标中键及侧键返回

### DIFF
--- a/src/App/Pages/Overlay/PlayerPage.xaml
+++ b/src/App/Pages/Overlay/PlayerPage.xaml
@@ -6,7 +6,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:loc="using:Richasy.Bili.Locator.Uwp"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:pages="using:Richasy.Bili.App.Pages"
     mc:Ignorable="d">
 

--- a/src/App/Pages/Overlay/PlayerPage.xaml.cs
+++ b/src/App/Pages/Overlay/PlayerPage.xaml.cs
@@ -80,25 +80,6 @@ namespace Richasy.Bili.App.Pages.Overlay
             CoreViewModel.IsOverLayerExtendToTitleBar = false;
         }
 
-        /// <inheritdoc/>
-        protected override void OnPointerReleased(PointerRoutedEventArgs e)
-        {
-            if (e.GetCurrentPoint(this).Properties.PointerUpdateKind == Windows.UI.Input.PointerUpdateKind.XButton1Released)
-            {
-                e.Handled = true;
-                if (ViewModel.PlayerDisplayMode != PlayerDisplayMode.Default)
-                {
-                    ViewModel.PlayerDisplayMode = PlayerDisplayMode.Default;
-                }
-                else
-                {
-                    CoreViewModel.Back();
-                }
-            }
-
-            base.OnPointerReleased(e);
-        }
-
         private async void OnLoadedAsync(object sender, RoutedEventArgs e)
         {
             ViewModel.PropertyChanged += OnViewModelPropertyChanged;

--- a/src/App/Pages/RootPage.xaml
+++ b/src/App/Pages/RootPage.xaml
@@ -10,7 +10,7 @@
     muxc:BackdropMaterial.ApplyToRootOrPageBackground="True"
     mc:Ignorable="d">
 
-    <Grid>
+    <Grid Background="{ThemeResource SystemControlTransparentBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />

--- a/src/App/Pages/RootPage.xaml.cs
+++ b/src/App/Pages/RootPage.xaml.cs
@@ -94,7 +94,9 @@ namespace Richasy.Bili.App.Pages
         /// <inheritdoc/>
         protected override void OnPointerReleased(PointerRoutedEventArgs e)
         {
-            if (e.GetCurrentPoint(this).Properties.PointerUpdateKind == Windows.UI.Input.PointerUpdateKind.XButton1Released)
+            var kind = e.GetCurrentPoint(this).Properties.PointerUpdateKind;
+            if (kind == Windows.UI.Input.PointerUpdateKind.XButton1Released
+                || kind == Windows.UI.Input.PointerUpdateKind.MiddleButtonReleased)
             {
                 e.Handled = true;
                 CoreViewModel.Back();


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #884 

支持按下鼠标侧键或鼠标中键来进行快速返回，其行为如下：

1. 有居中弹窗的，关闭居中弹窗
2. 正在播放视频，则关闭视频
3. 进入二级页面的，退出二级页面

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

鼠标侧键在二级页面可以返回，但在其它页面，不完全支持返回。

## 新的行为是什么？

完善鼠标侧键返回，并支持中键返回

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
