### PR TITLE
修复表情在换行边缘会遮挡其他文本的问题

### DIFF
--- a/src/App/Controls/Common/EmotiTextBlock/EmotiTextBlock.xaml
+++ b/src/App/Controls/Common/EmotiTextBlock/EmotiTextBlock.xaml
@@ -21,7 +21,7 @@
                             IsTextSelectionEnabled="True"
                             LineHeight="24"
                             MaxLines="{TemplateBinding MaxLines}"
-                            TextTrimming="CharacterEllipsis"
+                            TextTrimming="None"
                             TextWrapping="Wrap" />
                         <Button
                             x:Name="OverflowButton"


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1034 

出现问题的原因是本应显示表情的地方被默认的省略号给顶掉了。在文本溢出时不显示这个省略号可以解决问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

当表情位于文本行尾且正好处于溢出点时，表情的位置会被顶到行首

## 新的行为是什么？

不使用自动添加的省略号，让行尾表情正常显示

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
