### PR TITLE
修复用户视频滚动中条目消失的问题

### DIFF
--- a/src/App/Controls/Common/VideoCard/VideoCard.xaml
+++ b/src/App/Controls/Common/VideoCard/VideoCard.xaml
@@ -49,7 +49,7 @@
                                         <Setter Target="AdditionalOverlayContainer.HorizontalAlignment" Value="Left" />
                                         <Setter Target="RootCard.IsEnableHoverAnimation" Value="False" />
                                         <Setter Target="DescriptionBlock.(Grid.Row)" Value="3" />
-                                        <Setter Target="RootCard.MaxHeight" Value="140" />
+                                        <Setter Target="RootCard.MaxHeight" Value="132" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>

--- a/src/App/Controls/Favorite/FavoriteVideoView.xaml
+++ b/src/App/Controls/Favorite/FavoriteVideoView.xaml
@@ -81,7 +81,6 @@
                         <local:VerticalRepeaterView.ItemTemplate>
                             <DataTemplate x:DataType="uwp:VideoViewModel">
                                 <local:VideoCard
-                                    Height="132"
                                     DataContext="{x:Bind}"
                                     IsShowAvatar="False"
                                     IsShowDanmakuCount="True"

--- a/src/App/Controls/Favorite/PgcFavoritePanel.xaml
+++ b/src/App/Controls/Favorite/PgcFavoritePanel.xaml
@@ -28,7 +28,6 @@
                     <VisualState.Setters>
                         <Setter Target="ContentScrollViewer.Padding" Value="{StaticResource NarrowContainerPadding}" />
                         <Setter Target="PgcView.ItemOrientation" Value="Horizontal" />
-                        <Setter Target="PgcView.ItemTemplate" Value="{StaticResource NarrowSeasonItemTemplate}" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/src/App/Controls/User/UserView.xaml
+++ b/src/App/Controls/User/UserView.xaml
@@ -25,7 +25,6 @@
                 IsShowPlayCount="True"
                 ItemClick="OnVideoCardClick"
                 Orientation="Horizontal"
-                Height="120"
                 ViewModel="{x:Bind}" />
         </DataTemplate>
     </local:CenterPopup.Resources>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #934 

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

在查看用户视频列表时，如果滚动列表，可能会出现条目消失的情况

## 新的行为是什么？

调整布局属性，避免因布局计算失败导致条目无法被渲染

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
