### PR TITLE
修复新动态通知的链接问题

### DIFF
--- a/src/Tasks/DynamicNotifyTask.cs
+++ b/src/Tasks/DynamicNotifyTask.cs
@@ -38,6 +38,7 @@ namespace Bili.Tasks
             var isFirstCheck = settingsToolkit.ReadLocalSetting(SettingNames.IsFirstRunDynamicNotifyTask, true);
             var firstCard = dynamics.Dynamics.First();
             var cardList = dynamics.Dynamics.ToList();
+
             var lastReadId = settingsToolkit.ReadLocalSetting(SettingNames.LastReadVideoDynamicId, string.Empty);
 
             // 初次检查或者未更新时不会进行通知
@@ -80,19 +81,20 @@ namespace Bili.Tasks
 
                     var title = string.Empty;
                     var coverUrl = string.Empty;
-                    var type = string.Empty;
+                    var type = "video";
                     var id = string.Empty;
                     var avatar = item.User.Avatar.GetSourceUri().ToString();
                     var desc = item.Description?.Text;
                     var timeLabel = string.IsNullOrEmpty(item.Tip)
                         ? "ms-resource:AppName"
                         : item.Tip;
+                    var additional = string.Empty;
 
                     if (item.Data is VideoInformation videoInfo)
                     {
+                        id = videoInfo.Identifier.Id;
                         title = videoInfo.Identifier.Title;
                         coverUrl = videoInfo.Identifier.Cover.GetSourceUri().ToString();
-                        type = "video";
                         if (string.IsNullOrEmpty(desc))
                         {
                             desc = videoInfo.Publisher?.User?.Name ?? string.Empty;
@@ -100,9 +102,10 @@ namespace Bili.Tasks
                     }
                     else if (item.Data is EpisodeInformation episodeInfo)
                     {
+                        id = episodeInfo.VideoId;
                         title = episodeInfo.Identifier.Title;
                         coverUrl = episodeInfo.Identifier.Cover.GetSourceUri().ToString();
-                        type = "episode";
+                        additional = "&isPgc=true";
                         if (string.IsNullOrEmpty(desc))
                         {
                             desc = episodeInfo.Subtitle;
@@ -111,7 +114,7 @@ namespace Bili.Tasks
 
                     coverUrl += "@400w_250h_1c_100q.jpg";
                     avatar += "@100w_100h_1c_100q.jpg";
-                    var protocol = $"richasy-bili://play?{type}={id}";
+                    var protocol = $"richasy-bili://play?{type}={id}{additional}";
 
                     new ToastContentBuilder()
                         .AddText(title, hintWrap: true, hintMaxLines: 2)


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

修复点击动态卡片后不能正确导航到播放页的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

点击通知卡片，不能正确播放对应的视频

## 新的行为是什么？

点击通知卡片后可以播放视频

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
