### PR TITLE
修复因调整音量造成的UI卡死

### DIFF
--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Controls.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Controls.cs
@@ -131,7 +131,7 @@ namespace Bili.ViewModels.Uwp.Core
             });
         }
 
-        private async Task ChangeVolumeAsync(double volume)
+        private void ChangeVolume(double volume)
         {
             try
             {
@@ -151,22 +151,12 @@ namespace Bili.ViewModels.Uwp.Core
                 volume = 0;
             }
 
-            await _dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+            if (Volume != volume)
             {
-                if (Volume != volume)
-                {
-                    Volume = volume;
-                }
+                Volume = volume;
+            }
 
-                var msg = volume > 0
-                    ? $"{_resourceToolkit.GetLocaleString(LanguageNames.CurrentVolume)}: {Math.Round(volume)}"
-                    : _resourceToolkit.GetLocaleString(LanguageNames.Muted);
-
-                RequestShowTempMessage?.Invoke(this, msg);
-
-                _mediaPlayer.Volume = volume / 100.0;
-                _settingsToolkit.WriteLocalSetting(SettingNames.Volume, Volume);
-            });
+            _settingsToolkit.WriteLocalSetting(SettingNames.Volume, Volume);
         }
 
         private void ToggleFullScreenMode()

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
@@ -446,13 +446,31 @@ namespace Bili.ViewModels.Uwp.Core
         private void OnProgressTimerTick(object sender, object e)
             => ReportViewProgressCommand.Execute().Subscribe();
 
-        private void OnUnitTimerTickAsync(object sender, object e)
+        private async void OnUnitTimerTickAsync(object sender, object e)
         {
             if (_isInteractionProgressChanged)
             {
                 _isInteractionProgressChanged = false;
                 _mediaPlayer.PlaybackSession.Position = _interactionProgress;
                 _interactionProgress = TimeSpan.Zero;
+            }
+
+            _presetVolumeHoldTime += 100;
+            if (_presetVolumeHoldTime > 300)
+            {
+                _presetVolumeHoldTime = 0;
+                if (_mediaPlayer != null
+                && Volume != _mediaPlayer.Volume * 100d)
+                {
+                    await _dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+                    {
+                        var msg = Volume > 0
+                            ? $"{_resourceToolkit.GetLocaleString(LanguageNames.CurrentVolume)}: {Math.Round(Volume)}"
+                            : _resourceToolkit.GetLocaleString(LanguageNames.Muted);
+                        RequestShowTempMessage?.Invoke(this, msg);
+                        _mediaPlayer.Volume = Volume / 100d;
+                    });
+                }
             }
         }
 

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Properties.cs
@@ -64,6 +64,7 @@ namespace Bili.ViewModels.Uwp.Core
 
         private double _originalPlayRate;
         private double _originalDanmakuSpeed;
+        private double _presetVolumeHoldTime;
 
         /// <summary>
         /// 媒体播放器改变.

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
@@ -90,7 +90,7 @@ namespace Bili.ViewModels.Uwp.Core
             ForwardSkipCommand = ReactiveCommand.CreateFromTask(ForwardSkipAsync, outputScheduler: RxApp.MainThreadScheduler);
             BackwardSkipCommand = ReactiveCommand.CreateFromTask(BackwardSkipAsync, outputScheduler: RxApp.MainThreadScheduler);
             ChangePlayRateCommand = ReactiveCommand.CreateFromTask<double>(ChangePlayRateAsync, outputScheduler: RxApp.MainThreadScheduler);
-            ChangeVolumeCommand = ReactiveCommand.CreateFromTask<double>(ChangeVolumeAsync, outputScheduler: RxApp.MainThreadScheduler);
+            ChangeVolumeCommand = ReactiveCommand.Create<double>(ChangeVolume, outputScheduler: RxApp.MainThreadScheduler);
             ToggleFullScreenCommand = ReactiveCommand.Create(ToggleFullScreenMode, outputScheduler: RxApp.MainThreadScheduler);
             ToggleFullWindowCommand = ReactiveCommand.Create(ToggleFullWindowMode, outputScheduler: RxApp.MainThreadScheduler);
             ToggleCompactOverlayCommand = ReactiveCommand.Create(ToggleCompactOverlayMode, outputScheduler: RxApp.MainThreadScheduler);


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

在手动拖动音量条时极易触发UI卡死，因为往调度器里塞了太多的任务

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

拖动音量条UI易卡死

## 新的行为是什么？

通过简单的防抖，减少大部分无用的音量变化，保证UI的响应

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
