### PR TITLE
修复 DataContext 和 ViewModel 同时被bind的时候在ARM上会出现无限循环的问题

### DIFF
--- a/src/App/Controls/Favorite/FavoriteVideoView.xaml
+++ b/src/App/Controls/Favorite/FavoriteVideoView.xaml
@@ -90,7 +90,7 @@
                                     IsShowDuration="True"
                                     IsShowPlayCount="True"
                                     ItemClick="OnVideoCardClick"
-                                    ViewModel="{x:Bind}">
+                                    ViewModel="{x:Bind Mode=OneWay}">
                                     <local:VideoCard.ContextFlyout>
                                         <muxc:CommandBarFlyout Opening="OnVideoFlyoutOpening">
                                             <muxc:CommandBarFlyout.SecondaryCommands>


### PR DESCRIPTION
Close #911 #1147

## PR 类型
Bug 修复

## 当前行为是什么？
在ARM64/Release中，FavoriteVideoView中的VideoCard在加载时会栈溢出

## 新的行为是什么？
不会溢出

## PR 检查清单

请检查你的 PR 是否满足以下要求

- [X] 应用成功启动
- [ ] 新组件
  - [ ] 已经准备了关于新组件的说明文档，文档链接：[link]()
  - [ ] 对于控件，已将控件放在主项目的 Controls 文件夹内
- [ ] 主要的功能修改已经添加至 [Wiki](https://github.com/Richasy/Bili.Uwp/wiki)
- [X] 文件头已经被添加至所有源文件中
- [X] **不**包含破坏式更新


## 备注

