### PR TITLE
超时自动隐藏历史记录提醒

### DIFF
--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.Properties.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.Properties.cs
@@ -102,9 +102,9 @@ namespace Richasy.Bili.App.Controls
         private Button _decreaseVolumeButton;
         private int _segmentIndex;
         private double _cursorStayTime;
+        private double _historyMessageHoldSeconds;
         private double _tempMessageHoldSeconds;
 
-        private Point _manipulationStartPoint = new Point(0, 0);
         private double _manipulationDeltaX = 0d;
         private double _manipulationDeltaY = 0d;
         private double _manipulationProgress = 0d;

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
@@ -786,6 +786,16 @@ namespace Richasy.Bili.App.Controls
             {
                 _tempMessageHoldSeconds += 0.5;
             }
+
+            if (ViewModel.IsShowHistory)
+            {
+                _historyMessageHoldSeconds += 0.5;
+                if (_historyMessageHoldSeconds > 4)
+                {
+                    ViewModel.IsShowHistory = false;
+                    _historyMessageHoldSeconds = 0;
+                }
+            }
         }
 
         private void OnFocusTimerTick(object sender, object e)
@@ -802,7 +812,6 @@ namespace Richasy.Bili.App.Controls
             _manipulationProgress = 0;
             _manipulationDeltaX = 0;
             _manipulationDeltaY = 0;
-            _manipulationStartPoint = new Point(0, 0);
             _manipulationType = PlayerManipulationType.None;
 
             if (_manipulationBeforeIsPlay)
@@ -875,7 +884,6 @@ namespace Richasy.Bili.App.Controls
         private void OnInteractionControlManipulationStarted(object sender, ManipulationStartedRoutedEventArgs e)
         {
             var player = ViewModel.BiliPlayer.MediaPlayer;
-            _manipulationStartPoint = e.Position;
             _manipulationProgress = player.PlaybackSession.Position.TotalSeconds;
             _manipulationVolume = player.Volume * 100.0;
             _manipulationBeforeIsPlay = ViewModel.PlayerStatus == PlayerStatus.Playing;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #705 

超过4秒自动隐藏历史记录提醒

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

对于有历史记录的视频，提醒不会消失，直到用户手动关闭

## 新的行为是什么？

超过4秒用户没有关闭或跳转历史记录，则自动隐藏

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
