### PR TITLE
修复稍后再看条目菜单显示异常的问题

### DIFF
--- a/src/App/Controls/Common/VideoCard/VideoCard.cs
+++ b/src/App/Controls/Common/VideoCard/VideoCard.cs
@@ -72,7 +72,14 @@ namespace Richasy.Bili.App.Controls
             instance.CheckOrientation();
         }
 
-        private void OnLoaded(object sender, RoutedEventArgs e) => CheckOrientation();
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            CheckOrientation();
+            if (ContextFlyout != null)
+            {
+                _rootCard.ContextFlyout = null;
+            }
+        }
 
         private void CheckOrientation()
         {

--- a/src/App/Pages/Overlay/HistoryPage.xaml
+++ b/src/App/Pages/Overlay/HistoryPage.xaml
@@ -84,6 +84,7 @@
                                     <controls:VideoCard.ContextFlyout>
                                         <MenuFlyout>
                                             <MenuFlyoutItem
+                                                MinWidth="160"
                                                 Click="OnDeleteItemClickAsync"
                                                 DataContext="{x:Bind}"
                                                 Text="{loc:LocaleLocator Name=Delete}">

--- a/src/App/Pages/Overlay/ViewLaterPage.xaml
+++ b/src/App/Pages/Overlay/ViewLaterPage.xaml
@@ -92,7 +92,10 @@
                                         ViewModel="{x:Bind}">
                                         <controls:VideoCard.ContextFlyout>
                                             <MenuFlyout>
-                                                <MenuFlyoutItem Click="OnRemoveItemClickAsync" Text="{loc:LocaleLocator Name=Remove}">
+                                                <MenuFlyoutItem
+                                                    MinWidth="160"
+                                                    Click="OnRemoveItemClickAsync"
+                                                    Text="{loc:LocaleLocator Name=Remove}">
                                                     <MenuFlyoutItem.Icon>
                                                         <icons:RegularFluentIcon Foreground="{ThemeResource SystemFillColorCriticalBrush}" Symbol="Delete20" />
                                                     </MenuFlyoutItem.Icon>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #908 

修复设置在稍后再看/历史记录上的上下文菜单没有正常显示的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

稍后再看的视频卡片的上下文菜单显示不正确

## 新的行为是什么？

正确显示预期的上下文菜单

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
