### PR TITLE
修复全屏按钮在退出全屏模式后依然被选中的问题

### DIFF
--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
@@ -181,6 +181,12 @@ namespace Richasy.Bili.App.Controls
         protected override void OnPointerMoved(PointerRoutedEventArgs e)
         {
             Window.Current.CoreWindow.PointerCursor = new Windows.UI.Core.CoreCursor(Windows.UI.Core.CoreCursorType.Arrow, 0);
+
+            if (!_cursorTimer.IsEnabled)
+            {
+                _cursorTimer.Start();
+            }
+
             if (!IsControlPanelShown() && e.Pointer.PointerDeviceType == Windows.Devices.Input.PointerDeviceType.Mouse)
             {
                 Show();

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -17,6 +17,7 @@ using Richasy.Bili.Models.Enums;
 using Richasy.Bili.ViewModels.Uwp.Common;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage.Streams;
+using Windows.UI.ViewManagement;
 using Windows.UI.Xaml.Controls;
 
 namespace Richasy.Bili.ViewModels.Uwp
@@ -76,6 +77,8 @@ namespace Richasy.Bili.ViewModels.Uwp
             TagCollection.CollectionChanged += OnTagCollectionChanged;
             Controller.LiveMessageReceived += OnLiveMessageReceivedAsync;
             Controller.LoggedOut += OnUserLoggedOut;
+
+            ApplicationView.GetForCurrentView().VisibleBoundsChanged += OnAppViewVisibleBoundsChanged;
         }
 
         /// <summary>
@@ -854,5 +857,13 @@ namespace Richasy.Bili.ViewModels.Uwp
 
         private void OnTagCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
             => IsShowTags = TagCollection.Count > 0;
+
+        private void OnAppViewVisibleBoundsChanged(ApplicationView sender, object args)
+        {
+            if (!sender.IsFullScreenMode && PlayerDisplayMode == PlayerDisplayMode.FullScreen)
+            {
+                PlayerDisplayMode = PlayerDisplayMode.FullWindow;
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #930 

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

全屏模式下通过顶部按钮退出全屏，播放器的按钮状态未更改

## 新的行为是什么？

检测应用大小变化，在退出全屏时调整播放器按钮状态

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
