### PR TITLE
修复 PGC 类型的动态通知参数不正确的问题

### DIFF
--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
@@ -446,6 +446,19 @@ namespace Richasy.Bili.App.Controls
 
         private async void CheckCurrentPlayerModeAsync()
         {
+            if (ViewModel.IsDetailError
+                || ViewModel.IsPlayInformationError
+                || _fullScreenPlayModeButton == null
+                || !_fullScreenPlayModeButton.IsLoaded
+                || _fullWindowPlayModeButton == null
+                || !_fullWindowPlayModeButton.IsLoaded
+                || _compactOverlayPlayModeButton == null
+                || !_compactOverlayPlayModeButton.IsLoaded)
+            {
+                ViewModel.PlayerDisplayMode = PlayerDisplayMode.Default;
+                return;
+            }
+
             switch (ViewModel.PlayerDisplayMode)
             {
                 case PlayerDisplayMode.Default:

--- a/src/Models/Models.App/Constants/AppConstants.cs
+++ b/src/Models/Models.App/Constants/AppConstants.cs
@@ -53,6 +53,7 @@ namespace Richasy.Bili.Models.App.Constants
             public const string KeywordParam = "keyword";
             public const string IdParam = "id";
             public const string ModeParam = "mode";
+            public const string IsPgcParam = "isPgc";
         }
 #pragma warning restore SA1600 // Elements should be documented
     }

--- a/src/Tasks/DynamicNotifyTask.cs
+++ b/src/Tasks/DynamicNotifyTask.cs
@@ -46,6 +46,7 @@ namespace Richasy.Bili.Tasks
             var lastReadCard = cardList.FirstOrDefault(p => p.Extend.DynIdStr == lastReadId);
             var lastReadIndex = cardList.IndexOf(lastReadCard);
             var notifyCards = new List<DynamicItem>();
+
             if (lastReadIndex != -1)
             {
                 for (var i = 0; i < lastReadIndex; i++)
@@ -81,12 +82,12 @@ namespace Richasy.Bili.Tasks
                     ? video.Cover
                     : pgc.Cover;
                 var type = mainModule.ModuleItemCase == ModuleDynamic.ModuleItemOneofCase.DynArchive
-                    && video != null && !video.IsPGC
+                    && video != null
                     ? "video"
                     : "episode";
                 var id = type == "video"
                     ? video.Avid
-                    : video != null ? video.EpisodeId : pgc.Epid;
+                    : video.EpisodeId;
                 var avatar = userModule != null
                     ? userModule.Author.Face
                     : "ms-appx:///Assets/Bili_rgba_80.png";
@@ -100,6 +101,10 @@ namespace Richasy.Bili.Tasks
                 cover += "@400w_250h_1c_100q.jpg";
                 avatar += "@100w_100h_1c_100q.jpg";
                 var protocol = $"richasy-bili://play?{type}={id}";
+                if (video != null && video.IsPGC)
+                {
+                    protocol += "&isPgc=true";
+                }
 
                 new ToastContentBuilder()
                     .AddText(title, hintWrap: true, hintMaxLines: 2)

--- a/src/ViewModels/ViewModels.Uwp/Common/AppViewModel/AppViewModel.Command.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/AppViewModel/AppViewModel.Command.cs
@@ -56,10 +56,7 @@ namespace Richasy.Bili.ViewModels.Uwp
                             {
                                 if (int.TryParse(vm.EpisodeId.Replace("ep", string.Empty), out var episodeId))
                                 {
-                                    record = new CurrentPlayingRecord(episodeId.ToString(), 0, VideoType.Pgc)
-                                    {
-                                        NeedBiliPlus = true,
-                                    };
+                                    record = new CurrentPlayingRecord(episodeId.ToString(), 0, VideoType.Pgc);
                                 }
                             }
                             else if (!string.IsNullOrEmpty(vm.LiveId))
@@ -161,6 +158,12 @@ namespace Richasy.Bili.ViewModels.Uwp
                 if (hasVideoId)
                 {
                     record = new CurrentPlayingRecord(videoId, 0, VideoType.Video);
+                    var hasPgcSign = queryList.TryGetValue(AppConstants.Protocol.IsPgcParam, out var isPgc);
+                    if (hasPgcSign && Convert.ToBoolean(isPgc))
+                    {
+                        record.VideoType = VideoType.Pgc;
+                        record.NeedBiliPlus = true;
+                    }
                 }
                 else if (hasSeasonId)
                 {
@@ -181,10 +184,7 @@ namespace Richasy.Bili.ViewModels.Uwp
                 {
                     if (int.TryParse(episodeId.Replace("ep", string.Empty), out var episodeIdNum))
                     {
-                        record = new CurrentPlayingRecord(episodeIdNum.ToString(), 0, VideoType.Pgc)
-                        {
-                            NeedBiliPlus = true,
-                        };
+                        record = new CurrentPlayingRecord(episodeIdNum.ToString(), 0, VideoType.Pgc);
                     }
                 }
                 else if (hasLiveId)


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

在类型为视频，但实质是PGC的动态解析中，应传入aid而不是epid（此时epid为0）

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复 
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

弹出番剧出差的通知时，点击无法正确打开视频

## 新的行为是什么？

调整参数，修复这个问题

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
