### PR TITLE
修复第二次播放黑屏的问题

### DIFF
--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Dash.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Dash.cs
@@ -24,6 +24,11 @@ namespace Richasy.Bili.ViewModels.Uwp
         {
             try
             {
+                if (!AppViewModel.Instance.IsOpenPlayer)
+                {
+                    return;
+                }
+
                 var httpClient = new HttpClient();
                 httpClient.DefaultRequestHeaders.Referer = new Uri("https://www.bilibili.com");
                 httpClient.DefaultRequestHeaders.Add("User-Agent", ServiceConstants.DefaultUserAgentString);
@@ -104,6 +109,11 @@ namespace Richasy.Bili.ViewModels.Uwp
         {
             try
             {
+                if (!AppViewModel.Instance.IsOpenPlayer)
+                {
+                    return;
+                }
+
                 if (_interopMSS != null)
                 {
                     _interopMSS.Dispose();

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -280,7 +280,6 @@ namespace Richasy.Bili.ViewModels.Uwp
             }
 
             AppViewModel.Instance.CanShowHomeButton = _historyVideoList.Count > 0;
-
             switch (_videoType)
             {
                 case VideoType.Video:
@@ -594,6 +593,7 @@ namespace Richasy.Bili.ViewModels.Uwp
                 }
 
                 _currentVideoPlayer.Source = null;
+                _currentVideoPlayer = null;
             }
 
             _lastReportProgress = TimeSpan.Zero;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1006 #627 #1012 

根据 @dranklim 的提醒，我注意到了这个问题，现在每次启动新的播放都会生成一个新的 MediaPlayer

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

部分用户在播放第二个视频时会出现视频流无法加载的情况

## 新的行为是什么？

通过创建一个新的 MediaPlayer 来重新加载音频/视频流

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

顺便在生成播放条目时检查当前的页面情况，如果不是播放界面则不再加载
