### PR TITLE
在播放关联视频时固定播放模式

### DIFF
--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -90,8 +90,6 @@ namespace Richasy.Bili.ViewModels.Uwp
             ChoiceCollection.Clear();
             TagCollection.Clear();
             ReplyModuleViewModel.Instance.SetInformation(0, Models.Enums.Bili.ReplyType.None);
-            var preferPlayerMode = _settingsToolkit.ReadLocalSetting(SettingNames.DefaultPlayerDisplayMode, PlayerDisplayMode.Default);
-            PlayerDisplayMode = preferPlayerMode;
             Controller.CleanupLiveSocket();
             await ClearInitViewModelAsync();
         }
@@ -104,14 +102,9 @@ namespace Richasy.Bili.ViewModels.Uwp
                 IsDetailLoading = true;
                 try
                 {
-                    if (videoId.StartsWith("bv", StringComparison.OrdinalIgnoreCase))
-                    {
-                        _videoDetail = await Controller.GetVideoDetailAsync(videoId);
-                    }
-                    else
-                    {
-                        _videoDetail = await Controller.GetVideoDetailAsync(Convert.ToInt64(videoId.Replace("av", string.Empty)));
-                    }
+                    _videoDetail = videoId.StartsWith("bv", StringComparison.OrdinalIgnoreCase)
+                        ? await Controller.GetVideoDetailAsync(videoId)
+                        : await Controller.GetVideoDetailAsync(Convert.ToInt64(videoId.Replace("av", string.Empty)));
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #953 

<!-- 在上面的 `Close` 标题后添加要修复的 Issue 编号，比如 “Close #1234”，这样在 PR 合并后可以直接关闭 Issue -->

<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

在播放关联视频时，重置播放器模式

## 新的行为是什么？

现有的播放器模式会顺延到下一个播放的关联视频

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
