### PR TITLE
修复播放界面标题栏图标异常

### DIFF
--- a/src/App/Controls/App/AppTitleBar.xaml.cs
+++ b/src/App/Controls/App/AppTitleBar.xaml.cs
@@ -56,6 +56,7 @@ namespace Richasy.Bili.App.Controls
                 if (await PlayerViewModel.Instance.CheckBackAsync())
                 {
                     ViewModel.IsOpenPlayer = false;
+                    CheckDevice();
                     return true;
                 }
             }
@@ -84,12 +85,10 @@ namespace Richasy.Bili.App.Controls
         {
             if (e.PropertyName == nameof(ViewModel.IsOpenPlayer)
                 || e.PropertyName == nameof(ViewModel.IsShowOverlay)
-                || e.PropertyName == nameof(ViewModel.CanShowHomeButton))
+                || e.PropertyName == nameof(ViewModel.CanShowHomeButton)
+                || e.PropertyName == nameof(ViewModel.IsXbox))
             {
                 CheckBackButtonVisibility();
-            }
-            else if (e.PropertyName == nameof(ViewModel.IsXbox))
-            {
                 CheckDevice();
             }
         }
@@ -99,14 +98,14 @@ namespace Richasy.Bili.App.Controls
             var width = Window.Current.Bounds.Width;
             if (ViewModel.IsXbox)
             {
-                MenuButton.Visibility = Visibility.Visible;
+                MenuButton.Visibility = ViewModel.IsOpenPlayer ? Visibility.Collapsed : Visibility.Visible;
                 AppNameBlock.Visibility = Visibility.Visible;
                 RightPaddingColumn.Width = new GridLength(24);
             }
             else
             {
                 RightPaddingColumn.Width = new GridLength(172);
-                MenuButton.Visibility = width >= ViewModel.MediumWindowThresholdWidth ? Visibility.Collapsed : Visibility.Visible;
+                MenuButton.Visibility = width >= ViewModel.MediumWindowThresholdWidth || ViewModel.IsOpenPlayer ? Visibility.Collapsed : Visibility.Visible;
                 AppNameBlock.Visibility = width >= ViewModel.MediumWindowThresholdWidth ? Visibility.Visible : Visibility.Collapsed;
             }
         }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1024 

播放界面不应显示菜单按钮

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

窄屏时播放界面会显示菜单按钮

## 新的行为是什么？

窄屏时播放界面不显示菜单按钮

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
