### PR TITLE
限制播放器检测范围以避免光标无端消失

### DIFF
--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
@@ -787,6 +787,10 @@ namespace Richasy.Bili.App.Controls
                         Hide();
                     }
                 }
+                else if (!ViewModel.IsPointerInMediaElement && IsControlPanelShown())
+                {
+                    Hide();
+                }
 
                 _cursorStayTime = 0;
             }
@@ -1044,7 +1048,7 @@ namespace Richasy.Bili.App.Controls
 
         private bool IsCursorInControlPanel()
         {
-            if (IsControlPanelShown())
+            if (IsControlPanelShown() && ViewModel.IsPointerInMediaElement)
             {
                 var pointerPosition = Window.Current.CoreWindow.PointerPosition;
                 pointerPosition.X -= Window.Current.Bounds.X;
@@ -1060,6 +1064,11 @@ namespace Richasy.Bili.App.Controls
 
         private bool IsCursorInMediaElement()
         {
+            if (!ViewModel.IsPointerInMediaElement)
+            {
+                return false;
+            }
+
             var pointerPosition = Window.Current.CoreWindow.PointerPosition;
             pointerPosition.X -= Window.Current.Bounds.X;
             pointerPosition.Y -= Window.Current.Bounds.Y;

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
@@ -779,7 +779,11 @@ namespace Richasy.Bili.App.Controls
             _cursorStayTime += 500;
             if (_cursorStayTime > 2000)
             {
-                if (IsCursorInMediaElement() && (!IsCursorInControlPanel() || _isTouch))
+                if (_isTouch && IsControlPanelShown())
+                {
+                    Hide();
+                }
+                else if (IsCursorInMediaElement() && !IsCursorInControlPanel())
                 {
                     Window.Current.CoreWindow.PointerCursor = null;
                     if (IsControlPanelShown())

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -14,6 +14,7 @@ using Richasy.Bili.Models.BiliBili;
 using Richasy.Bili.Models.Enums;
 using Windows.Media.Playback;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Input;
 
 namespace Richasy.Bili.ViewModels.Uwp
 {
@@ -1069,5 +1070,14 @@ namespace Richasy.Bili.ViewModels.Uwp
 
             return result;
         }
+
+        private void OnBiliPlayerPointerMoved(object sender, PointerRoutedEventArgs e)
+            => IsPointerInMediaElement = true;
+
+        private void OnBiliPlayerPointerExited(object sender, PointerRoutedEventArgs e)
+            => IsPointerInMediaElement = false;
+
+        private void OnBiliPlayerPointerEntered(object sender, PointerRoutedEventArgs e)
+            => IsPointerInMediaElement = true;
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Properties.cs
@@ -796,6 +796,11 @@ namespace Richasy.Bili.ViewModels.Uwp
         [Reactive]
         public double NextVideoCountdown { get; set; }
 
+        /// <summary>
+        /// 光标是否在播放器范围内.
+        /// </summary>
+        public bool IsPointerInMediaElement { get; set; }
+
         private BiliController Controller { get; } = BiliController.Instance;
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -19,6 +19,7 @@ using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage.Streams;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 
 namespace Richasy.Bili.ViewModels.Uwp
 {
@@ -97,7 +98,17 @@ namespace Richasy.Bili.ViewModels.Uwp
         /// <param name="playerControl">标准播放器控件.</param>
         public void ApplyMediaControl(MediaPlayerElement playerControl)
         {
+            if (BiliPlayer != null)
+            {
+                BiliPlayer.PointerEntered -= OnBiliPlayerPointerEntered;
+                BiliPlayer.PointerExited -= OnBiliPlayerPointerExited;
+                BiliPlayer.PointerMoved -= OnBiliPlayerPointerMoved;
+            }
+
             BiliPlayer = playerControl;
+            BiliPlayer.PointerEntered += OnBiliPlayerPointerEntered;
+            BiliPlayer.PointerExited += OnBiliPlayerPointerExited;
+            BiliPlayer.PointerMoved += OnBiliPlayerPointerMoved;
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #967 #964 #952 #954

在之前引入的检测光标位置的代码中，没有考虑到元素遮盖产生的影响。
这次通过对播放器pointer事件的监听增加限制条件，避免光标在与其他元素交互时突然消失

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

当有元素叠在播放器上面时，光标会在2s后消失

## 新的行为是什么？

增加限制条件，避免光标不在播放器上时仍会消失

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
