### PR TITLE
修复默认收藏夹为空时的空引用错误

### DIFF
--- a/src/Adapter/Adapter.Implementation/FavoriteAdapter.cs
+++ b/src/Adapter/Adapter.Implementation/FavoriteAdapter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
+using System.Collections.Generic;
 using System.Linq;
 using Bili.Adapter.Interfaces;
 using Bili.Models.BiliBili;
@@ -68,7 +69,7 @@ namespace Bili.Adapter
         public VideoFavoriteFolderDetail ConvertToVideoFavoriteFolderDetail(VideoFavoriteListResponse response)
         {
             var folder = ConvertToVideoFavoriteFolder(response.Detail ?? response.Information);
-            var videos = response.Medias.Select(p => _videoAdapter.ConvertToVideoInformation(p));
+            var videos = response.Medias?.Select(p => _videoAdapter.ConvertToVideoInformation(p)) ?? new List<VideoInformation>();
             var videoSet = new VideoSet(videos, folder.TotalCount);
             return new VideoFavoriteFolderDetail(folder, videoSet);
         }
@@ -79,8 +80,8 @@ namespace Bili.Adapter
             var id = folder.Id;
             var name = _textToolkit.ConvertToTraditionalChineseIfNeeded(folder.Name);
             var isMine = id == 1;
-            var folders = folder.MediaList.List.Select(p => ConvertToVideoFavoriteFolder(p));
-            var set = new VideoFavoriteSet(folders, folder.MediaList.Count);
+            var folders = folder.MediaList?.List?.Select(p => ConvertToVideoFavoriteFolder(p)) ?? new List<VideoFavoriteFolder>();
+            var set = new VideoFavoriteSet(folders, folder.MediaList?.Count ?? 0);
             return new VideoFavoriteFolderGroup(id.ToString(), name, isMine, set);
         }
 
@@ -90,7 +91,7 @@ namespace Bili.Adapter
             var defaultFolder = ConvertToVideoFavoriteFolderDetail(response.DefaultFavoriteList);
 
             // 过滤稍后再看的内容，稍后再看列表的Id为3.
-            var favoriteSets = response.FavoriteFolderList
+            var favoriteSets = response.FavoriteFolderList?
                 .Where(p => p.Id != 3)
                 .Select(p => ConvertToVideoFavoriteFolderGroup(p));
             return new VideoFavoriteView(favoriteSets, defaultFolder);


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1275 

如果默认收藏夹为空，则不能正确获取到媒体列表，进而引发错误

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

默认收藏夹为空时页面报错

## 新的行为是什么？

允许收藏夹为空

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
