### PR TITLE
修复部分动态类型评论打不开的问题

### DIFF
--- a/src/App/Controls/Dynamic/DynamicItem.xaml.cs
+++ b/src/App/Controls/Dynamic/DynamicItem.xaml.cs
@@ -136,13 +136,16 @@ namespace Richasy.Bili.App.Controls
             {
                 case Bilibili.App.Dynamic.V2.DynamicType.Forward:
                 case Bilibili.App.Dynamic.V2.DynamicType.Word:
-                case Bilibili.App.Dynamic.V2.DynamicType.Draw:
                 case Bilibili.App.Dynamic.V2.DynamicType.Live:
                     type = ReplyType.Dynamic;
+                    break;
+                case Bilibili.App.Dynamic.V2.DynamicType.Draw:
+                    type = ReplyType.Album;
                     break;
                 case Bilibili.App.Dynamic.V2.DynamicType.Av:
                 case Bilibili.App.Dynamic.V2.DynamicType.Pgc:
                 case Bilibili.App.Dynamic.V2.DynamicType.UgcSeason:
+                case Bilibili.App.Dynamic.V2.DynamicType.Medialist:
                     type = ReplyType.Video;
                     break;
                 case Bilibili.App.Dynamic.V2.DynamicType.Courses:
@@ -166,7 +169,8 @@ namespace Richasy.Bili.App.Controls
                 return;
             }
 
-            ReplyModuleViewModel.Instance.SetInformation(Convert.ToInt64(Data.Extend.BusinessId), type, Bilibili.Main.Community.Reply.V1.Mode.MainListTime);
+            var id = type == ReplyType.Dynamic ? Data.Extend.DynIdStr : Data.Extend.BusinessId;
+            ReplyModuleViewModel.Instance.SetInformation(Convert.ToInt64(id), type, Bilibili.Main.Community.Reply.V1.Mode.MainListTime);
             await ReplyDetailView.Instance.ShowAsync(ReplyModuleViewModel.Instance);
         }
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

部分动态类型（图文动态/转发动态）的评论打不开，因为没有正确的传入目标Id和动态类型

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

部分动态类型评论打不开

## 新的行为是什么？

支持显示的动态都可以正常打开评论

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
