### PR TITLE
避免搜索建议在搜索后才弹出

### DIFF
--- a/src/App/Controls/Search/SearchSuggestBox.xaml.cs
+++ b/src/App/Controls/Search/SearchSuggestBox.xaml.cs
@@ -70,22 +70,22 @@ namespace Richasy.Bili.App.Controls
 
         private void OnSearchBoxSubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
         {
+            ViewModel.StopRequestSearchSuggestion();
             if (args.ChosenSuggestion is ResultItem item)
             {
                 ViewModel.InputWords = item.Keyword;
-                ViewModel.SuggestionCollection.Clear();
             }
 
             if (!string.IsNullOrEmpty(sender.Text))
             {
                 AppViewModel.Instance.SetOverlayContentId(Models.Enums.PageIds.Search);
             }
+
+            ViewModel.SuggestionCollection.Clear();
         }
 
         private void OnHotSearchButtonClick(object sender, RoutedEventArgs e)
-        {
-            HotSearchFlyout.ShowAt(AppSearchBox);
-        }
+            => HotSearchFlyout.ShowAt(AppSearchBox);
 
         private async void OnTextChangedAsync(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
         {

--- a/src/Controller/Controller.Uwp/BiliController.Search.cs
+++ b/src/Controller/Controller.Uwp/BiliController.Search.cs
@@ -169,12 +169,7 @@ namespace Richasy.Bili.Controller.Uwp
         /// <returns>搜索建议.</returns>
         public async Task<List<Bilibili.App.Interfaces.V1.ResultItem>> GetSearchSuggestionAsync(string keyword)
         {
-            if (_suggestionTokenSource != null && !_suggestionTokenSource.IsCancellationRequested)
-            {
-                _suggestionTokenSource?.Cancel();
-                _suggestionTokenSource?.Dispose();
-                _suggestionTokenSource = null;
-            }
+            StopRequestSearchSuggestion();
 
             try
             {
@@ -193,6 +188,19 @@ namespace Richasy.Bili.Controller.Uwp
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// 立刻停止请求搜索建议.
+        /// </summary>
+        public void StopRequestSearchSuggestion()
+        {
+            if (_suggestionTokenSource != null && !_suggestionTokenSource.IsCancellationRequested)
+            {
+                _suggestionTokenSource?.Cancel();
+                _suggestionTokenSource?.Dispose();
+                _suggestionTokenSource = null;
+            }
         }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Home/SearchViewModel/SearchModuleViewModel/SearchModuleViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Home/SearchViewModel/SearchModuleViewModel/SearchModuleViewModel.cs
@@ -156,6 +156,12 @@ namespace Richasy.Bili.ViewModels.Uwp
             }
         }
 
+        /// <summary>
+        /// 立刻停止获取搜索建议.
+        /// </summary>
+        public void StopRequestSearchSuggestion()
+            => Controller.StopRequestSearchSuggestion();
+
         private void LoadModule()
         {
             VideoModule = new SearchSubModuleViewModel(SearchModuleType.Video);


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

当用户输入过快时，有时候搜索建议会在用户切换到搜索结果页后才显示出来，有点碍事。这个PR用于在用户提交输入后结束尚未完成的搜索建议请求，以及清除残留的搜索建议

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

当用户输入过快时，有时候搜索建议会在用户切换到搜索结果页后才显示出来

## 新的行为是什么？

在用户提交输入后结束尚未完成的搜索建议请求，以及清除残留的搜索建议

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
