### PR TITLE
在发送弹幕后重置播放按钮焦点

### DIFF
--- a/src/App/Controls/Danmaku/DanmakuBox.xaml.cs
+++ b/src/App/Controls/Danmaku/DanmakuBox.xaml.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
+using Richasy.Bili.ViewModels.Uwp;
 using Richasy.Bili.ViewModels.Uwp.Common;
 using Windows.UI.Xaml.Controls;
 
@@ -35,6 +36,11 @@ namespace Richasy.Bili.App.Controls
                 if (result)
                 {
                     sender.Text = string.Empty;
+                    (PlayerViewModel.Instance.BiliPlayer.TransportControls as BiliPlayerTransportControls).CheckPlayPauseButtonFocus();
+                }
+                else
+                {
+                    sender.Focus(Windows.UI.Xaml.FocusState.Programmatic);
                 }
             }
         }

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
@@ -63,6 +63,17 @@ namespace Richasy.Bili.App.Controls
             return false;
         }
 
+        /// <summary>
+        /// 检查播放暂停按钮是否聚焦.
+        /// </summary>
+        public void CheckPlayPauseButtonFocus()
+        {
+            if (_playPauseButton != null)
+            {
+                _playPauseButton.Focus(FocusState.Programmatic);
+            }
+        }
+
         /// <inheritdoc/>
         protected override void OnApplyTemplate()
         {


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #976 

弹幕发送成功就将焦点设置在播放按钮上，失败则保持焦点在输入框中

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

发送弹幕后，焦点转移到旁边的弹幕设置按钮上

## 新的行为是什么？

弹幕发送成功就将焦点设置在播放按钮上，失败则保持焦点在输入框中

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
