### PR TITLE
移除搜索类型的禁用状态

### DIFF
--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Dash.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Dash.cs
@@ -78,7 +78,7 @@ namespace Bili.ViewModels.Uwp.Core
             }
         }
 
-        private async Task GetDashLiveSourceAsync(string url)
+        private async Task LoadDashLiveSourceAsync(string url)
         {
             try
             {

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Live.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Live.cs
@@ -102,7 +102,7 @@ namespace Bili.ViewModels.Uwp.Core
 
         private async Task InitializeLivePlayerAsync(string url)
         {
-            await GetDashLiveSourceAsync(url.ToString());
+            await LoadDashLiveSourceAsync(url.ToString());
         }
 
         private async Task ChangeLiveAudioOnlyAsync(bool isAudioOnly)

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
@@ -154,7 +154,6 @@ namespace Bili.ViewModels.Uwp.Core
                 return;
             }
 
-            await Task.Delay(100);
             await LoadDashVideoSourceAsync();
             StartTimersAndDisplayRequest();
         }

--- a/src/ViewModels/ViewModels.Uwp/Search/SearchPageViewModel/SearchPageViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Search/SearchPageViewModel/SearchPageViewModel.Properties.cs
@@ -25,6 +25,7 @@ namespace Bili.ViewModels.Uwp.Search
         private readonly IHomeProvider _homeProvider;
         private readonly IArticleProvider _articleProvider;
         private readonly IResourceToolkit _resourceToolkit;
+        private readonly ISettingsToolkit _settingsToolkit;
         private readonly Dictionary<SearchModuleType, bool> _requestStatusCache;
         private readonly Dictionary<SearchModuleType, IEnumerable<SearchFilterViewModel>> _filters;
         private readonly ObservableAsPropertyHelper<bool> _isReloadingModule;

--- a/src/ViewModels/ViewModels.Uwp/Search/SearchPageViewModel/SearchPageViewModel.Request.cs
+++ b/src/ViewModels/ViewModels.Uwp/Search/SearchPageViewModel/SearchPageViewModel.Request.cs
@@ -62,7 +62,7 @@ namespace Bili.ViewModels.Uwp.Search
                     var module = Items.FirstOrDefault(p => p.Type == item.Key);
                     if (module != null)
                     {
-                        module.IsEnabled = item.Value > 0;
+                        module.IsEnabled = item.Value >= 0;
                     }
                 }
             }

--- a/src/ViewModels/ViewModels.Uwp/Search/SearchPageViewModel/SearchPageViewModel.Request.cs
+++ b/src/ViewModels/ViewModels.Uwp/Search/SearchPageViewModel/SearchPageViewModel.Request.cs
@@ -54,15 +54,18 @@ namespace Bili.ViewModels.Uwp.Search
             var duration = GetCondition(Duration);
             var data = await _searchProvider.GetComprehensiveSearchResultAsync(Keyword, orderType, partitionId, duration);
 
+            var isProxySearch = _settingsToolkit.ReadLocalSetting(SettingNames.IsOpenRoaming, false)
+                    && !string.IsNullOrEmpty(_settingsToolkit.ReadLocalSetting(SettingNames.RoamingSearchAddress, string.Empty));
+
             // 处理元数据.
-            if (data.Metadata != null && data.Metadata.Count > 0)
+            if (data.Metadata != null && data.Metadata.Count > 0 && !isProxySearch)
             {
                 foreach (var item in data.Metadata)
                 {
                     var module = Items.FirstOrDefault(p => p.Type == item.Key);
                     if (module != null)
                     {
-                        module.IsEnabled = item.Value >= 0;
+                        module.IsEnabled = item.Value > 0;
                     }
                 }
             }
@@ -75,7 +78,7 @@ namespace Bili.ViewModels.Uwp.Search
                 {
                     if (!Videos.Any(p => p.Information.Equals(item)))
                     {
-                        var videoVM = Splat.Locator.Current.GetService<VideoItemViewModel>();
+                        var videoVM = Locator.Current.GetService<VideoItemViewModel>();
                         videoVM.SetInformation(item);
                         Videos.Add(videoVM);
                     }

--- a/src/ViewModels/ViewModels.Uwp/Search/SearchPageViewModel/SearchPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Search/SearchPageViewModel/SearchPageViewModel.cs
@@ -35,6 +35,7 @@ namespace Bili.ViewModels.Uwp.Search
             IResourceToolkit resourceToolkit,
             IHomeProvider homeProvider,
             IArticleProvider articleProvider,
+            ISettingsToolkit settingsToolkit,
             CoreDispatcher dispatcher)
             : base(dispatcher)
         {
@@ -42,6 +43,7 @@ namespace Bili.ViewModels.Uwp.Search
             _resourceToolkit = resourceToolkit;
             _homeProvider = homeProvider;
             _articleProvider = articleProvider;
+            _settingsToolkit = settingsToolkit;
 
             _requestStatusCache = new Dictionary<SearchModuleType, bool>();
             _filters = new Dictionary<SearchModuleType, IEnumerable<SearchFilterViewModel>>();


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1299 

综合搜索 API 并没有走代理，得到的还是国区的结果，所以会和实际情况有出入

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

在开启代理的时候搜 `进击的巨人` 等港澳台番剧，搜索结果与实际结果不匹配

## 新的行为是什么？

在开启代理的情况下，搜索结果不根据数量禁用标头

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

暂不就此问题修改代理脚本
