### PR TITLE
重新添加原生播放解析，并提供设置项切换

### DIFF
--- a/src/Adapter/Adapter.Implementation/PlayerAdapter.cs
+++ b/src/Adapter/Adapter.Implementation/PlayerAdapter.cs
@@ -39,7 +39,13 @@ namespace Bili.Adapter
                 item.Id.ToString(),
                 item.BaseUrl,
                 item.BackupUrl,
-                item.Codecs);
+                item.BandWidth,
+                item.MimeType,
+                item.Codecs,
+                item.Width,
+                item.Height,
+                item.SegmentBase.Initialization,
+                item.SegmentBase.IndexRange);
         }
 
         /// <inheritdoc/>
@@ -51,6 +57,7 @@ namespace Bili.Adapter
                 return default;
             }
 
+            var minBuffer = dash.MinBufferTime;
             var videos = dash.Video?.Count > 0
                 ? dash.Video.Select(p => ConvertToSegmentInformation(p))
                 : null;
@@ -58,7 +65,7 @@ namespace Bili.Adapter
                 ? dash.Audio.Select(p => ConvertToSegmentInformation(p))
                 : null;
             var formats = information.SupportFormats.Select(p => ConvertToFormatInformation(p)).ToList();
-            return new MediaInformation(videos, audios, formats);
+            return new MediaInformation(minBuffer, videos, audios, formats);
         }
 
         /// <inheritdoc/>
@@ -89,7 +96,13 @@ namespace Bili.Adapter
                     video.StreamInfo.Quality.ToString(),
                     video.DashVideo.BaseUrl,
                     video.DashVideo.BackupUrl.ToList(),
-                    video.DashVideo.Codecid.ToString());
+                    default,
+                    default,
+                    video.DashVideo.Codecid.ToString(),
+                    default,
+                    default,
+                    default,
+                    default);
                 var format = new FormatInformation(
                     Convert.ToInt32(video.StreamInfo.Quality),
                     video.StreamInfo.Description,
@@ -104,12 +117,18 @@ namespace Bili.Adapter
                     audio.Id.ToString(),
                     audio.BaseUrl,
                     audio.BackupUrl.ToList(),
-                    audio.Codecid.ToString());
+                    default,
+                    default,
+                    audio.Codecid.ToString(),
+                    default,
+                    default,
+                    default,
+                    default);
 
                 audios.Add(seg);
             }
 
-            return new MediaInformation(videos, audios, formats);
+            return new MediaInformation(default, videos, audios, formats);
         }
 
         /// <inheritdoc/>

--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -530,6 +530,7 @@
     <Compile Include="Resources\Converter\PgcFavoriteStatusConverter.cs" />
     <Compile Include="Resources\Converter\PgcFollowTextConverter.cs" />
     <Compile Include="Resources\Converter\PlayerDisplayModeConverter.cs" />
+    <Compile Include="Resources\Converter\PlayerTypeConverter.cs" />
     <Compile Include="Resources\Converter\PreferCodecConverter.cs" />
     <Compile Include="Resources\Converter\RelationButtonStyleConverter.cs" />
     <Compile Include="Resources\Converter\RelationTextConverter.cs" />
@@ -557,6 +558,8 @@
     <Content Include="Assets\Bili_rgba_80.png" />
     <Content Include="Assets\Bili_rgba_25.png" />
     <Content Include="Assets\Bili_rgba_500.png" />
+    <Content Include="Assets\DashVideoTemplate.xml" />
+    <Content Include="Assets\DashVideoWithoutAudioTemplate.xml" />
     <Content Include="Assets\ERROR_rgba.png" />
     <Content Include="Assets\img_holder_rect.png" />
     <Content Include="Assets\Level\level_0.png" />

--- a/src/App/Assets/DashVideoTemplate.xml
+++ b/src/App/Assets/DashVideoTemplate.xml
@@ -1,0 +1,13 @@
+﻿<MPD xmlns="urn:mpeg:DASH:schema:MPD:2011" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static"
+     minBufferTime="{bufferTime}">
+    <Period start="PT0S">
+        <AdaptationSet group="1">
+            <ContentComponent contentType="audio" id="1" />
+            {audio}
+        </AdaptationSet>
+        <AdaptationSet group="2">
+            <ContentComponent contentType="video" id="2" />
+            {video}
+        </AdaptationSet>
+    </Period>
+</MPD>

--- a/src/App/Assets/DashVideoWithoutAudioTemplate.xml
+++ b/src/App/Assets/DashVideoWithoutAudioTemplate.xml
@@ -1,0 +1,9 @@
+﻿<MPD xmlns="urn:mpeg:DASH:schema:MPD:2011" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static"
+     minBufferTime="{bufferTime}">
+    <Period start="PT0S">
+        <AdaptationSet group="1">
+            <ContentComponent contentType="video" id="1" />
+            {video}
+        </AdaptationSet>
+    </Period>
+</MPD>

--- a/src/App/Controls/Settings/PlayerControlSettingSection.xaml
+++ b/src/App/Controls/Settings/PlayerControlSettingSection.xaml
@@ -12,6 +12,7 @@
     xmlns:local="using:Bili.App.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:player="using:Bili.Models.Enums.Player"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -19,6 +20,7 @@
     <local:SettingSectionControl.Resources>
         <converter:PreferCodecConverter x:Key="PreferCodecConverter" />
         <converter:DecodeTypeConverter x:Key="DecodeTypeConverter" />
+        <converter:PlayerTypeConverter x:Key="PlayerTypeConverter" />
     </local:SettingSectionControl.Resources>
 
     <exp:ExpanderEx>
@@ -37,6 +39,30 @@
             <exp:ExpanderExMenuPanel>
 
                 <exp:ExpanderExWrapper Style="{StaticResource WrapperInExpanderContentStyle}">
+                    <exp:ExpanderExWrapper.MainContent>
+                        <exp:ExpanderExDescriptor
+                            Title="{loc:Locale Name=PlayerType}"
+                            Description="{loc:Locale Name=PlayerTypeDescription}"
+                            IconVisibility="Collapsed"
+                            IsAutoHideIcon="False" />
+                    </exp:ExpanderExWrapper.MainContent>
+                    <exp:ExpanderExWrapper.WrapContent>
+                        <ComboBox
+                            MinWidth="120"
+                            ItemsSource="{x:Bind ViewModel.PlayerTypeCollection, Mode=OneWay}"
+                            SelectedItem="{x:Bind ViewModel.PlayerType, Mode=TwoWay}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate x:DataType="player:PlayerType">
+                                    <TextBlock Text="{x:Bind Converter={StaticResource PlayerTypeConverter}}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                    </exp:ExpanderExWrapper.WrapContent>
+                </exp:ExpanderExWrapper>
+
+                <exp:ExpanderExItemSeparator />
+
+                <exp:ExpanderExWrapper Style="{StaticResource WrapperInExpanderContentStyle}" Visibility="{x:Bind ViewModel.IsFFmpegPlayer, Mode=OneWay}">
                     <exp:ExpanderExWrapper.MainContent>
                         <exp:ExpanderExDescriptor
                             Title="{loc:Locale Name=DecodeType}"
@@ -58,7 +84,7 @@
                     </exp:ExpanderExWrapper.WrapContent>
                 </exp:ExpanderExWrapper>
 
-                <exp:ExpanderExItemSeparator />
+                <exp:ExpanderExItemSeparator Visibility="{x:Bind ViewModel.IsFFmpegPlayer, Mode=OneWay}" />
 
                 <exp:ExpanderExWrapper Style="{StaticResource WrapperInExpanderContentStyle}">
                     <exp:ExpanderExWrapper.MainContent>

--- a/src/App/Resources/Converter/PlayerTypeConverter.cs
+++ b/src/App/Resources/Converter/PlayerTypeConverter.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Richasy. All rights reserved.
+
+using System;
+using Bili.Models.Enums;
+using Bili.Models.Enums.Player;
+using Bili.Toolkit.Interfaces;
+using Splat;
+using Windows.UI.Xaml.Data;
+
+namespace Bili.App.Resources.Converter
+{
+    internal sealed class PlayerTypeConverter : IValueConverter
+    {
+        /// <inheritdoc/>
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            var result = string.Empty;
+            var resourceToolkit = Locator.Current.GetService<IResourceToolkit>();
+            if (value is PlayerType decode)
+            {
+                switch (decode)
+                {
+                    case PlayerType.Native:
+                        result = resourceToolkit.GetLocaleString(LanguageNames.NativePlayer);
+                        break;
+                    case PlayerType.FFmpeg:
+                        result = resourceToolkit.GetLocaleString(LanguageNames.FFmpegPlayer);
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc/>
+        public object ConvertBack(object value, Type targetType, object parameter, string language) => throw new NotImplementedException();
+    }
+}

--- a/src/App/Resources/Strings/zh-Hans/Resources.resw
+++ b/src/App/Resources/Strings/zh-Hans/Resources.resw
@@ -571,6 +571,9 @@ UGC优先级：分P &gt; 播放列表 &gt; 合集视频 &gt; 关联视频 (如�
   <data name="FavoriteHaveNoVideos" xml:space="preserve">
     <value>收藏夹内没有视频</value>
   </data>
+  <data name="FFmpegPlayer" xml:space="preserve">
+    <value>FFmpeg</value>
+  </data>
   <data name="FilterByGreaterThan60Min" xml:space="preserve">
     <value>60分钟+</value>
   </data>
@@ -888,6 +891,9 @@ UGC优先级：分P &gt; 播放列表 &gt; 合集视频 &gt; 关联视频 (如�
   <data name="MyWebPage" xml:space="preserve">
     <value>个人主页</value>
   </data>
+  <data name="NativePlayer" xml:space="preserve">
+    <value>原生</value>
+  </data>
   <data name="Navigation" xml:space="preserve">
     <value>导航</value>
   </data>
@@ -1073,6 +1079,12 @@ UGC优先级：分P &gt; 播放列表 &gt; 合集视频 &gt; 关联视频 (如�
   </data>
   <data name="PlayerModeDescription" xml:space="preserve">
     <value>包含播放器的基础设置和默认行为</value>
+  </data>
+  <data name="PlayerType" xml:space="preserve">
+    <value>播放器类型</value>
+  </data>
+  <data name="PlayerTypeDescription" xml:space="preserve">
+    <value>对于集显或无显，建议使用原生播放；独显或者原生播放有问题的，可以使用FFmpeg播放</value>
   </data>
   <data name="PlayLine" xml:space="preserve">
     <value>线路</value>

--- a/src/App/Resources/Strings/zh-Hant/Resources.resw
+++ b/src/App/Resources/Strings/zh-Hant/Resources.resw
@@ -572,6 +572,9 @@ UGC優先級：分P &gt; 播放列表 &gt; 合集影片 &gt; 關聯影片 (如�
   <data name="FavoriteHaveNoVideos" xml:space="preserve">
     <value>收藏夾內沒有影片</value>
   </data>
+  <data name="FFmpegPlayer" xml:space="preserve">
+    <value>FFmpeg</value>
+  </data>
   <data name="FilterByGreaterThan60Min" xml:space="preserve">
     <value>60分鐘+</value>
   </data>
@@ -889,6 +892,9 @@ UGC優先級：分P &gt; 播放列表 &gt; 合集影片 &gt; 關聯影片 (如�
   <data name="MyWebPage" xml:space="preserve">
     <value>個人首頁</value>
   </data>
+  <data name="NativePlayer" xml:space="preserve">
+    <value>原生</value>
+  </data>
   <data name="Navigation" xml:space="preserve">
     <value>導航</value>
   </data>
@@ -1074,6 +1080,12 @@ UGC優先級：分P &gt; 播放列表 &gt; 合集影片 &gt; 關聯影片 (如�
   </data>
   <data name="PlayerModeDescription" xml:space="preserve">
     <value>包含播放器的基本設定和預設行為</value>
+  </data>
+  <data name="PlayerType" xml:space="preserve">
+    <value>播放器類型</value>
+  </data>
+  <data name="PlayerTypeDescription" xml:space="preserve">
+    <value>對於集顯或無顯，建議使用原生播放；獨顯或者原生播放有問題的，可以使用FFmpeg播放</value>
   </data>
   <data name="PlayLine" xml:space="preserve">
     <value>線路</value>

--- a/src/Models/Models.Data/Player/MediaInformation.cs
+++ b/src/Models/Models.Data/Player/MediaInformation.cs
@@ -17,14 +17,21 @@ namespace Bili.Models.Data.Player
         /// <param name="audioSegments">不同码率的音频列表.</param>
         /// <param name="formats">格式列表.</param>
         public MediaInformation(
+            double minBufferTime,
             IEnumerable<SegmentInformation> videoSegments,
             IEnumerable<SegmentInformation> audioSegments,
             IEnumerable<FormatInformation> formats)
         {
+            MinBufferTime = minBufferTime;
             VideoSegments = videoSegments;
             AudioSegments = audioSegments;
             Formats = formats;
         }
+
+        /// <summary>
+        /// 最低缓冲时间.
+        /// </summary>
+        public double MinBufferTime { get; }
 
         /// <summary>
         /// 不同清晰度的视频列表.

--- a/src/Models/Models.Data/Player/SegmentInformation.cs
+++ b/src/Models/Models.Data/Player/SegmentInformation.cs
@@ -15,17 +15,35 @@ namespace Bili.Models.Data.Player
         /// <param name="id">分段 Id.</param>
         /// <param name="baseUrl">基链接.</param>
         /// <param name="backupUrls">备份链接.</param>
+        /// <param name="bandwidth">媒体要求的带宽.</param>
+        /// <param name="mimeType">媒体格式.</param>
         /// <param name="codecs">媒体编码.</param>
+        /// <param name="width">媒体宽度.</param>
+        /// <param name="height">媒体高度.</param>
+        /// <param name="initialization">起始位置.</param>
+        /// <param name="indexRange">索引范围.</param>
         public SegmentInformation(
             string id,
             string baseUrl,
             IEnumerable<string> backupUrls,
-            string codecs)
+            int bandwidth,
+            string mimeType,
+            string codecs,
+            int width,
+            int height,
+            string initialization,
+            string indexRange)
         {
             Id = id;
             BaseUrl = baseUrl;
             BackupUrls = backupUrls;
+            Bandwidth = bandwidth;
+            MimeType = mimeType;
             Codecs = codecs;
+            Width = width;
+            Height = height;
+            Initialization = initialization;
+            IndexRange = indexRange;
         }
 
         /// <summary>
@@ -44,9 +62,39 @@ namespace Bili.Models.Data.Player
         public IEnumerable<string> BackupUrls { get; }
 
         /// <summary>
+        /// 媒体要求的带宽.
+        /// </summary>
+        public int Bandwidth { get; }
+
+        /// <summary>
+        /// 媒体格式.
+        /// </summary>
+        public string MimeType { get; }
+
+        /// <summary>
         /// 媒体编码.
         /// </summary>
         public string Codecs { get; }
+
+        /// <summary>
+        /// 媒体宽度.
+        /// </summary>
+        public int Width { get; }
+
+        /// <summary>
+        /// 媒体高度.
+        /// </summary>
+        public int Height { get; }
+
+        /// <summary>
+        /// 起始位置.
+        /// </summary>
+        public string Initialization { get; }
+
+        /// <summary>
+        /// 索引范围.
+        /// </summary>
+        public string IndexRange { get; }
 
         /// <inheritdoc/>
         public override bool Equals(object obj) => obj is SegmentInformation information && Id == information.Id;

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -533,6 +533,10 @@ namespace Bili.Models.Enums
         FullTraditionalChineseDescription,
         HardwareDecode,
         SoftwareDecode,
+        NativePlayer,
+        FFmpegPlayer,
+        PlayerType,
+        PlayerTypeDescription,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/Models/Models.Enums/App/SettingNames.cs
+++ b/src/Models/Models.Enums/App/SettingNames.cs
@@ -80,6 +80,7 @@ namespace Bili.Models.Enums
         LastAppLanguage,
         IsFullTraditionalChinese,
         DecodeType,
+        PlayerType,
 #pragma warning disable SA1602 // Enumeration items should be documented
     }
 }

--- a/src/Models/Models.Enums/Player/PlayerType.cs
+++ b/src/Models/Models.Enums/Player/PlayerType.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Richasy. All rights reserved.
+
+namespace Bili.Models.Enums.Player
+{
+    /// <summary>
+    /// 播放器类型.
+    /// </summary>
+    public enum PlayerType
+    {
+        /// <summary>
+        /// 原生播放解码，使用 AdaptiveMediaSource.
+        /// </summary>
+        Native,
+
+        /// <summary>
+        /// FFmpeg解码，借助 FFmpegInteropX.
+        /// </summary>
+        FFmpeg,
+    }
+}

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Controls.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Controls.cs
@@ -27,16 +27,38 @@ namespace Bili.ViewModels.Uwp.Core
             {
                 if (Status == PlayerStatus.Playing)
                 {
-                    _mediaTimelineController.Pause();
+                    if (_mediaTimelineController == null)
+                    {
+                        _videoPlayer.Pause();
+                    }
+                    else
+                    {
+                        _mediaTimelineController.Pause();
+                    }
                 }
                 else if (Status == PlayerStatus.Pause)
                 {
-                    _mediaTimelineController.Resume();
+                    if (_mediaTimelineController == null)
+                    {
+                        _videoPlayer.Play();
+                    }
+                    else
+                    {
+                        _mediaTimelineController.Resume();
+                    }
                 }
                 else if (Status == PlayerStatus.End)
                 {
-                    _mediaTimelineController.Position = TimeSpan.Zero;
-                    _mediaTimelineController.Resume();
+                    if (_mediaTimelineController == null)
+                    {
+                        _videoPlayer.PlaybackSession.Position = TimeSpan.Zero;
+                        _videoPlayer.Play();
+                    }
+                    else
+                    {
+                        _mediaTimelineController.Position = TimeSpan.Zero;
+                        _mediaTimelineController.Resume();
+                    }
                 }
             });
         }
@@ -56,7 +78,9 @@ namespace Bili.ViewModels.Uwp.Core
             await _dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
             {
                 var duration = _videoPlayer.PlaybackSession.NaturalDuration;
-                var currentPos = _mediaTimelineController.Position;
+                var currentPos = _mediaTimelineController == null
+                    ? _videoPlayer.PlaybackSession.Position
+                    : _mediaTimelineController.Position;
                 if ((duration - currentPos).TotalSeconds > seconds)
                 {
                     currentPos += TimeSpan.FromSeconds(seconds);
@@ -66,7 +90,14 @@ namespace Bili.ViewModels.Uwp.Core
                     currentPos = duration;
                 }
 
-                _mediaTimelineController.Position = currentPos;
+                if (_mediaTimelineController == null)
+                {
+                    _videoPlayer.PlaybackSession.Position = currentPos;
+                }
+                else
+                {
+                    _mediaTimelineController.Position = currentPos;
+                }
             });
         }
 
@@ -85,7 +116,9 @@ namespace Bili.ViewModels.Uwp.Core
             await _dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
             {
                 var duration = _videoPlayer.PlaybackSession.NaturalDuration;
-                var currentPos = _mediaTimelineController.Position;
+                var currentPos = _mediaTimelineController == null
+                    ? _videoPlayer.PlaybackSession.Position
+                    : _mediaTimelineController.Position;
                 if (currentPos.TotalSeconds > seconds)
                 {
                     currentPos -= TimeSpan.FromSeconds(seconds);
@@ -95,7 +128,14 @@ namespace Bili.ViewModels.Uwp.Core
                     currentPos = TimeSpan.Zero;
                 }
 
-                _mediaTimelineController.Position = currentPos;
+                if (_mediaTimelineController == null)
+                {
+                    _videoPlayer.PlaybackSession.Position = currentPos;
+                }
+                else
+                {
+                    _mediaTimelineController.Position = currentPos;
+                }
             });
         }
 
@@ -122,7 +162,7 @@ namespace Bili.ViewModels.Uwp.Core
                     PlaybackRate = rate;
                 }
 
-                if(_mediaTimelineController != null)
+                if (_mediaTimelineController != null)
                 {
                     _mediaTimelineController.ClockRate = PlaybackRate;
                 }

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Dash.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Dash.cs
@@ -2,11 +2,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using Bili.Models.App.Constants;
 using Bili.Models.Enums.App;
 using FFmpegInteropX;
+using Windows.Media.Core;
 using Windows.Media.Playback;
+using Windows.Media.Streaming.Adaptive;
 using Windows.Web.Http;
 
 namespace Bili.ViewModels.Uwp.Core
@@ -16,18 +21,16 @@ namespace Bili.ViewModels.Uwp.Core
     /// </summary>
     public sealed partial class MediaPlayerViewModel
     {
-        private async Task LoadDashVideoSourceAsync()
+        private async Task LoadDashVideoSourceFromFFmpegAsync()
         {
-            try
-            {
-                var hasAudio = _audio != null;
-                _videoConfig.VideoDecoderMode = GetDecoderMode();
+            var hasAudio = _audio != null;
+            _videoConfig.VideoDecoderMode = GetDecoderMode();
 
-                var tasks = new List<Task>
+            var tasks = new List<Task>
                 {
                     Task.Run(async () =>
                     {
-                        var client = GetClient();
+                        var client = GetVideoClient();
                         _videoStream = await HttpRandomAccessStream.CreateAsync(client, new Uri(_video.BaseUrl));
                         _videoFFSource = await FFmpegMediaSource.CreateFromStreamAsync(_videoStream, _videoConfig);
                     }),
@@ -35,47 +38,85 @@ namespace Bili.ViewModels.Uwp.Core
                     {
                         if (hasAudio)
                         {
-                            var client = GetClient();
+                            var client = GetVideoClient();
                             _audioStream = await HttpRandomAccessStream.CreateAsync(client, new Uri(_audio.BaseUrl));
                             _audioFFSource = await FFmpegMediaSource.CreateFromStreamAsync(_audioStream, _videoConfig);
                         }
                     }),
                 };
 
-                await Task.WhenAll(tasks);
-                _videoPlaybackItem = _videoFFSource.CreateMediaPlaybackItem();
+            await Task.WhenAll(tasks);
+            _videoPlaybackItem = _videoFFSource.CreateMediaPlaybackItem();
 
-                _videoPlayer = GetVideoPlayer();
-                _videoPlayer.Source = _videoPlaybackItem;
+            _videoPlayer = GetVideoPlayer();
+            _videoPlayer.Source = _videoPlaybackItem;
 
-                if (hasAudio)
+            if (hasAudio)
+            {
+                _audioPlaybackItem = _audioFFSource.CreateMediaPlaybackItem();
+                _mediaTimelineController = GetTimelineController();
+                _videoPlayer.CommandManager.IsEnabled = false;
+                _videoPlayer.TimelineController = _mediaTimelineController;
+                _audioPlayer = new MediaPlayer();
+                _audioPlayer.CommandManager.IsEnabled = false;
+                _audioPlayer.Source = _audioPlaybackItem;
+                _audioPlayer.TimelineController = _mediaTimelineController;
+            }
+
+            MediaPlayerChanged?.Invoke(this, _videoPlayer);
+        }
+
+        private async Task LoadDashVideoSourceFromNativeAsync()
+        {
+            var httpClient = GetVideoClient();
+            var mpdFilePath = _audio == null
+                    ? AppConstants.DashVideoWithoudAudioMPDFile
+                    : AppConstants.DashVideoMPDFile;
+            var mpdStr = await _fileToolkit.ReadPackageFile(mpdFilePath);
+
+            var videoStr =
+                    $@"<Representation bandwidth=""{_video.Bandwidth}"" codecs=""{_video.Codecs}"" height=""{_video.Height}"" mimeType=""{_video.MimeType}"" id=""{_video.Id}"" width=""{_video.Width}"">
+                               <BaseURL></BaseURL>
+                               <SegmentBase indexRange=""{_video.IndexRange}"">
+                                   <Initialization range=""{_video.Initialization}"" />
+                               </SegmentBase>
+                           </Representation>";
+
+            var audioStr = string.Empty;
+
+            if (_audio != null)
+            {
+                audioStr =
+                        $@"<Representation bandwidth=""{_audio.Bandwidth}"" codecs=""{_audio.Codecs}"" mimeType=""{_audio.MimeType}"" id=""{_audio.Id}"">
+                               <BaseURL></BaseURL>
+                               <SegmentBase indexRange=""{_audio.IndexRange}"">
+                                   <Initialization range=""{_audio.Initialization}"" />
+                               </SegmentBase>
+                           </Representation>";
+            }
+
+            videoStr = videoStr.Trim();
+            audioStr = audioStr.Trim();
+            mpdStr = mpdStr.Replace("{video}", videoStr)
+                             .Replace("{audio}", audioStr)
+                             .Replace("{bufferTime}", $"PT{_mediaInformation.MinBufferTime}S");
+
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(mpdStr)).AsInputStream();
+            var soure = await AdaptiveMediaSource.CreateFromStreamAsync(stream, new Uri(_video.BaseUrl), "application/dash+xml", httpClient);
+            Debug.Assert(soure.Status == AdaptiveMediaSourceCreationStatus.Success, "解析MPD失败");
+            soure.MediaSource.DownloadRequested += (sender, args) =>
+            {
+                if (args.ResourceContentType == "audio/mp4" && _audio != null)
                 {
-                    _audioPlaybackItem = _audioFFSource.CreateMediaPlaybackItem();
-                    _mediaTimelineController = GetTimelineController();
-                    _videoPlayer.CommandManager.IsEnabled = false;
-                    _videoPlayer.TimelineController = _mediaTimelineController;
-                    _audioPlayer = new MediaPlayer();
-                    _audioPlayer.CommandManager.IsEnabled = false;
-                    _audioPlayer.Source = _audioPlaybackItem;
-                    _audioPlayer.TimelineController = _mediaTimelineController;
+                    args.Result.ResourceUri = new Uri(_audio.BaseUrl);
                 }
+            };
 
-                MediaPlayerChanged?.Invoke(this, _videoPlayer);
-            }
-            catch (Exception ex)
-            {
-                IsError = true;
-                ErrorText = _resourceToolkit.GetLocaleString(Models.Enums.LanguageNames.RequestVideoFailed);
-                LogException(ex);
-            }
-
-            HttpClient GetClient()
-            {
-                var httpClient = new HttpClient();
-                httpClient.DefaultRequestHeaders.Referer = new Uri("https://www.bilibili.com");
-                httpClient.DefaultRequestHeaders.Add("User-Agent", ServiceConstants.DefaultUserAgentString);
-                return httpClient;
-            }
+            var mediaSource = MediaSource.CreateFromAdaptiveMediaSource(soure.MediaSource);
+            _videoPlaybackItem = new MediaPlaybackItem(mediaSource);
+            _videoPlayer = GetVideoPlayer();
+            _videoPlayer.Source = _videoPlaybackItem;
+            MediaPlayerChanged?.Invoke(this, _videoPlayer);
         }
 
         private async Task LoadDashLiveSourceAsync(string url)
@@ -109,6 +150,14 @@ namespace Bili.ViewModels.Uwp.Core
                 DecodeType.SoftwareDecode => VideoDecoderMode.ForceFFmpegSoftwareDecoder,
                 _ => VideoDecoderMode.Automatic
             };
+        }
+
+        private HttpClient GetVideoClient()
+        {
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Referer = new Uri("https://www.bilibili.com");
+            httpClient.DefaultRequestHeaders.Add("User-Agent", ServiceConstants.DefaultUserAgentString);
+            return httpClient;
         }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Bili.Models.Data.Player;
 using Bili.Models.Data.Video;
 using Bili.Models.Enums;
+using Bili.Models.Enums.Player;
 
 namespace Bili.ViewModels.Uwp.Core
 {
@@ -154,8 +155,26 @@ namespace Bili.ViewModels.Uwp.Core
                 return;
             }
 
-            await LoadDashVideoSourceAsync();
-            StartTimersAndDisplayRequest();
+            try
+            {
+                var playerType = _settingsToolkit.ReadLocalSetting(SettingNames.PlayerType, PlayerType.Native);
+                if(playerType == PlayerType.Native)
+                {
+                    await LoadDashVideoSourceFromNativeAsync();
+                }
+                else
+                {
+                    await LoadDashVideoSourceFromFFmpegAsync();
+                }
+
+                StartTimersAndDisplayRequest();
+            }
+            catch (Exception ex)
+            {
+                IsError = true;
+                ErrorText = _resourceToolkit.GetLocaleString(Models.Enums.LanguageNames.RequestVideoFailed);
+                LogException(ex);
+            }
         }
 
         private void CheckVideoP2PUrls()

--- a/src/ViewModels/ViewModels.Uwp/Home/SettingsPageViewModel/SettingsPageViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Home/SettingsPageViewModel/SettingsPageViewModel.Properties.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Reactive;
 using Bili.Models.Enums;
 using Bili.Models.Enums.App;
+using Bili.Models.Enums.Player;
 using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Uwp.Core;
 using ReactiveUI;
@@ -42,6 +43,12 @@ namespace Bili.ViewModels.Uwp.Home
         /// </summary>
         [Reactive]
         public ObservableCollection<DecodeType> DecodeTypeCollection { get; set; }
+
+        /// <summary>
+        /// 播放器类型可选集合.
+        /// </summary>
+        [Reactive]
+        public ObservableCollection<PlayerType> PlayerTypeCollection { get; set; }
 
         /// <summary>
         /// 应用主题.
@@ -120,6 +127,12 @@ namespace Bili.ViewModels.Uwp.Home
         /// </summary>
         [Reactive]
         public DecodeType DecodeType { get; set; }
+
+        /// <summary>
+        /// 播放器类型.
+        /// </summary>
+        [Reactive]
+        public PlayerType PlayerType { get; set; }
 
         /// <summary>
         /// 单次快进/快退时长.
@@ -210,5 +223,11 @@ namespace Bili.ViewModels.Uwp.Home
         /// </summary>
         [Reactive]
         public bool IsFullTraditionalChinese { get; set; }
+
+        /// <summary>
+        /// 是否为FFmpeg播放器.
+        /// </summary>
+        [Reactive]
+        public bool IsFFmpegPlayer { get; set; }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Home/SettingsPageViewModel/SettingsPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Home/SettingsPageViewModel/SettingsPageViewModel.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using Bili.Models.App.Constants;
 using Bili.Models.Enums;
 using Bili.Models.Enums.App;
+using Bili.Models.Enums.Player;
 using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces;
 using Bili.ViewModels.Uwp.Core;
@@ -67,6 +68,7 @@ namespace Bili.ViewModels.Uwp.Home
             StartupInitAsync();
             BackgroundTaskInitAsync();
             RoamingInit();
+            PlayerTypeInit();
 
             Version = _appToolkit.GetPackageVersion();
             PropertyChanged += OnPropertyChangedAsync;
@@ -152,6 +154,10 @@ namespace Bili.ViewModels.Uwp.Home
                 case nameof(DecodeType):
                     WriteSetting(SettingNames.DecodeType, DecodeType);
                     break;
+                case nameof(PlayerType):
+                    WriteSetting(SettingNames.PlayerType, PlayerType);
+                    IsFFmpegPlayer = PlayerType == PlayerType.FFmpeg;
+                    break;
                 default:
                     break;
             }
@@ -218,6 +224,21 @@ namespace Bili.ViewModels.Uwp.Home
             }
 
             DecodeType = ReadSetting(SettingNames.DecodeType, DecodeType.Automatic);
+        }
+
+        private void PlayerTypeInit()
+        {
+            if (PlayerTypeCollection == null || PlayerTypeCollection.Count == 0)
+            {
+                PlayerTypeCollection = new ObservableCollection<PlayerType>
+                {
+                    PlayerType.Native,
+                    PlayerType.FFmpeg,
+                };
+            }
+
+            PlayerType = ReadSetting(SettingNames.PlayerType, PlayerType.Native);
+            IsFFmpegPlayer = PlayerType == PlayerType.FFmpeg;
         }
 
         private void RoamingInit()


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

在集显或者无显的设备上，ffmpeg的工作不尽如人意，还不如原生解析，所以还是保留原生解析方式，并将其作为默认。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

只使用ffmpeg播放.

## 新的行为是什么？

默认原生 （AdaptiveMediaSource）解析，并允许用户切换到 ffmpeg 解析

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 新组件
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
