### PR TITLE
修复推荐视频卡片中的元素遮挡问题

### DIFF
--- a/src/App/Controls/Common/VideoCard/VideoCard.xaml
+++ b/src/App/Controls/Common/VideoCard/VideoCard.xaml
@@ -48,6 +48,8 @@
                                         <Setter Target="AdditionalOverlayContainer.VerticalAlignment" Value="Top" />
                                         <Setter Target="AdditionalOverlayContainer.HorizontalAlignment" Value="Left" />
                                         <Setter Target="RootCard.IsEnableHoverAnimation" Value="False" />
+                                        <Setter Target="DescriptionBlock.(Grid.Row)" Value="3" />
+                                        <Setter Target="RootCard.MaxHeight" Value="140" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -111,9 +113,9 @@
 
                                     <Grid
                                         x:Name="AdditionalOverlayContainer"
-                                        Margin="0,0,8,8"
+                                        Margin="0,8,8,0"
                                         HorizontalAlignment="Right"
-                                        VerticalAlignment="Bottom"
+                                        VerticalAlignment="Top"
                                         Visibility="{TemplateBinding AdditionalOverlayContentVisibility}">
                                         <ContentPresenter Content="{TemplateBinding AdditionalOverlayContent}" />
                                     </Grid>
@@ -161,6 +163,7 @@
                                             Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Publisher.Name}" />
                                     </Grid>
                                     <TextBlock
+                                        x:Name="DescriptionBlock"
                                         Style="{StaticResource CaptionTextBlockStyle}"
                                         VerticalAlignment="Center"
                                         Opacity="0.6"


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #909 

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

当存在推荐理由时，用户头像会挡住推荐理由

## 新的行为是什么？

将推荐理由移到卡片上部

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
