### PR TITLE
播放时自动滚动到正在播放的分P/分集

### DIFF
--- a/src/App/Controls/Player/Related/EpisodeView.xaml
+++ b/src/App/Controls/Player/Related/EpisodeView.xaml
@@ -43,10 +43,12 @@
             VerticalScrollMode="{x:Bind VerticalScrollMode, Mode=OneWay}">
             <Grid>
                 <controls:VerticalRepeaterView
+                    x:Name="EpisodeRepeater"
                     EnableDetectParentScrollViewer="False"
                     HeaderVisibility="Collapsed"
                     ItemOrientation="Horizontal"
                     ItemsSource="{x:Bind ViewModel.EpisodeCollection}"
+                    Loaded="OnEpisodeRepeaterLoaded"
                     Visibility="{x:Bind ViewModel.IsOnlyShowIndex, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
                     <controls:VerticalRepeaterView.ItemTemplate>
                         <DataTemplate x:DataType="uwp:PgcEpisodeViewModel">
@@ -108,7 +110,11 @@
                         </DataTemplate>
                     </controls:VerticalRepeaterView.ItemTemplate>
                 </controls:VerticalRepeaterView>
-                <muxc:ItemsRepeater ItemsSource="{x:Bind ViewModel.EpisodeCollection, Mode=OneWay}" Visibility="{x:Bind ViewModel.IsOnlyShowIndex, Mode=OneWay}">
+                <muxc:ItemsRepeater
+                    x:Name="IndexRepeater"
+                    Loaded="OnEpisodeRepeaterLoaded"
+                    ItemsSource="{x:Bind ViewModel.EpisodeCollection, Mode=OneWay}"
+                    Visibility="{x:Bind ViewModel.IsOnlyShowIndex, Mode=OneWay}">
                     <muxc:ItemsRepeater.Layout>
                         <muxc:UniformGridLayout
                             ItemsStretch="Fill"

--- a/src/App/Controls/Player/Related/EpisodeView.xaml.cs
+++ b/src/App/Controls/Player/Related/EpisodeView.xaml.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
+using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Richasy.Bili.ViewModels.Uwp;
 using Windows.UI.Xaml;
@@ -32,6 +34,30 @@ namespace Richasy.Bili.App.Controls.Player.Related
                 data.IsSelected = false;
                 await Task.Delay(100);
                 data.IsSelected = true;
+            }
+        }
+
+        private void OnEpisodeRepeaterLoaded(object sender, RoutedEventArgs e)
+            => RelocateSelectedItem();
+
+        private void RelocateSelectedItem()
+        {
+            var vm = ViewModel.EpisodeCollection.FirstOrDefault(p => p.IsSelected);
+            if (vm != null)
+            {
+                var index = ViewModel.EpisodeCollection.IndexOf(vm);
+                if (index >= 0)
+                {
+                    EpisodeRepeater.ScrollToItem(index);
+                    if (ViewModel.IsOnlyShowIndex)
+                    {
+                        var ele = IndexRepeater.GetOrCreateElement(index);
+                        if (ele != null)
+                        {
+                            ele.StartBringIntoView(new BringIntoViewOptions { VerticalAlignmentRatio = 0f });
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/App/Controls/Player/Related/VideoPartView.xaml
+++ b/src/App/Controls/Player/Related/VideoPartView.xaml
@@ -43,10 +43,12 @@
             VerticalScrollMode="{x:Bind VerticalScrollMode, Mode=OneWay}">
             <Grid>
                 <controls:VerticalRepeaterView
+                    x:Name="PartRepeater"
                     EnableDetectParentScrollViewer="False"
                     HeaderVisibility="Collapsed"
                     ItemOrientation="Horizontal"
                     ItemsSource="{x:Bind ViewModel.VideoPartCollection}"
+                    Loaded="OnPartRepeaterLoaded"
                     Visibility="{x:Bind ViewModel.IsOnlyShowIndex, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
                     <controls:VerticalRepeaterView.ItemTemplate>
                         <DataTemplate x:DataType="uwp:VideoPartViewModel">
@@ -82,7 +84,11 @@
                         </DataTemplate>
                     </controls:VerticalRepeaterView.ItemTemplate>
                 </controls:VerticalRepeaterView>
-                <muxc:ItemsRepeater ItemsSource="{x:Bind ViewModel.VideoPartCollection, Mode=OneWay}" Visibility="{x:Bind ViewModel.IsOnlyShowIndex, Mode=OneWay}">
+                <muxc:ItemsRepeater
+                    x:Name="IndexRepeater"
+                    ItemsSource="{x:Bind ViewModel.VideoPartCollection, Mode=OneWay}"
+                    Visibility="{x:Bind ViewModel.IsOnlyShowIndex, Mode=OneWay}"
+                    Loaded="OnPartRepeaterLoaded">
                     <muxc:ItemsRepeater.Layout>
                         <muxc:UniformGridLayout
                             ItemsStretch="Fill"

--- a/src/App/Controls/Player/Related/VideoPartView.xaml.cs
+++ b/src/App/Controls/Player/Related/VideoPartView.xaml.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
+using System.Linq;
 using Richasy.Bili.ViewModels.Uwp;
+using Windows.UI.Xaml;
 
 namespace Richasy.Bili.App.Controls.Player.Related
 {
@@ -30,5 +32,29 @@ namespace Richasy.Bili.App.Controls.Player.Related
                 data.IsSelected = true;
             }
         }
+
+        private void RelocateSelectedItem()
+        {
+            var vm = ViewModel.VideoPartCollection.FirstOrDefault(p => p.IsSelected);
+            if (vm != null)
+            {
+                var index = ViewModel.VideoPartCollection.IndexOf(vm);
+                if (index >= 0)
+                {
+                    PartRepeater.ScrollToItem(index);
+                    if (ViewModel.IsOnlyShowIndex)
+                    {
+                        var ele = IndexRepeater.GetOrCreateElement(index);
+                        if (ele != null)
+                        {
+                            ele.StartBringIntoView(new BringIntoViewOptions { VerticalAlignmentRatio = 0f });
+                        }
+                    }
+                }
+            }
+        }
+
+        private void OnPartRepeaterLoaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+            => RelocateSelectedItem();
     }
 }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

在观看集数较多的视频时要滚动好久（最近在看柯南），所以现在支持打开带有分P/分集的视频时直接滚动到正在播放的分P

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

不会自动锚定

## 新的行为是什么？

主动滚动到正在播放的分P

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
