### PR TITLE
移除SYEngine

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -1102,9 +1102,6 @@
     <PackageReference Include="Richasy.FluentIcon.Regular.UWP">
       <Version>1.1.150</Version>
     </PackageReference>
-    <PackageReference Include="Richasy.SYEnginePackage">
-      <Version>1.0.0</Version>
-    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using FFmpegInterop;
 using Richasy.Bili.Controller.Uwp.Interfaces;
 using Richasy.Bili.Locator.Uwp;
@@ -73,12 +72,6 @@ namespace Richasy.Bili.App
 
         private async void OnLaunchedOrActivatedAsync(IActivatedEventArgs e)
         {
-            // 用于解析Flv视频
-            if (RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
-            {
-                _ = SYEngine.Core.Initialize();
-            }
-
             var appView = ApplicationView.GetForCurrentView();
             appView.SetPreferredMinSize(new Size(AppConstants.AppMinWidth, AppConstants.AppMinHeight));
             appView.SetDesiredBoundsMode(ApplicationViewBoundsMode.UseCoreWindow);

--- a/src/ViewModels/ViewModels.Uwp/ViewModels.Uwp.csproj
+++ b/src/ViewModels/ViewModels.Uwp/ViewModels.Uwp.csproj
@@ -162,9 +162,6 @@
     <PackageReference Include="ReactiveUI.Uwp">
       <Version>17.1.50</Version>
     </PackageReference>
-    <PackageReference Include="Richasy.SYEnginePackage">
-      <Version>1.0.0</Version>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Controller\Controller.Uwp\Controller.Uwp.csproj">


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## 理由

添加SYEngine的目的就是为了支持flv视频，但目前除了一些“上古”内容，用户观看的绝大多数内容已不再需要flv。
且SYEngine所支持的ffmpeg过于古老，似乎视频播放卡顿也与此有关，由于可能已经影响到功能，所以移除

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
- 其他，请描述内容：依赖移除

## 当前行为是什么？

尝试支持flv

## 新的行为是什么？

放弃对flv的支持

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

似乎视频播放卡顿也与此有关
