### PR TITLE
修复因查询P2P失败造成的播放问题

### DIFF
--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
@@ -171,19 +171,25 @@ namespace Bili.ViewModels.Uwp.Core
             // 剔除 P2P CDN URL
             if (_mediaInformation.AudioSegments != null)
             {
-                var filteredAudios = _mediaInformation.AudioSegments.Where(p => !p.BaseUrl.Contains("bilivideo.com"));
-                foreach (var item in filteredAudios)
+                var filteredAudios = _mediaInformation.AudioSegments.Where(p => !(p.BaseUrl?.Contains("bilivideo.com") ?? false));
+                if (filteredAudios.Any())
                 {
-                    item.BaseUrl = item.BackupUrls.FirstOrDefault(p => p.Contains("bilivideo.com")) ?? item.BaseUrl;
+                    foreach (var item in filteredAudios)
+                    {
+                        item.BaseUrl = item.BackupUrls?.FirstOrDefault(p => p?.Contains("bilivideo.com") ?? false) ?? item.BaseUrl;
+                    }
                 }
             }
 
             if (_mediaInformation.VideoSegments != null)
             {
-                var filteredAudios = _mediaInformation.VideoSegments.Where(p => !p.BaseUrl.Contains("bilivideo.com"));
-                foreach (var item in filteredAudios)
+                var filteredVideos = _mediaInformation.VideoSegments.Where(p => !(p.BaseUrl?.Contains("bilivideo.com") ?? false));
+                if (filteredVideos.Any())
                 {
-                    item.BaseUrl = item.BackupUrls.FirstOrDefault(p => p.Contains("bilivideo.com")) ?? item.BaseUrl;
+                    foreach (var item in filteredVideos)
+                    {
+                        item.BaseUrl = item.BackupUrls?.FirstOrDefault(p => p?.Contains("bilivideo.com") ?? false) ?? item.BaseUrl;
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1278 

在进行 Linq 索引时没有考虑到可能为空的情况，导致报错

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

对于部分视频可能出现空引用的问题

## 新的行为是什么？

进行了空值判断

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
