### PR TITLE
修复在播放结束后有时会卡死的问题

### DIFF
--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
@@ -216,7 +216,7 @@ namespace Richasy.Bili.App.Controls
 
             if (IsControlPanelShown() && e.Pointer.PointerDeviceType == Windows.Devices.Input.PointerDeviceType.Mouse)
             {
-                HideControls();
+                HideControlsAsync();
             }
 
             _cursorStayTime = 0;
@@ -484,7 +484,11 @@ namespace Richasy.Bili.App.Controls
             _segmentIndex = 1;
             _danmakuDictionary.Clear();
             _danmakuTimer.Stop();
-            _danmakuView.ClearAll();
+
+            if (_danmakuView != null)
+            {
+                _danmakuView.ClearAll();
+            }
         }
 
         private void OnMediaPlayerUdpated(object sender, EventArgs e)
@@ -502,11 +506,11 @@ namespace Richasy.Bili.App.Controls
             {
                 CheckDanmakuZoom();
             }
-            else if (e.PropertyName == nameof(DanmakuViewModel.DanmakuArea))
+            else if (e.PropertyName == nameof(DanmakuViewModel.DanmakuArea) && _danmakuView != null)
             {
                 _danmakuView.DanmakuArea = DanmakuViewModel.DanmakuArea;
             }
-            else if (e.PropertyName == nameof(DanmakuViewModel.DanmakuSpeed))
+            else if (e.PropertyName == nameof(DanmakuViewModel.DanmakuSpeed) && _danmakuView != null)
             {
                 _danmakuView.DanmakuDuration = Convert.ToInt32((2.1 - DanmakuViewModel.DanmakuSpeed) * 10);
             }
@@ -556,16 +560,16 @@ namespace Richasy.Bili.App.Controls
             {
                 if (sender.PlaybackState == MediaPlaybackState.Buffering)
                 {
-                    _danmakuView.PauseDanmaku();
+                    _danmakuView?.PauseDanmaku();
                 }
                 else if (sender.PlaybackState == MediaPlaybackState.Paused && sender.Position < sender.NaturalDuration)
                 {
-                    _danmakuView.PauseDanmaku();
+                    _danmakuView?.PauseDanmaku();
                 }
                 else if (sender.PlaybackState == MediaPlaybackState.Playing)
                 {
-                    _danmakuView.ResumeDanmaku();
-                    HideControls();
+                    _danmakuView?.ResumeDanmaku();
+                    HideControlsAsync();
                 }
 
                 _playPauseButton?.Focus(FocusState.Programmatic);
@@ -797,7 +801,7 @@ namespace Richasy.Bili.App.Controls
                     {
                         foreach (var item in data)
                         {
-                            _danmakuView.AddScreenDanmaku(item, false);
+                            _danmakuView?.AddScreenDanmaku(item, false);
                         }
                     });
                 }
@@ -814,19 +818,19 @@ namespace Richasy.Bili.App.Controls
             {
                 if (_isTouch && IsControlPanelShown())
                 {
-                    HideControls();
+                    HideControlsAsync();
                 }
                 else if (IsCursorInMediaElement() && !IsCursorInControlPanel())
                 {
                     Window.Current.CoreWindow.PointerCursor = null;
                     if (IsControlPanelShown())
                     {
-                        HideControls();
+                        HideControlsAsync();
                     }
                 }
                 else if (!ViewModel.IsPointerInMediaElement && IsControlPanelShown())
                 {
-                    HideControls();
+                    HideControlsAsync();
                 }
 
                 _cursorStayTime = 0;
@@ -1120,10 +1124,13 @@ namespace Richasy.Bili.App.Controls
             return rootBounds.Contains(pointerPosition);
         }
 
-        private void HideControls()
+        private async void HideControlsAsync()
         {
-            Hide();
-            ViewModel.IsFocusInputControl = false;
+            await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+            {
+                Hide();
+                ViewModel.IsFocusInputControl = false;
+            });
         }
     }
 }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1046 #1019 #1016 

造成这个问题的原因可能来自多个方面，一方面网络请求与UI变化同时发生，造成线程卡死；一方面UI元素布局出现异常。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

有些时候，视频播放结束会卡死UI

## 新的行为是什么？

将可能的原因修复，目前该问题已无法在本机复现

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

这可能并没有彻底修复该问题，需等待进一步反馈
