### PR TITLE
过滤切换片源期间非预期的播放错误

### DIFF
--- a/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
+++ b/src/App/Controls/Player/BiliPlayerTransportControls/BiliPlayerTransportControls.cs
@@ -662,7 +662,7 @@ namespace Richasy.Bili.App.Controls
             if (_danmakuTimer == null)
             {
                 _danmakuTimer = new DispatcherTimer();
-                _danmakuTimer.Interval = TimeSpan.FromSeconds(0.5);
+                _danmakuTimer.Interval = TimeSpan.FromSeconds(0.1);
                 _danmakuTimer.Tick += OnDanmkuTimerTickAsync;
             }
         }

--- a/src/ViewModels/ViewModels.Uwp/Common/DanmakuViewModel/DanmakuViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/DanmakuViewModel/DanmakuViewModel.Methods.cs
@@ -16,8 +16,27 @@ namespace Richasy.Bili.ViewModels.Uwp.Common
         /// </summary>
         /// <param name="newSegmentIndex">新的分片索引.</param>
         /// <returns><see cref="Task"/>.</returns>
-        public Task RequestNewSegmentDanmakuAsync(int newSegmentIndex)
-            => Controller.RequestNewSegmentDanmakuAsync(_videoId, _partId, newSegmentIndex);
+        public async Task RequestNewSegmentDanmakuAsync(int newSegmentIndex)
+        {
+            if (_isRequestingDanmaku)
+            {
+                return;
+            }
+
+            _isRequestingDanmaku = true;
+            try
+            {
+                await Controller.RequestNewSegmentDanmakuAsync(_videoId, _partId, newSegmentIndex);
+            }
+            catch (System.Exception)
+            {
+                throw;
+            }
+            finally
+            {
+                _isRequestingDanmaku = false;
+            }
+        }
 
         private void OnSegmentDanmakuIteration(object sender, SegmentDanmakuIterationEventArgs e)
         {

--- a/src/ViewModels/ViewModels.Uwp/Common/DanmakuViewModel/DanmakuViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/DanmakuViewModel/DanmakuViewModel.Properties.cs
@@ -22,6 +22,7 @@ namespace Richasy.Bili.ViewModels.Uwp.Common
 
         private long _videoId;
         private long _partId;
+        private bool _isRequestingDanmaku;
 
         /// <summary>
         /// 弹幕视图模型单例.

--- a/src/ViewModels/ViewModels.Uwp/Common/DanmakuViewModel/DanmakuViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/DanmakuViewModel/DanmakuViewModel.cs
@@ -54,22 +54,13 @@ namespace Richasy.Bili.ViewModels.Uwp.Common
         {
             _videoId = videoId;
             _partId = partId;
+            _isRequestingDanmaku = false;
             Reset();
-
-            if (UseCloudShieldSettings)
-            {
-                try
-                {
-                    var danmakuMeta = await Controller.GetDanmakuMetaDataAsync(_videoId, _partId);
-                    DanmakuConfig = danmakuMeta;
-                }
-                catch (Exception)
-                {
-                }
-            }
 
             try
             {
+                var danmakuMeta = await Controller.GetDanmakuMetaDataAsync(_videoId, _partId);
+                DanmakuConfig = danmakuMeta;
                 await Controller.RequestNewSegmentDanmakuAsync(_videoId, _partId, 1);
             }
             catch (Exception)

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.Methods.cs
@@ -959,7 +959,7 @@ namespace Richasy.Bili.ViewModels.Uwp
 
         private async void OnMediaPlayerFailedAsync(MediaPlayer sender, MediaPlayerFailedEventArgs args)
         {
-            if (args.ExtendedErrorCode?.HResult == -1072873851)
+            if (args.ExtendedErrorCode?.HResult == -1072873851 || args.Error == MediaPlayerError.Unknown)
             {
                 // 不处理 Shutdown 造成的错误.
                 return;
@@ -978,9 +978,6 @@ namespace Richasy.Bili.ViewModels.Uwp
                 var message = string.Empty;
                 switch (args.Error)
                 {
-                    case MediaPlayerError.Unknown:
-                        message = _resourceToolkit.GetLocaleString(LanguageNames.UnknownError);
-                        break;
                     case MediaPlayerError.Aborted:
                         message = _resourceToolkit.GetLocaleString(LanguageNames.Aborted);
                         break;

--- a/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Common/PlayerViewModel/PlayerViewModel.cs
@@ -971,7 +971,6 @@ namespace Richasy.Bili.ViewModels.Uwp
                     }
 
                     break;
-                case nameof(IsPlayInformationError):
                 case nameof(IsDetailError):
                     PlayerDisplayMode = PlayerDisplayMode.Default;
                     break;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Description

在切换分P时会触发MediaFailed事件，该条件非预期，且在切换片源期间切换播放器模式会导致一些布局错误，过滤这个事件能够解决一些问题：

1. 全窗口或全屏播放视频时强制返回默认模式
2. 出现布局闭环，导致界面失去响应

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

1. 全窗口或全屏播放视频时强制返回默认模式
2. 出现布局闭环，导致界面失去响应

## 新的行为是什么？

通过过滤到不需要的错误来阻止非预期的状态切换

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

调整了弹幕同调频率，让弹幕不至于一卡一卡地前进
