### PR TITLE
为评论/消息/空间视频添加相对时间显示

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -45,12 +45,6 @@ jobs:
         $manifest.Package.Identity.Version = "${{github.event.inputs.version}}"
         $manifest.save(".\$env:UWP_Project_Directory\Package.appxmanifest")
         
-    - name: Build x86
-      run: msbuild $env:Solution_Path /p:Platform=x86 /p:AppxBundlePlatforms="x86" /p:AppxPackageDir=C:\Package\x86 /p:PackageCertificateKeyFile=$env:SigningCertificate /restore
-      env:
-        BuildMode: SideloadOnly
-        Configuration: Release
-        
     - name: Build x64
       run: msbuild $env:Solution_Path /p:Platform=x64 /p:AppxBundlePlatforms="x64" /p:AppxPackageDir=C:\Package\x64 /p:PackageCertificateKeyFile=$env:SigningCertificate /restore
       env:
@@ -62,26 +56,12 @@ jobs:
       env:
         BuildMode: SideloadOnly
         Configuration: Release
-   
-    - name: Create x86 archive
-      run: Compress-Archive -Path C:\Package\x86\App_${{github.event.inputs.version}}_Test -DestinationPath C:\Package\Bili.Uwp_${{github.event.inputs.version}}_x86.zip
       
     - name: Create x64 archive
       run: Compress-Archive -Path C:\Package\x64\App_${{github.event.inputs.version}}_Test -DestinationPath C:\Package\Bili.Uwp_${{github.event.inputs.version}}_x64.zip
       
     - name: Create ARM64 archive
       run: Compress-Archive -Path C:\Package\ARM64\App_${{github.event.inputs.version}}_Test -DestinationPath C:\Package\Bili.Uwp_${{github.event.inputs.version}}_ARM64.zip
-
-    - name: Update x86 release asset
-      id: upload-release-asset-x86
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.release-drafter.outputs.upload_url }}
-        asset_path: C:\Package\Bili.Uwp_${{github.event.inputs.version}}_x86.zip
-        asset_name: Bili.Uwp_${{github.event.inputs.version}}_x86.zip
-        asset_content_type: application/zip
         
     - name: Update x64 release asset
       id: upload-release-asset-x64

--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -1154,6 +1154,9 @@
     <PackageReference Include="FFmpegInteropX">
       <Version>0.9.4</Version>
     </PackageReference>
+    <PackageReference Include="Humanizer.Core.zh-CN">
+      <Version>2.14.1</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.13</Version>
     </PackageReference>

--- a/src/App/Controls/Common/ReplyItem.xaml.cs
+++ b/src/App/Controls/Common/ReplyItem.xaml.cs
@@ -2,6 +2,7 @@
 
 using System;
 using Bilibili.Main.Community.Reply.V1;
+using Humanizer;
 using Richasy.Bili.Locator.Uwp;
 using Richasy.Bili.Toolkit.Interfaces;
 using Richasy.Bili.ViewModels.Uwp;
@@ -88,7 +89,7 @@ namespace Richasy.Bili.App.Controls
                 instance.UserAvatar.Avatar = data.Member.Face;
                 instance.LevelImage.Source = new BitmapImage(new Uri($"ms-appx:///Assets/Level/level_{data.Member.Level}.png"));
                 var time = DateTimeOffset.FromUnixTimeSeconds(data.Ctime).ToLocalTime();
-                instance.PublishTimeBlock.Text = time.ToString("HH:mm");
+                instance.PublishTimeBlock.Text = time.Humanize();
                 ToolTipService.SetToolTip(instance.PublishTimeBlock, time.ToString("yyyy/MM/dd HH:mm:ss"));
                 instance.LikeButton.IsChecked = data.ReplyControl.Action == 1;
                 instance.LikeCountBlock.Text = ServiceLocator.Instance.GetService<INumberToolkit>().GetCountText(data.Like);

--- a/src/App/Controls/Common/VideoCard/VideoCard.xaml
+++ b/src/App/Controls/Common/VideoCard/VideoCard.xaml
@@ -236,11 +236,18 @@
                                             ToolTipService.ToolTip="{loc:LocaleLocator Name=ReplyCount}"
                                             Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=IsShowReplayCount, Converter={StaticResource BoolToVisibilityConverter}}" />
                                         <local:IconTextBlock
+                                            Margin="0,0,12,0"
                                             Opacity="0.6"
                                             Symbol="People16"
                                             Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.ViewerCount}"
                                             ToolTipService.ToolTip="{loc:LocaleLocator Name=Viewer}"
                                             Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=IsShowViewerCount}" />
+                                        <local:IconTextBlock
+                                            Opacity="0.6"
+                                            Symbol="CalendarLtr16"
+                                            Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.PublishDate}"
+                                            ToolTipService.ToolTip="{loc:LocaleLocator Name=PublishDate}"
+                                            Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=IsShowPublishDateTime}" />
                                     </StackPanel>
                                     <Grid Grid.Row="3" Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=AdditionalFooterContent, Converter={StaticResource ObjectToVisibilityConverter}}">
                                         <ContentPresenter x:Name="AdditionalFooterPresenter" Content="{TemplateBinding AdditionalFooterContent}" />

--- a/src/App/Controls/Message/AtMessageItem.xaml.cs
+++ b/src/App/Controls/Message/AtMessageItem.xaml.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
 using System;
+using Humanizer;
 using Richasy.Bili.Locator.Uwp;
 using Richasy.Bili.Toolkit.Interfaces;
 using Windows.Foundation;
@@ -57,7 +58,7 @@ namespace Richasy.Bili.App.Controls
                 instance.DetailBlock.Text = data.Item.SourceContent;
                 instance.TypeBlock.Text = string.Format(resourceToolkit.GetLocaleString(Models.Enums.LanguageNames.AtMessageTypeDescription), data.Item.Business);
                 var dateTime = DateTimeOffset.FromUnixTimeSeconds(data.AtTime).ToLocalTime();
-                instance.TimeBlock.Text = dateTime.ToString("HH:mm");
+                instance.TimeBlock.Text = dateTime.Humanize();
                 ToolTipService.SetToolTip(instance.TimeBlock, dateTime.ToString("yyyy/MM/dd HH:mm"));
                 instance.TitleBlock.Text = string.IsNullOrEmpty(data.Item.Title) ? resourceToolkit.GetLocaleString(Models.Enums.LanguageNames.NoSpecificData) : data.Item.Title;
             }

--- a/src/App/Controls/Message/LikeMessageItem.xaml.cs
+++ b/src/App/Controls/Message/LikeMessageItem.xaml.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Linq;
+using Humanizer;
 using Richasy.Bili.Locator.Uwp;
 using Richasy.Bili.Toolkit.Interfaces;
 using Windows.Foundation;
@@ -83,7 +84,7 @@ namespace Richasy.Bili.App.Controls
 
                 instance.DetailBlock.Text = detail;
                 var dateTime = DateTimeOffset.FromUnixTimeSeconds(data.LikeTime).ToLocalTime();
-                instance.TimeBlock.Text = dateTime.ToString("HH:mm");
+                instance.TimeBlock.Text = dateTime.Humanize();
                 ToolTipService.SetToolTip(instance.TimeBlock, dateTime.ToString("yyyy/MM/dd HH:mm"));
                 instance.TitleBlock.Text = string.IsNullOrEmpty(data.Item.Title) ? data.Item.Description : data.Item.Title;
             }

--- a/src/App/Controls/Message/ReplyMessageItem.xaml.cs
+++ b/src/App/Controls/Message/ReplyMessageItem.xaml.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
 using System;
+using Humanizer;
 using Richasy.Bili.Locator.Uwp;
 using Richasy.Bili.Models.Enums.Bili;
 using Richasy.Bili.Toolkit.Interfaces;
@@ -62,7 +63,7 @@ namespace Richasy.Bili.App.Controls
                     data.Item.Business,
                     data.Counts);
                 var dateTime = DateTimeOffset.FromUnixTimeSeconds(data.ReplyTime).ToLocalTime();
-                instance.TimeBlock.Text = dateTime.ToString("HH:mm");
+                instance.TimeBlock.Text = dateTime.Humanize();
                 ToolTipService.SetToolTip(instance.TimeBlock, dateTime.ToString("yyyy/MM/dd HH:mm"));
                 instance.TitleBlock.Text = string.IsNullOrEmpty(data.Item.Title) ? data.Item.Description : data.Item.Title;
             }

--- a/src/App/Controls/User/UserView.xaml
+++ b/src/App/Controls/User/UserView.xaml
@@ -24,6 +24,7 @@
                 IsShowDanmakuCount="True"
                 IsShowDuration="True"
                 IsShowPlayCount="True"
+                IsShowPublishDateTime="True"
                 ItemClick="OnVideoCardClick"
                 Orientation="Horizontal"
                 ViewModel="{x:Bind}" />

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -1067,6 +1067,9 @@ BV号以 BV 开头，是一串英文数字混合的编号， 如 BV1JL4y1875w</v
   <data name="PublicServer" xml:space="preserve">
     <value>公共服务器</value>
   </data>
+  <data name="PublishDate" xml:space="preserve">
+    <value>发布时间</value>
+  </data>
   <data name="PublisherApp" xml:space="preserve">
     <value>开发者的其它应用</value>
   </data>

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -504,6 +504,7 @@ namespace Richasy.Bili.Models.Enums
         FixContent,
         UnfixContent,
         StartQuickPlay,
+        PublishDate,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Common/VideoViewModel/VideoViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/VideoViewModel/VideoViewModel.Properties.cs
@@ -68,6 +68,12 @@ namespace Richasy.Bili.ViewModels.Uwp
         public string ViewerCount { get; set; }
 
         /// <summary>
+        /// 发布时间.
+        /// </summary>
+        [Reactive]
+        public string PublishDate { get; set; }
+
+        /// <summary>
         /// 发布者.
         /// </summary>
         [Reactive]

--- a/src/ViewModels/ViewModels.Uwp/Common/VideoViewModel/VideoViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/VideoViewModel/VideoViewModel.cs
@@ -8,6 +8,7 @@ using Bilibili.App.Dynamic.V2;
 using Bilibili.App.Interfaces.V1;
 using Bilibili.App.Show.V1;
 using Bilibili.App.View.V1;
+using Humanizer;
 using Richasy.Bili.Locator.Uwp;
 using Richasy.Bili.Models.App.Constants;
 using Richasy.Bili.Models.BiliBili;
@@ -278,6 +279,7 @@ namespace Richasy.Bili.ViewModels.Uwp
             DanmakuCount = _numberToolkit.GetCountText(item.DanmakuCount);
             Publisher = new UserViewModel(item.PublisherName);
             Duration = _numberToolkit.GetDurationText(TimeSpan.FromSeconds(item.Duration));
+            PublishDate = DateTimeOffset.FromUnixTimeSeconds(item.CreateTime).ToLocalTime().Humanize();
             LimitCover(item.Cover);
             Source = item;
         }

--- a/src/ViewModels/ViewModels.Uwp/ViewModels.Uwp.csproj
+++ b/src/ViewModels/ViewModels.Uwp/ViewModels.Uwp.csproj
@@ -147,6 +147,9 @@
     <PackageReference Include="FFmpegInteropX">
       <Version>0.9.4</Version>
     </PackageReference>
+    <PackageReference Include="Humanizer.Core.zh-CN">
+      <Version>2.14.1</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>6.0.0</Version>
     </PackageReference>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1107 

该问题反馈较多，遂将一些应用标准时间的场景改为相对时间显示，更为易读

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

上述卡片的时间显示为24小时的精确时间，但是不直接包含日期信息，容易让人误解

## 新的行为是什么？

使用可读的相对时间（比如`一天前`），虽然不甚精确，但是对人更友好

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

引入 `Humanize` 包进行相对时间解析
