### PR TITLE
修复快捷键没有正常切换迷你视图的问题

### DIFF
--- a/src/App/Controls/Danmaku/DanmakuView/DanmakuView.cs
+++ b/src/App/Controls/Danmaku/DanmakuView/DanmakuView.cs
@@ -111,19 +111,27 @@ namespace Richasy.Bili.App.Controls
 
         private void InitializeController()
         {
-            _rootGrid.Children.Clear();
-            _canvas = new CanvasAnimatedControl();
-            _rootGrid.Children.Add(_canvas);
-            _danmakuController = new DanmakuFrostMaster(_canvas);
+            if (_rootGrid == null)
+            {
+                _rootGrid = GetTemplateChild(RootGridName) as Grid;
+            }
 
-            _danmakuController.SetAutoControlDensity(IsDanmakuLimit);
-            _danmakuController.SetRollingDensity(-1);
-            _danmakuController.SetBorderColor(Colors.Gray);
-            _danmakuController.SetRollingAreaRatio(Convert.ToInt32(DanmakuArea * 10));
-            _danmakuController.SetDanmakuFontSizeOffset(GetFontSize(DanmakuSize));
-            _danmakuController.SetFontFamilyName(DanmakuFontFamily ?? "Segoe UI");
-            _danmakuController.SetRollingSpeed(Convert.ToInt32(DanmakuDuration * 5));
-            _danmakuController.SetIsTextBold(DanmakuBold);
+            if (_rootGrid != null)
+            {
+                _rootGrid.Children.Clear();
+                _canvas = new CanvasAnimatedControl();
+                _rootGrid.Children.Add(_canvas);
+                _danmakuController = new DanmakuFrostMaster(_canvas);
+
+                _danmakuController.SetAutoControlDensity(IsDanmakuLimit);
+                _danmakuController.SetRollingDensity(-1);
+                _danmakuController.SetBorderColor(Colors.Gray);
+                _danmakuController.SetRollingAreaRatio(Convert.ToInt32(DanmakuArea * 10));
+                _danmakuController.SetDanmakuFontSizeOffset(GetFontSize(DanmakuSize));
+                _danmakuController.SetFontFamilyName(DanmakuFontFamily ?? "Segoe UI");
+                _danmakuController.SetRollingSpeed(Convert.ToInt32(DanmakuDuration * 5));
+                _danmakuController.SetIsTextBold(DanmakuBold);
+            }
         }
     }
 }

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.Properties.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.Properties.cs
@@ -66,8 +66,9 @@ namespace Richasy.Bili.App.Controls
         private const string DecreaseVolumeButtonName = "DecreaseVolumeButton";
         private const string NextVideoInformerName = "NextVideoInformer";
         private const string VisibilityStateGroupName = "ControlPanelVisibilityStates";
-        private const string FormatButtonName = "FormatButtonName";
-        private const string LiveQualityButtonName = "LiveQualityButtonName";
+        private const string FormatButtonName = "FormatButton";
+        private const string LiveQualityButtonName = "LiveQualityButton";
+        private const string MiniViewButtonName = "MiniViewButton";
 
         private DispatcherTimer _danmakuTimer;
         private DispatcherTimer _cursorTimer;
@@ -108,6 +109,7 @@ namespace Richasy.Bili.App.Controls
         private Button _formatButton;
         private Button _liveQualityButton;
         private GestureRecognizer _gestureRecognizer;
+        private Button _miniViewButton;
 
         private int _segmentIndex;
         private double _cursorStayTime;

--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.xaml
@@ -329,6 +329,17 @@
                                     <KeyboardAccelerator Key="Down" IsEnabled="True" />
                                 </Button.KeyboardAccelerators>
                             </Button>
+                            <Button
+                                x:Name="MiniViewButton"
+                                AutomationProperties.AccessibilityView="Raw"
+                                IsTabStop="False">
+                                <Button.KeyboardAccelerators>
+                                    <KeyboardAccelerator
+                                        Key="M"
+                                        IsEnabled="True"
+                                        Modifiers="Control" />
+                                </Button.KeyboardAccelerators>
+                            </Button>
                         </Grid>
 
                         <Grid
@@ -933,12 +944,6 @@
                                                         <ToggleButton.Content>
                                                             <icons:RegularFluentIcon FontSize="16" Symbol="ExpandUpRight48" />
                                                         </ToggleButton.Content>
-                                                        <ToggleButton.KeyboardAccelerators>
-                                                            <KeyboardAccelerator
-                                                                Key="M"
-                                                                IsEnabled="True"
-                                                                Modifiers="Control" />
-                                                        </ToggleButton.KeyboardAccelerators>
                                                     </ToggleButton>
                                                     <ToggleButton
                                                         x:Name="FullWindowModeButton"

--- a/src/App/Pages/Overlay/PlayerPage.xaml.cs
+++ b/src/App/Pages/Overlay/PlayerPage.xaml.cs
@@ -2,6 +2,8 @@
 
 using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
+using Richasy.Bili.App.Controls;
 using Richasy.Bili.Models.Enums;
 using Richasy.Bili.ViewModels.Uwp;
 using Windows.UI.ViewManagement;
@@ -60,10 +62,10 @@ namespace Richasy.Bili.App.Pages.Overlay
         }
 
         /// <inheritdoc/>
-        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        protected override async void OnNavigatedFrom(NavigationEventArgs e)
         {
             _navigateVM = null;
-            EnterDefaultModeAsync();
+            await EnterDefaultModeAsync();
             if (ViewModel.IsShowViewLater)
             {
                 foreach (var item in ViewModel.ViewLaterVideoCollection)
@@ -77,13 +79,13 @@ namespace Richasy.Bili.App.Pages.Overlay
 
         private async void OnLoadedAsync(object sender, RoutedEventArgs e)
         {
-            ViewModel.PropertyChanged += OnViewModelPropertyChanged;
+            ViewModel.PropertyChanged += OnViewModelPropertyChangedAsync;
             if (_navigateVM != null)
             {
                 await ViewModel.LoadAsync(_navigateVM);
             }
 
-            CheckPlayerDisplayModeAsync();
+            await CheckPlayerDisplayModeAsync();
 
             if (ViewModel.IsDetailCanLoaded)
             {
@@ -91,12 +93,12 @@ namespace Richasy.Bili.App.Pages.Overlay
             }
         }
 
-        private void OnViewModelPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private async void OnViewModelPropertyChangedAsync(object sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
                 case nameof(ViewModel.PlayerDisplayMode):
-                    CheckPlayerDisplayModeAsync();
+                    await CheckPlayerDisplayModeAsync();
                     break;
                 case nameof(ViewModel.IsDetailCanLoaded):
                     if (ViewModel.IsDetailCanLoaded)
@@ -112,7 +114,7 @@ namespace Richasy.Bili.App.Pages.Overlay
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
         {
-            ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            ViewModel.PropertyChanged -= OnViewModelPropertyChangedAsync;
             ViewModel.ClearPlayer();
         }
 
@@ -134,13 +136,13 @@ namespace Richasy.Bili.App.Pages.Overlay
             }
         }
 
-        private async void CheckPlayerDisplayModeAsync()
+        private async Task CheckPlayerDisplayModeAsync()
         {
             var appView = ApplicationView.GetForCurrentView();
 
             if (ViewModel.PlayerDisplayMode == PlayerDisplayMode.Default)
             {
-                EnterDefaultModeAsync();
+                await EnterDefaultModeAsync();
                 CoreViewModel.IsOverLayerExtendToTitleBar = false;
             }
             else
@@ -172,14 +174,17 @@ namespace Richasy.Bili.App.Pages.Overlay
                 }
                 else
                 {
-                    EnterDefaultModeAsync();
+                    await EnterDefaultModeAsync();
                 }
             }
 
             CheckPlayerVisual();
+
+            await Task.Delay(500);
+            await (ViewModel.BiliPlayer.TransportControls as BiliPlayerTransportControls).CheckCurrentPlayerModeAsync();
         }
 
-        private async void EnterDefaultModeAsync()
+        private async Task EnterDefaultModeAsync()
         {
             var appView = ApplicationView.GetForCurrentView();
             VisualStateManager.GoToState(this, nameof(StandardPlayerState), false);


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1127 

修复迷你视图快捷键问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

Ctrl+M可以进入迷你视图，但不能退出

## 新的行为是什么？

可以正常进入/退出

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

调整弹幕及播放模式按钮的状态切换
