### PR TITLE
在全窗口/全屏时去除播放器圆角

### DIFF
--- a/src/App/Controls/Player/PlayerPagePanel/PlayerPagePanel.xaml
+++ b/src/App/Controls/Player/PlayerPagePanel/PlayerPagePanel.xaml
@@ -72,6 +72,7 @@
                                         <Setter Target="ExpandButtonContainer.Visibility" Value="Collapsed" />
                                         <Setter Target="RootView.OpenPaneLength" Value="0" />
                                         <Setter Target="RootView.IsPaneOpen" Value="False" />
+                                        <Setter Target="PlayerComponent.CornerRadius" Value="0" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

在全窗口时将播放器圆角设置为0，以避免在Win10的直角窗口中露馅

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

Win10下全窗口/全屏时播放器四角不能全覆盖

## 新的行为是什么？

全覆盖

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
