### PR TITLE
修复互动视频返回异常

### DIFF
--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
@@ -1007,7 +1007,7 @@
                                     Padding="0"
                                     ToolTipService.ToolTip="{loc:LocaleLocator Name=BackToStart}"
                                     Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsInteraction, Converter={StaticResource BoolToVisibilityConverter}}">
-                                    <icons:RegularFluentIcon FontSize="14" Symbol="Home16" />
+                                    <icons:RegularFluentIcon FontSize="14" Symbol="EraserMedium24" />
                                     <Button.KeyboardAccelerators>
                                         <KeyboardAccelerator Key="H" Modifiers="Control" />
                                     </Button.KeyboardAccelerators>

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -650,7 +650,7 @@ BV号以 BV 开头，是一串英文数字混合的编号， 如 BV1JL4y1875w</v
     <value>请输入验证码</value>
   </data>
   <data name="InteractionEnd" xml:space="preserve">
-    <value>互动视频结束，可点击左上角“🏘”按钮返回开头</value>
+    <value>互动视频结束，可点击视频区域内左上角的 “橡皮擦” 按钮返回开头</value>
   </data>
   <data name="InteractionQuality" xml:space="preserve">
     <value>交互式清晰度选择</value>

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -300,7 +300,7 @@ namespace Richasy.Bili.ViewModels.Uwp
                 RelatedVideoCollection.Add(new VideoViewModel(video));
             }
 
-            if (_videoDetail.History != null && _videoDetail.History.Progress > 0)
+            if (_videoDetail.History != null && _videoDetail.History.Progress > 0 && !IsInteraction)
             {
                 var title = string.Empty;
                 if (IsShowParts)
@@ -624,7 +624,7 @@ namespace Richasy.Bili.ViewModels.Uwp
                 item.IsSelected = item.Data.Equals(CurrentVideoPart);
             }
 
-            if (VideoPartCollection.Count > 0)
+            if (VideoPartCollection.Count > 0 && CurrentVideoPart != null)
             {
                 IsPreviousEpisodeButtonEnabled = CurrentVideoPart.Page.Page_ != VideoPartCollection.First().Data.Page.Page_;
                 IsNextEpisodeButtonEnabled = CurrentVideoPart.Page.Page_ != VideoPartCollection.Last().Data.Page.Page_;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #992 

修复从上一视频返回互动视频时出现的空引用错误

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

打开一个互动视频，再打开一个其它的视频，返回互动视频时会报错

## 新的行为是什么？

修复这个问题

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
