### PR TITLE
修复后台会连播关联视频的问题

### DIFF
--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -139,8 +139,6 @@ namespace Richasy.Bili.ViewModels.Uwp
             DanmakuViewModel.Instance.Reset();
             IsPlayInformationError = false;
             IsShowNextVideoTip = false;
-            IsShowViewLater = false;
-            ViewLaterVideoCollection.Clear();
             await ClearInitViewModelAsync();
         }
 
@@ -149,9 +147,8 @@ namespace Richasy.Bili.ViewModels.Uwp
         /// </summary>
         /// <param name="vm">视图模型.</param>
         /// <param name="isRefresh">是否刷新.</param>
-        /// <param name="clearAdditionalList">是否清除附加列表 (比如稍后再看) 的数据.</param>
         /// <returns><see cref="Task"/>.</returns>
-        public async Task LoadAsync(object vm, bool isRefresh = false, bool clearAdditionalList = true)
+        public async Task LoadAsync(object vm, bool isRefresh = false)
         {
             var videoId = string.Empty;
             var seasonId = 0;
@@ -161,12 +158,6 @@ namespace Richasy.Bili.ViewModels.Uwp
             IsPv = false;
 
             CurrentPlayingRecord record = null;
-
-            if (clearAdditionalList)
-            {
-                IsShowViewLater = false;
-                ViewLaterVideoCollection.Clear();
-            }
 
             if (vm is VideoViewModel videoVM)
             {
@@ -227,6 +218,11 @@ namespace Richasy.Bili.ViewModels.Uwp
                     {
                         item.IsSelected = item.VideoId == internalVM.VideoId;
                     }
+                }
+                else
+                {
+                    IsShowViewLater = false;
+                    ViewLaterVideoCollection.Clear();
                 }
             }
         }
@@ -757,7 +753,7 @@ namespace Richasy.Bili.ViewModels.Uwp
                 if (index != -1 && index < ViewLaterVideoCollection.Count)
                 {
                     var nextVideo = ViewLaterVideoCollection[index + 1];
-                    await LoadAsync(nextVideo, clearAdditionalList: false);
+                    await LoadAsync(nextVideo);
                 }
             }
             else if (RelatedVideoCollection.Count > 0)

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -138,6 +138,9 @@ namespace Richasy.Bili.ViewModels.Uwp
             _historyVideoList.Clear();
             DanmakuViewModel.Instance.Reset();
             IsPlayInformationError = false;
+            IsShowNextVideoTip = false;
+            IsShowViewLater = false;
+            ViewLaterVideoCollection.Clear();
             await ClearInitViewModelAsync();
         }
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #925 

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

在出现下一视频提示时退出会导致后台继续播放视频

## 新的行为是什么？

在退出时强制停止继续播放

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

顺带调整点击稍后再看列表的行为，不直接清除列表
