### PR TITLE
支持连续播放稍后再看列表

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -46,6 +46,9 @@
     <Compile Include="Controls\App\CenterPopup\CenterPopup.Properties.cs" />
     <Compile Include="Controls\App\IconTextBlock\IconTextBlock.cs" />
     <Compile Include="Controls\Common\VerticalRepeaterView\VerticalRepeaterView.Properties.cs" />
+    <Compile Include="Controls\Player\Related\ViewLaterView.xaml.cs">
+      <DependentUpon>ViewLaterView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\Settings\ScreenshotSettingSection.xaml.cs">
       <DependentUpon>ScreenshotSettingSection.xaml</DependentUpon>
     </Compile>
@@ -562,6 +565,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Controls\Common\VerticalRepeaterView\VerticalRepeaterView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\Player\Related\ViewLaterView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/App/Controls/App/CardPanel/CardPanel.Properties.cs
+++ b/src/App/Controls/App/CardPanel/CardPanel.Properties.cs
@@ -184,7 +184,6 @@ namespace Richasy.Bili.App.Controls
             get { return (double)GetValue(StrokeThicknessProperty); }
             set { SetValue(StrokeThicknessProperty, value); }
         }
-
 #pragma warning restore SA1600 // Elements should be documented
     }
 }

--- a/src/App/Controls/App/CardPanel/CardPanel.cs
+++ b/src/App/Controls/App/CardPanel/CardPanel.cs
@@ -44,11 +44,7 @@ namespace Richasy.Bili.App.Controls
         /// <inheritdoc/>
         protected override void OnToggle()
         {
-            if (!IsEnableCheck)
-            {
-                IsChecked = false;
-            }
-            else
+            if (IsEnableCheck)
             {
                 IsChecked = !IsChecked;
             }

--- a/src/App/Controls/App/CommonImageEx/CommonImageEx.cs
+++ b/src/App/Controls/App/CommonImageEx/CommonImageEx.cs
@@ -16,7 +16,7 @@ namespace Richasy.Bili.App.Controls
         /// <see cref="ImageUrl"/>的依赖属性.
         /// </summary>
         public static readonly DependencyProperty ImageUrlProperty =
-            DependencyProperty.Register(nameof(ImageUrl), typeof(string), typeof(CommonImageEx), new PropertyMetadata(null, new PropertyChangedCallback(OnImageUrlChanged)));
+            DependencyProperty.Register(nameof(ImageUrl), typeof(string), typeof(CommonImageEx), new PropertyMetadata(null));
 
         /// <summary>
         /// <see cref="Stretch"/>的依赖属性.
@@ -30,15 +30,12 @@ namespace Richasy.Bili.App.Controls
         public static readonly DependencyProperty RetryCountProperty =
             DependencyProperty.Register(nameof(RetryCount), typeof(int), typeof(CommonImageEx), new PropertyMetadata(2));
 
-        private ImageEx _image;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="CommonImageEx"/> class.
         /// </summary>
         public CommonImageEx()
         {
             DefaultStyleKey = typeof(CommonImageEx);
-            Loaded += OnLoaded;
         }
 
         /// <summary>
@@ -66,28 +63,6 @@ namespace Richasy.Bili.App.Controls
         {
             get { return (int)GetValue(RetryCountProperty); }
             set { SetValue(RetryCountProperty, value); }
-        }
-
-        /// <inheritdoc/>
-        protected override void OnApplyTemplate()
-            => _image = GetTemplateChild("Image") as ImageEx;
-
-        private static void OnImageUrlChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var instance = d as CommonImageEx;
-
-            if (instance._image != null)
-            {
-                instance._image.Source = e.NewValue;
-            }
-        }
-
-        private void OnLoaded(object sender, RoutedEventArgs e)
-        {
-            if (_image != null && !string.IsNullOrEmpty(ImageUrl))
-            {
-                _image.Source = ImageUrl;
-            }
         }
     }
 }

--- a/src/App/Controls/App/CommonImageEx/CommonImageEx.xaml
+++ b/src/App/Controls/App/CommonImageEx/CommonImageEx.xaml
@@ -14,6 +14,7 @@
                         LazyLoadingEnabled="True"
                         RetryCount="{TemplateBinding RetryCount}"
                         RetryDelay="0:0:5"
+                        Source="{TemplateBinding ImageUrl}"
                         Stretch="{TemplateBinding Stretch}">
                         <hn:ImageEx.LoadingTemplate>
                             <DataTemplate>

--- a/src/App/Controls/Common/VideoItem.xaml
+++ b/src/App/Controls/Common/VideoItem.xaml
@@ -40,7 +40,9 @@
     <local:CardPanel
         x:Name="RootCard"
         AutomationProperties.Name="{x:Bind ViewModel.Title, Mode=OneWay}"
-        Click="OnContainerClickAsync">
+        Click="OnContainerClickAsync"
+        IsChecked="{x:Bind ViewModel.IsSelected, Mode=OneWay}"
+        IsEnableCheck="False">
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LayoutGroup">

--- a/src/App/Controls/Common/VideoItem.xaml.cs
+++ b/src/App/Controls/Common/VideoItem.xaml.cs
@@ -284,7 +284,11 @@ namespace Richasy.Bili.App.Controls
 
         private void OnContainerClickAsync(object sender, RoutedEventArgs e)
         {
-            AppViewModel.OpenPlayer(ViewModel);
+            if (!ViewModel.IsSelected)
+            {
+                AppViewModel.OpenPlayer(ViewModel);
+            }
+
             ItemClick?.Invoke(this, ViewModel);
         }
 

--- a/src/App/Controls/Player/PlayerRelatedView.xaml
+++ b/src/App/Controls/Player/PlayerRelatedView.xaml
@@ -56,6 +56,10 @@
             SelectionChanged="OnNavSelectionChanged">
             <muxc:NavigationView.MenuItems>
                 <muxc:NavigationViewItem
+                    x:Name="ViewLaterItem"
+                    Content="{loc:LocaleLocator Name=ViewLater}"
+                    Visibility="{x:Bind ViewModel.IsShowViewLater, Mode=OneWay}" />
+                <muxc:NavigationViewItem
                     x:Name="PartsItem"
                     Content="{loc:LocaleLocator Name=Parts}"
                     Visibility="{x:Bind ViewModel.IsShowParts, Mode=OneWay}" />
@@ -86,6 +90,10 @@
             </muxc:NavigationView.MenuItems>
 
             <Grid x:Name="DetailGrid" Width="360">
+                <related:ViewLaterView
+                    x:Name="ViewLaterVideoView"
+                    x:Load="{x:Bind ViewModel.IsShowViewLater, Mode=OneWay}"
+                    Visibility="Collapsed" />
                 <related:RelatedVideoView
                     x:Name="RelatedVideoView"
                     x:Load="{x:Bind ViewModel.IsShowRelatedVideos, Mode=OneWay}"

--- a/src/App/Controls/Player/PlayerRelatedView.xaml.cs
+++ b/src/App/Controls/Player/PlayerRelatedView.xaml.cs
@@ -23,9 +23,7 @@ namespace Richasy.Bili.App.Controls
         }
 
         private void OnViewModelLoaded(object sender, EventArgs e)
-        {
-            InitializeLayoutAsync();
-        }
+            => InitializeLayoutAsync();
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
@@ -45,6 +43,10 @@ namespace Richasy.Bili.App.Controls
                 if (!string.IsNullOrEmpty(ViewModel.InitializeSection))
                 {
                     InitializeSelectedSection();
+                }
+                else if (ViewModel.IsShowViewLater)
+                {
+                    Nav.SelectedItem = ViewLaterItem;
                 }
                 else if (ViewModel.IsPgc && ViewModel.IsCurrentEpisodeInPgcSection)
                 {
@@ -111,6 +113,12 @@ namespace Richasy.Bili.App.Controls
 
         private async void InitializeLayoutAsync()
         {
+            if (ViewModel.IsShowViewLater && ViewLaterVideoView != null)
+            {
+                ViewLaterVideoView.Visibility = Nav.SelectedItem == ViewLaterItem ?
+                Visibility.Visible : Visibility.Collapsed;
+            }
+
             if (ViewModel.IsShowRelatedVideos && RelatedVideoView != null)
             {
                 RelatedVideoView.Visibility = Nav.SelectedItem == RelatedViedeosItem ?
@@ -165,6 +173,9 @@ namespace Richasy.Bili.App.Controls
             {
                 case AppConstants.ReplySection:
                     Nav.SelectedItem = ReplyItem;
+                    break;
+                case AppConstants.ViewLaterSection:
+                    Nav.SelectedItem = ViewLaterItem;
                     break;
                 default:
                     break;

--- a/src/App/Controls/Player/Related/EpisodeView.xaml.cs
+++ b/src/App/Controls/Player/Related/EpisodeView.xaml.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
+using System.Threading.Tasks;
 using Richasy.Bili.ViewModels.Uwp;
 using Windows.UI.Xaml;
 
@@ -28,6 +29,8 @@ namespace Richasy.Bili.App.Controls.Player.Related
             }
             else
             {
+                data.IsSelected = false;
+                await Task.Delay(100);
                 data.IsSelected = true;
             }
         }

--- a/src/App/Controls/Player/Related/PgcSectionView.xaml
+++ b/src/App/Controls/Player/Related/PgcSectionView.xaml
@@ -28,7 +28,7 @@
                                     Click="OnEpisodeItemClickAsync"
                                     DataContext="{x:Bind}"
                                     IsChecked="{x:Bind IsSelected, Mode=OneWay}"
-                                    IsEnableCheck="True"
+                                    IsEnableCheck="False"
                                     IsEnableHoverAnimation="False">
                                     <Grid
                                         Padding="12"

--- a/src/App/Controls/Player/Related/PgcSectionView.xaml.cs
+++ b/src/App/Controls/Player/Related/PgcSectionView.xaml.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
+using System.Threading.Tasks;
 using Richasy.Bili.ViewModels.Uwp;
 
 namespace Richasy.Bili.App.Controls.Player.Related
@@ -25,10 +26,6 @@ namespace Richasy.Bili.App.Controls.Player.Related
             if (!data.Data.Id.ToString().Equals(ViewModel.EpisodeId))
             {
                 await ViewModel.LoadAsync(data.Data);
-            }
-            else
-            {
-                data.IsSelected = true;
             }
         }
     }

--- a/src/App/Controls/Player/Related/ViewLaterView.xaml
+++ b/src/App/Controls/Player/Related/ViewLaterView.xaml
@@ -1,0 +1,35 @@
+﻿<controls:PlayerComponent
+    x:Class="Richasy.Bili.App.Controls.Player.Related.ViewLaterView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Richasy.Bili.App.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:Richasy.Bili.App.Controls.Player.Related"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uwp="using:Richasy.Bili.ViewModels.Uwp"
+    d:DesignHeight="300"
+    d:DesignWidth="400"
+    mc:Ignorable="d">
+
+    <ScrollViewer
+        HorizontalScrollMode="Disabled"
+        VerticalScrollBarVisibility="Hidden"
+        VerticalScrollMode="{x:Bind VerticalScrollMode, Mode=OneWay}">
+        <controls:VerticalRepeaterView
+            EnableDetectParentScrollViewer="False"
+            HeaderVisibility="Collapsed"
+            ItemOrientation="Horizontal"
+            ItemsSource="{x:Bind ViewModel.ViewLaterVideoCollection}">
+            <controls:VerticalRepeaterView.ItemTemplate>
+                <DataTemplate x:DataType="uwp:VideoViewModel">
+                    <controls:VideoItem
+                        MaxHeight="100"
+                        HorizontalCoverWidth="120"
+                        IsShowDanmakuCount="True"
+                        IsShowPlayCount="True"
+                        ViewModel="{x:Bind}" />
+                </DataTemplate>
+            </controls:VerticalRepeaterView.ItemTemplate>
+        </controls:VerticalRepeaterView>
+    </ScrollViewer>
+</controls:PlayerComponent>

--- a/src/App/Controls/Player/Related/ViewLaterView.xaml.cs
+++ b/src/App/Controls/Player/Related/ViewLaterView.xaml.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Richasy. All rights reserved.
+
+namespace Richasy.Bili.App.Controls.Player.Related
+{
+    /// <summary>
+    /// 稍后再看视频列表.
+    /// </summary>
+    public sealed partial class ViewLaterView : PlayerComponent
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ViewLaterView"/> class.
+        /// </summary>
+        public ViewLaterView() => this.InitializeComponent();
+    }
+}

--- a/src/App/Pages/Overlay/PlayerPage.xaml.cs
+++ b/src/App/Pages/Overlay/PlayerPage.xaml.cs
@@ -52,18 +52,7 @@ namespace Richasy.Bili.App.Pages.Overlay
         {
             if (e.Parameter != null)
             {
-                if (e.Parameter is VideoViewModel videoVM)
-                {
-                    _navigateVM = videoVM;
-                }
-                else if (e.Parameter is SeasonViewModel ssVM)
-                {
-                    _navigateVM = ssVM;
-                }
-                else if (e.Parameter is CurrentPlayingRecord record)
-                {
-                    _navigateVM = record;
-                }
+                _navigateVM = e.Parameter;
 
                 if (IsLoaded)
                 {
@@ -77,6 +66,14 @@ namespace Richasy.Bili.App.Pages.Overlay
         {
             _navigateVM = null;
             EnterDefaultModeAsync();
+            if (ViewModel.IsShowViewLater)
+            {
+                foreach (var item in ViewModel.ViewLaterVideoCollection)
+                {
+                    item.IsSelected = false;
+                }
+            }
+
             CoreViewModel.IsOverLayerExtendToTitleBar = false;
         }
 

--- a/src/App/Pages/Overlay/ViewLaterPage.xaml
+++ b/src/App/Pages/Overlay/ViewLaterPage.xaml
@@ -57,6 +57,14 @@
                             <controls:VerticalRepeaterView.AdditionalContent>
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <Button
+                                        x:Name="PlayAllButton"
+                                        Style="{StaticResource AccentButtonStyle}"
+                                        VerticalAlignment="Center"
+                                        Click="OnPlayAllButtonClick"
+                                        Visibility="{x:Bind ViewModel.IsShowEmpty, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
+                                        <controls:IconTextBlock Symbol="Play16" Text="{loc:LocaleLocator Name=PlayAll}" />
+                                    </Button>
+                                    <Button
                                         x:Name="RefreshButton"
                                         VerticalAlignment="Center"
                                         Click="OnRefreshButtonClickAsync">

--- a/src/App/Pages/Overlay/ViewLaterPage.xaml.cs
+++ b/src/App/Pages/Overlay/ViewLaterPage.xaml.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
 using System;
+using System.Linq;
 using Richasy.Bili.App.Controls.Dialogs;
 using Richasy.Bili.Locator.Uwp;
+using Richasy.Bili.Models.App.Constants;
 using Richasy.Bili.Models.Enums;
 using Richasy.Bili.Toolkit.Interfaces;
 using Richasy.Bili.ViewModels.Uwp;
@@ -83,6 +85,24 @@ namespace Richasy.Bili.App.Pages.Overlay
         {
             var vm = (sender as FrameworkElement).DataContext as VideoViewModel;
             await ViewModel.RemoveAsync(vm);
+        }
+
+        private void OnPlayAllButtonClick(object sender, RoutedEventArgs e)
+        {
+            var videoList = ViewModel.VideoCollection.Where(p => p.VideoType == VideoType.Video).ToList();
+            if (videoList.Count > 1)
+            {
+                PlayerViewModel.Instance.InitializeSection = AppConstants.ViewLaterSection;
+                CoreViewModel.OpenPlayer(videoList);
+            }
+            else
+            {
+                var firstVideo = videoList.FirstOrDefault();
+                if (firstVideo != null)
+                {
+                    CoreViewModel.OpenPlayer(firstVideo);
+                }
+            }
         }
     }
 }

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -902,6 +902,9 @@ BV号以 BV 开头，是一串英文数字混合的编号， 如 BV1JL4y1875w</v
   <data name="PgcNotFollow" xml:space="preserve">
     <value>追</value>
   </data>
+  <data name="PlayAll" xml:space="preserve">
+    <value>播放全部</value>
+  </data>
   <data name="PlaybackRate" xml:space="preserve">
     <value>播放速率</value>
   </data>

--- a/src/Models/Models.App/Constants/AppConstants.cs
+++ b/src/Models/Models.App/Constants/AppConstants.cs
@@ -23,6 +23,7 @@ namespace Richasy.Bili.Models.App.Constants
         public const string LinkClickEvent = "LinkClick";
 
         public const string ReplySection = "Reply";
+        public const string ViewLaterSection = "ViewLater";
 
         public const string LastOpenVideoFileName = "LastOpenVideo.json";
         public const string FixedPublisherFolderName = "Fixed publisher";

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -445,6 +445,7 @@ namespace Richasy.Bili.Models.Enums
         AutoNextRelatedVideoDescription,
         PlayNow,
         PlayNextVideo,
+        PlayAll,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -1038,15 +1038,33 @@ namespace Richasy.Bili.ViewModels.Uwp
 
         private bool HasNextVideo()
         {
-            var result = !IsInteraction
+            var result = IsShowViewLater
+                ? ViewLaterVideoCollection.FirstOrDefault(p => p.IsSelected) != ViewLaterVideoCollection.Last()
+                : !IsInteraction
                 && _videoType == VideoType.Video
                 && IsShowRelatedVideos
                 && RelatedVideoCollection.Count > 0;
 
             if (result)
             {
-                var nextVideo = RelatedVideoCollection.First();
-                NextVideoTipText = nextVideo.Title;
+                if (IsShowViewLater)
+                {
+                    var index = ViewLaterVideoCollection.IndexOf(ViewLaterVideoCollection.FirstOrDefault(p => p.IsSelected));
+                    if (index != -1)
+                    {
+                        var nextVideo = ViewLaterVideoCollection[index + 1];
+                        NextVideoTipText = nextVideo.Title;
+                    }
+                    else
+                    {
+                        result = false;
+                    }
+                }
+                else
+                {
+                    var nextVideo = RelatedVideoCollection.First();
+                    NextVideoTipText = nextVideo.Title;
+                }
             }
 
             return result;

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
@@ -312,6 +312,11 @@ namespace Richasy.Bili.ViewModels.Uwp
         public ObservableCollection<double> PlaybackRateNodeCollection { get; }
 
         /// <summary>
+        /// 稍后再看视频集合.
+        /// </summary>
+        public ObservableCollection<VideoViewModel> ViewLaterVideoCollection { get; }
+
+        /// <summary>
         /// 当前分P.
         /// </summary>
         [Reactive]
@@ -436,6 +441,12 @@ namespace Richasy.Bili.ViewModels.Uwp
         /// </summary>
         [Reactive]
         public bool IsShowReply { get; set; }
+
+        /// <summary>
+        /// 是否显示稍后再看列表.
+        /// </summary>
+        [Reactive]
+        public bool IsShowViewLater { get; set; }
 
         /// <summary>
         /// 点赞按钮是否被选中.

--- a/src/ViewModels/ViewModels.Uwp/Common/VideoViewModel/VideoViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/VideoViewModel/VideoViewModel.Properties.cs
@@ -104,6 +104,12 @@ namespace Richasy.Bili.ViewModels.Uwp
         public bool CanShowAvatar { get; set; }
 
         /// <summary>
+        /// 是否被选中.
+        /// </summary>
+        [Reactive]
+        public bool IsSelected { get; set; }
+
+        /// <summary>
         /// 视频类型.
         /// </summary>
         public VideoType VideoType { get; set; }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #713 

在稍后再看页面中加入 `播放全部` 按钮，点击后会将当前页面内的视频作为一个播放列表丢到播放页中，会从第一个开始顺序播放。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

稍后再看仅能单个点击观看

## 新的行为是什么？

可以顺序播放稍后再看列表

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 新组件
  - [x] 对于控件，已将控件放在主项目的 Controls 文件夹内
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
