### PR TITLE
修复因播放提示导致的崩溃问题

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Controls\Common\VerticalRepeaterView\VerticalRepeaterView.Properties.cs" />
     <Compile Include="Controls\Common\VideoCard\VideoCard.cs" />
     <Compile Include="Controls\Common\VideoCard\VideoCard.Properties.cs" />
+    <Compile Include="Controls\Player\PlayerTip\PlayerTip.cs" />
     <Compile Include="Controls\Player\Related\ViewLaterView.xaml.cs">
       <DependentUpon>ViewLaterView.xaml</DependentUpon>
     </Compile>
@@ -570,6 +571,10 @@
     <Page Include="Controls\Common\VideoCard\VideoCard.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Controls\Player\PlayerTip\PlayerTip.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Controls\Player\Related\ViewLaterView.xaml">
       <SubType>Designer</SubType>

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -59,7 +59,7 @@ namespace Richasy.Bili.App
         /// <param name="e">Detailed information about the start request and process.</param>
         protected override void OnLaunched(LaunchActivatedEventArgs e)
         {
-            OnLaunchedOrActivated(e);
+            OnLaunchedOrActivatedAsync(e);
         }
 
         /// <summary>
@@ -68,10 +68,10 @@ namespace Richasy.Bili.App
         /// <param name="args">Detailed information about the active request and process.</param>
         protected override void OnActivated(IActivatedEventArgs args)
         {
-            OnLaunchedOrActivated(args);
+            OnLaunchedOrActivatedAsync(args);
         }
 
-        private async void OnLaunchedOrActivated(IActivatedEventArgs e)
+        private async void OnLaunchedOrActivatedAsync(IActivatedEventArgs e)
         {
             // 用于解析Flv视频
             if (RuntimeInformation.ProcessArchitecture != Architecture.Arm64)

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.Properties.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.Properties.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using Richasy.Bili.Models.Enums.App;
 using Richasy.Bili.ViewModels.Uwp;
 using Richasy.Bili.ViewModels.Uwp.Common;
-using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -53,7 +52,7 @@ namespace Richasy.Bili.App.Controls
         private const string SubtitleBlockName = "SubtitleBlock";
         private const string HomeButtonName = "HomeButton";
         private const string BackToDefaultButtonName = "BackToDefaultButton";
-        private const string ContinuePreviousViewButtonName = "ContinuePreviousViewButton";
+        private const string PreviousViewInformerName = "PreviousViewInformer";
         private const string LiveRefreshButtonName = "LiveRefreshButton";
         private const string TempMessageContaienrName = "TempMessageContainer";
         private const string TempMessageBlockName = "TempMessageBlock";
@@ -65,7 +64,7 @@ namespace Richasy.Bili.App.Controls
         private const string DecreasePlayRateButtonName = "DecreasePlayRateButton";
         private const string IncreaseVolumeButtonName = "IncreaseVolumeButton";
         private const string DecreaseVolumeButtonName = "DecreaseVolumeButton";
-        private const string PlayNextVideoButtonName = "PlayNextVideoButton";
+        private const string NextVideoInformerName = "NextVideoInformer";
         private const string VisibilityStateGroupName = "ControlPanelVisibilityStates";
         private const string FormatButtonName = "FormatButtonName";
         private const string LiveQualityButtonName = "LiveQualityButtonName";
@@ -92,7 +91,6 @@ namespace Richasy.Bili.App.Controls
         private Button _danmakuBarVisibilityButton;
         private Button _homeButton;
         private Button _backToDefaultButton;
-        private Button _continuePreviousViewButton;
         private Button _liveRefreshButton;
         private Button _previousEpisodeButton;
         private Button _nextEpisodeButton;
@@ -105,7 +103,8 @@ namespace Richasy.Bili.App.Controls
         private Button _decreasePlayRateButton;
         private Button _increaseVolumeButton;
         private Button _decreaseVolumeButton;
-        private HyperlinkButton _playNextVideoButton;
+        private PlayerTip _previousViewInformer;
+        private PlayerTip _nextVidepInformer;
         private Grid _rootGrid;
         private VisualStateGroup _visibilityStateGroup;
         private Button _formatButton;

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
@@ -82,7 +82,6 @@ namespace Richasy.Bili.App.Controls
             _danmakuBarVisibilityButton = GetTemplateChild(DanmakuBarVisibilityButtonName) as Button;
             _homeButton = GetTemplateChild(HomeButtonName) as Button;
             _backToDefaultButton = GetTemplateChild(BackToDefaultButtonName) as Button;
-            _continuePreviousViewButton = GetTemplateChild(ContinuePreviousViewButtonName) as Button;
             _liveRefreshButton = GetTemplateChild(LiveRefreshButtonName) as Button;
             _previousEpisodeButton = GetTemplateChild(PreviousEpisodeButtonName) as Button;
             _nextEpisodeButton = GetTemplateChild(NextEpisodeButtonName) as Button;
@@ -95,7 +94,8 @@ namespace Richasy.Bili.App.Controls
             _decreasePlayRateButton = GetTemplateChild(DecreasePlayRateButtonName) as Button;
             _increaseVolumeButton = GetTemplateChild(IncreaseVolumeButtonName) as Button;
             _decreaseVolumeButton = GetTemplateChild(DecreaseVolumeButtonName) as Button;
-            _playNextVideoButton = GetTemplateChild(PlayNextVideoButtonName) as HyperlinkButton;
+            _nextVidepInformer = GetTemplateChild(NextVideoInformerName) as PlayerTip;
+            _previousViewInformer = GetTemplateChild(PreviousViewInformerName) as PlayerTip;
             _formatButton = GetTemplateChild(FormatButtonName) as Button;
             _liveQualityButton = GetTemplateChild(LiveQualityButtonName) as Button;
             _rootGrid = GetTemplateChild(RootGridName) as Grid;
@@ -114,7 +114,6 @@ namespace Richasy.Bili.App.Controls
             _homeButton.Click += OnHomeButtonClickAsync;
             _backToDefaultButton.Click += OnBackButtonClick;
             _liveRefreshButton.Click += OnLiveRefreshButtonClickAsync;
-            _continuePreviousViewButton.Click += OnContinuePreviousViewButtonClickAsync;
             _previousEpisodeButton.Click += OnPreviousEpisodeButtonClickAsync;
             _nextEpisodeButton.Click += OnNextEpisodeButtonClickAsync;
             _screenshotButton.Click += OnScreenshotButtonClickAsync;
@@ -123,7 +122,8 @@ namespace Richasy.Bili.App.Controls
             _decreasePlayRateButton.Click += OnDecreasePlayRateButtonClick;
             _increaseVolumeButton.Click += OnIncreaseVolumeButtonClick;
             _decreaseVolumeButton.Click += OnDecreaseVolumeButtonClick;
-            _playNextVideoButton.Click += OnPlayNextVideoButtonClickAsync;
+            _previousViewInformer.ActionClick += OnContinuePreviousViewButtonClickAsync;
+            _nextVidepInformer.ActionClick += OnPlayNextVideoButtonClickAsync;
 
             if (_formatListView != null)
             {
@@ -352,7 +352,7 @@ namespace Richasy.Bili.App.Controls
             await ViewModel.BackToInteractionStartAsync();
         }
 
-        private async void OnContinuePreviousViewButtonClickAsync(object sender, RoutedEventArgs e)
+        private async void OnContinuePreviousViewButtonClickAsync(object sender, EventArgs e)
         {
             ViewModel.IsShowHistoryTip = false;
             ViewModel.HistoryTipText = string.Empty;
@@ -1011,7 +1011,7 @@ namespace Richasy.Bili.App.Controls
             }
         }
 
-        private async void OnPlayNextVideoButtonClickAsync(object sender, RoutedEventArgs e)
+        private async void OnPlayNextVideoButtonClickAsync(object sender, EventArgs e)
         {
             ViewModel.IsShowNextVideoTip = false;
             _nextVideoHoldSeconds = 0;

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
@@ -66,13 +66,6 @@
         x:Key="MediaControlButtonStyle"
         BasedOn="{StaticResource DefaultButtonStyle}"
         TargetType="Button" />
-    <Style x:Key="MediaControlInfoBarStyle" TargetType="muxc:InfoBar">
-        <Setter Property="Background" Value="{ThemeResource MediaTransportControlsPanelBackground}" />
-        <Setter Property="BorderBrush" Value="{ThemeResource MediaTransportControlsBorderBrush}" />
-        <Setter Property="IsClosable" Value="True" />
-        <Setter Property="IsIconVisible" Value="False" />
-        <Setter Property="RenderTransformOrigin" Value="0.5,0.5" />
-    </Style>
 
     <Style BasedOn="{StaticResource DefaultMTCStyle}" TargetType="local:BiliPlayerTransportControls" />
 
@@ -425,41 +418,24 @@
                                     </Grid>
                                 </Grid>
                                 <Border x:Name="PreviousViewInformer_Border" Grid.Column="1">
-                                    <muxc:InfoBar
+                                    <local:PlayerTip
                                         x:Name="PreviousViewInformer"
-                                        Style="{StaticResource MediaControlInfoBarStyle}"
-                                        CornerRadius="{TemplateBinding CornerRadius}"
+                                        Title="{loc:LocaleLocator Name=ViewHistory}"
+                                        HorizontalAlignment="Right"
+                                        ActionContent="{loc:LocaleLocator Name=ContinuePreviousView}"
                                         IsOpen="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsShowHistoryTip, Mode=TwoWay}"
-                                        Message="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.HistoryTipText}"
-                                        RenderTransformOrigin="0.5,0.5">
-                                        <muxc:InfoBar.ActionButton>
-                                            <Button
-                                                x:Name="ContinuePreviousViewButton"
-                                                MinWidth="120"
-                                                Content="{loc:LocaleLocator Name=ContinuePreviousView}" />
-                                        </muxc:InfoBar.ActionButton>
-                                    </muxc:InfoBar>
+                                        Message="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.HistoryTipText}" />
                                 </Border>
 
                                 <Border x:Name="NextVideoInformer_Border" Grid.Column="1">
-                                    <muxc:InfoBar
+                                    <local:PlayerTip
                                         x:Name="NextVideoInformer"
                                         Title="{loc:LocaleLocator Name=PlayNextVideo}"
-                                        Style="{StaticResource MediaControlInfoBarStyle}"
-                                        CornerRadius="{TemplateBinding CornerRadius}"
-                                        IsIconVisible="True"
+                                        HorizontalAlignment="Right"
+                                        ActionContent="{loc:LocaleLocator Name=PlayNow}"
+                                        AdditionalTitle="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.NextVideoCountdown}"
                                         IsOpen="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsShowNextVideoTip, Mode=TwoWay}"
-                                        Message="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.NextVideoTipText}"
-                                        Severity="Informational">
-                                        <muxc:InfoBar.ActionButton>
-                                            <HyperlinkButton x:Name="PlayNextVideoButton">
-                                                <TextBlock>
-                                                    <Run Text="{loc:LocaleLocator Name=PlayNow}" />
-                                                    <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.NextVideoCountdown}" />
-                                                </TextBlock>
-                                            </HyperlinkButton>
-                                        </muxc:InfoBar.ActionButton>
-                                    </muxc:InfoBar>
+                                        Message="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.NextVideoTipText}" />
                                 </Border>
                             </Grid>
 

--- a/src/App/Controls/Player/PlayerTip/PlayerTip.cs
+++ b/src/App/Controls/Player/PlayerTip/PlayerTip.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) Richasy. All rights reserved.
+
+using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Richasy.Bili.App.Controls
+{
+    /// <summary>
+    /// 播放器提示，通常从右侧弹出.
+    /// </summary>
+    public sealed class PlayerTip : Control
+    {
+        /// <summary>
+        /// <see cref="IsOpen"/> 的依赖属性.
+        /// </summary>
+        public static readonly DependencyProperty IsOpenProperty =
+            DependencyProperty.Register(nameof(IsOpen), typeof(bool), typeof(PlayerTip), new PropertyMetadata(default));
+
+        /// <summary>
+        /// <see cref="Message"/> 的依赖属性.
+        /// </summary>
+        public static readonly DependencyProperty MessageProperty =
+            DependencyProperty.Register(nameof(Message), typeof(string), typeof(PlayerTip), new PropertyMetadata(string.Empty));
+
+        /// <summary>
+        /// <see cref="Title"/> 的依赖属性.
+        /// </summary>
+        public static readonly DependencyProperty TitleProperty =
+            DependencyProperty.Register(nameof(Title), typeof(string), typeof(PlayerTip), new PropertyMetadata(string.Empty));
+
+        /// <summary>
+        /// <see cref="ActionContent"/> 的依赖属性.
+        /// </summary>
+        public static readonly DependencyProperty ActionContentProperty =
+            DependencyProperty.Register(nameof(ActionContent), typeof(string), typeof(PlayerTip), new PropertyMetadata(string.Empty));
+
+        /// <summary>
+        /// <see cref="AdditionalTitle"/> 的依赖属性.
+        /// </summary>
+        public static readonly DependencyProperty AdditionalTitleProperty =
+            DependencyProperty.Register(nameof(AdditionalTitle), typeof(string), typeof(PlayerTip), new PropertyMetadata(string.Empty));
+
+        private const string ActionButtonName = "ActionButton";
+        private const string CloseButtonName = "CloseButton";
+
+        private Button _actionButton;
+        private Button _closeButton;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlayerTip"/> class.
+        /// </summary>
+        public PlayerTip()
+        {
+            this.DefaultStyleKey = typeof(PlayerTip);
+        }
+
+        /// <summary>
+        /// 动作按钮被点击时触发.
+        /// </summary>
+        public event EventHandler ActionClick;
+
+        /// <summary>
+        /// 标题.
+        /// </summary>
+        public string Title
+        {
+            get { return (string)GetValue(TitleProperty); }
+            set { SetValue(TitleProperty, value); }
+        }
+
+        /// <summary>
+        /// 消息内容.
+        /// </summary>
+        public string Message
+        {
+            get { return (string)GetValue(MessageProperty); }
+            set { SetValue(MessageProperty, value); }
+        }
+
+        /// <summary>
+        /// 是否显示.
+        /// </summary>
+        public bool IsOpen
+        {
+            get { return (bool)GetValue(IsOpenProperty); }
+            set { SetValue(IsOpenProperty, value); }
+        }
+
+        /// <summary>
+        /// 动作按钮的内容.
+        /// </summary>
+        public string ActionContent
+        {
+            get { return (string)GetValue(ActionContentProperty); }
+            set { SetValue(ActionContentProperty, value); }
+        }
+
+        /// <summary>
+        /// 附加标题.
+        /// </summary>
+        public string AdditionalTitle
+        {
+            get { return (string)GetValue(AdditionalTitleProperty); }
+            set { SetValue(AdditionalTitleProperty, value); }
+        }
+
+        /// <inheritdoc/>
+        protected override void OnApplyTemplate()
+        {
+            _actionButton = GetTemplateChild(ActionButtonName) as Button;
+            _closeButton = GetTemplateChild(CloseButtonName) as Button;
+
+            _actionButton.Click += OnActionButtonClick;
+            _closeButton.Click += OnCloseButtonClick;
+        }
+
+        private void OnCloseButtonClick(object sender, RoutedEventArgs e)
+            => IsOpen = false;
+
+        private void OnActionButtonClick(object sender, RoutedEventArgs e)
+            => ActionClick?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/App/Controls/Player/PlayerTip/PlayerTip.xaml
+++ b/src/App/Controls/Player/PlayerTip/PlayerTip.xaml
@@ -1,0 +1,93 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:animations="using:Microsoft.Toolkit.Uwp.UI.Animations"
+    xmlns:local="using:Richasy.Bili.App.Controls">
+    <Style TargetType="local:PlayerTip">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="local:PlayerTip">
+                    <Grid
+                        x:Name="RootGrid"
+                        MinWidth="240"
+                        Padding="16,12"
+                        Background="{ThemeResource MediaTransportControlsPanelBackground}"
+                        ColumnSpacing="4"
+                        CornerRadius="{StaticResource ControlCornerRadius}"
+                        RowSpacing="8"
+                        Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=IsOpen, Converter={StaticResource BoolToVisibilityConverter}}">
+                        <animations:Implicit.ShowAnimations>
+                            <animations:OpacityAnimation
+                                From="0"
+                                To="1"
+                                Duration="0:0:0.3" />
+                            <animations:TranslationAnimation
+                                From="200,0,0"
+                                To="-20,0,0"
+                                Duration="0:0:0.3" />
+                        </animations:Implicit.ShowAnimations>
+
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <TextBlock
+                                x:Name="TitleBlock"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                HorizontalAlignment="Left"
+                                FontWeight="Bold"
+                                Text="{TemplateBinding Title}"
+                                TextTrimming="CharacterEllipsis" />
+                            <TextBlock
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="{TemplateBinding AdditionalTitle}" />
+                        </StackPanel>
+
+                        <TextBlock
+                            x:Name="MessageBlock"
+                            Style="{StaticResource CaptionTextBlockStyle}"
+                            Grid.Row="1"
+                            Grid.ColumnSpan="2"
+                            MaxWidth="320"
+                            Margin="0,-4,0,0"
+                            HorizontalAlignment="Left"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            MaxLines="2"
+                            Text="{TemplateBinding Message}"
+                            TextWrapping="Wrap">
+                            <ToolTipService.ToolTip>
+                                <ToolTip Content="{TemplateBinding Message}" IsEnabled="{Binding ElementName=MessageBlock, Path=IsTextTrimmed}" />
+                            </ToolTipService.ToolTip>
+                        </TextBlock>
+                        <Button
+                            x:Name="ActionButton"
+                            Style="{StaticResource AccentButtonStyle}"
+                            Grid.Row="2"
+                            Grid.ColumnSpan="2"
+                            HorizontalAlignment="Left"
+                            BorderThickness="0"
+                            Content="{TemplateBinding ActionContent}"
+                            FontSize="12" />
+                        <Button
+                            x:Name="CloseButton"
+                            Grid.Column="1"
+                            Padding="4"
+                            BorderThickness="0">
+                            <FontIcon
+                                FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                FontSize="12"
+                                Glyph="&#xE10A;" />
+                        </Button>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/App/Themes/Generic.xaml
+++ b/src/App/Themes/Generic.xaml
@@ -13,5 +13,6 @@
         <ResourceDictionary Source="ms-appx:///Controls/Common/VerticalRepeaterView/VerticalRepeaterView.xaml" />
         <ResourceDictionary Source="ms-appx:///Controls/Danmaku/DanmakuView/DanmakuView.xaml" />
         <ResourceDictionary Source="ms-appx:///Controls/Player/BiliPlayer/BiliPlayer.xaml" />
+        <ResourceDictionary Source="ms-appx:///Controls/Player/PlayerTip/PlayerTip.xaml" />
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/ViewModels/ViewModels.Uwp/ViewModels.Uwp.csproj
+++ b/src/ViewModels/ViewModels.Uwp/ViewModels.Uwp.csproj
@@ -159,6 +159,9 @@
     <PackageReference Include="ReactiveUI.Fody">
       <Version>17.1.50</Version>
     </PackageReference>
+    <PackageReference Include="ReactiveUI.Uwp">
+      <Version>17.1.50</Version>
+    </PackageReference>
     <PackageReference Include="Richasy.SYEnginePackage">
       <Version>1.0.0</Version>
     </PackageReference>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #970 

当提示弹出时，若同时有布局变化，比如全屏或者刷新，就会导致没被限制高度的提示在重复布局中走向崩溃。
所以这个PR使用自定义控件限制宽高，以解决这个问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

大布局套着小布局引发回环，最终导致整个布局崩溃

## 新的行为是什么？

解决小布局的回环问题

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 新组件
  - [x] 对于控件，已将控件放在主项目的 Controls 文件夹内
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

不确定是否最终解决了全部问题，但是在数次测试中都不会再复现
