### PR TITLE
双击改变播放模式后，恢复播放

### DIFF
--- a/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Handlers.cs
+++ b/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Handlers.cs
@@ -103,7 +103,14 @@ namespace Bili.App.Controls.Player
             {
                 if (e.PointerDeviceType == Windows.Devices.Input.PointerDeviceType.Mouse)
                 {
-                    ViewModel.ToggleFullScreenCommand.Execute().Subscribe();
+                    ViewModel.ToggleFullScreenCommand.Execute().Subscribe(
+                        _ =>
+                        {
+                            if (ViewModel.IsMediaPause)
+                            {
+                                ViewModel.PlayPauseCommand.Execute().Subscribe();
+                            }
+                        });
                 }
                 else
                 {

--- a/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.cs
+++ b/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
 using System;
-using System.ComponentModel;
 using Bili.App.Controls.Danmaku;
 using Bili.ViewModels.Uwp.Core;
-using Windows.Media.Playback;
 using Windows.UI.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1250 

在桌面鼠标双击改变播放器显示模式后，如果此时播放器处于暂停状态，则恢复播放

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

播放模式改变后，播放/暂停状态不确定，看手速

## 新的行为是什么？

改变后即恢复播放，取消暂停

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
