### PR TITLE
支持画质选择

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -532,6 +532,7 @@
     <Compile Include="Resources\Converter\PlayerDisplayModeConverter.cs" />
     <Compile Include="Resources\Converter\PlayerTypeConverter.cs" />
     <Compile Include="Resources\Converter\PreferCodecConverter.cs" />
+    <Compile Include="Resources\Converter\PreferQualityConverter.cs" />
     <Compile Include="Resources\Converter\RelationButtonStyleConverter.cs" />
     <Compile Include="Resources\Converter\RelationTextConverter.cs" />
     <Compile Include="Resources\Converter\SeasonCoverConverter.cs" />

--- a/src/App/Controls/Pgc/PgcSeasonDetailView.xaml
+++ b/src/App/Controls/Pgc/PgcSeasonDetailView.xaml
@@ -3,7 +3,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:account="using:Bili.ViewModels.Uwp.Account"
-    xmlns:bilibili="using:Bili.Models.BiliBili"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:loc="using:Bili.App.Resources.Extension"
     xmlns:local="using:Bili.App.Controls"

--- a/src/App/Controls/Settings/PlayerModeSettingSection.xaml
+++ b/src/App/Controls/Settings/PlayerModeSettingSection.xaml
@@ -9,6 +9,7 @@
     xmlns:loc="using:Bili.App.Resources.Extension"
     xmlns:local="using:Bili.App.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:player="using:Bili.Models.Enums.Player"
     xmlns:uwp="using:Richasy.FluentIcon.Uwp"
     d:DesignHeight="300"
     d:DesignWidth="400"
@@ -16,6 +17,7 @@
 
     <local:SettingSectionControl.Resources>
         <converter:PlayerDisplayModeConverter x:Key="PlayerDisplayModeConverter" />
+        <converter:PreferQualityConverter x:Key="PreferQualityConverter" />
     </local:SettingSectionControl.Resources>
 
     <exp:ExpanderEx>
@@ -34,17 +36,6 @@
             <exp:ExpanderExMenuPanel>
                 <exp:ExpanderExWrapper Style="{StaticResource WrapperInExpanderContentStyle}">
                     <exp:ExpanderExWrapper.MainContent>
-                        <TextBlock VerticalAlignment="Center" Text="{loc:Locale Name=AutoPlayWhenLoaded}" />
-                    </exp:ExpanderExWrapper.MainContent>
-                    <exp:ExpanderExWrapper.WrapContent>
-                        <ToggleSwitch Style="{StaticResource RightAlignedCompactToggleSwitchStyle}" IsOn="{x:Bind ViewModel.IsAutoPlayWhenLoaded, Mode=TwoWay}" />
-                    </exp:ExpanderExWrapper.WrapContent>
-                </exp:ExpanderExWrapper>
-
-                <exp:ExpanderExItemSeparator />
-
-                <exp:ExpanderExWrapper Style="{StaticResource WrapperInExpanderContentStyle}">
-                    <exp:ExpanderExWrapper.MainContent>
                         <TextBlock VerticalAlignment="Center" Text="{loc:Locale Name=DefaultPlayerDisplayMode}" />
                     </exp:ExpanderExWrapper.MainContent>
                     <exp:ExpanderExWrapper.WrapContent>
@@ -61,7 +52,38 @@
                     </exp:ExpanderExWrapper.WrapContent>
                 </exp:ExpanderExWrapper>
 
-                <exp:ExpanderExItemSeparator Visibility="{x:Bind CoreViewModel.IsXbox, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}" />
+                <exp:ExpanderExItemSeparator />
+
+                <exp:ExpanderExWrapper Style="{StaticResource WrapperInExpanderContentStyle}">
+                    <exp:ExpanderExWrapper.MainContent>
+                        <TextBlock VerticalAlignment="Center" Text="{loc:Locale Name=PreferQuality}" />
+                    </exp:ExpanderExWrapper.MainContent>
+                    <exp:ExpanderExWrapper.WrapContent>
+                        <ComboBox
+                            MinWidth="120"
+                            ItemsSource="{x:Bind ViewModel.PreferQualities}"
+                            SelectedItem="{x:Bind ViewModel.PreferQuality, Mode=TwoWay}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate x:DataType="player:PreferQuality">
+                                    <TextBlock Text="{x:Bind Converter={StaticResource PreferQualityConverter}}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                    </exp:ExpanderExWrapper.WrapContent>
+                </exp:ExpanderExWrapper>
+
+                <exp:ExpanderExItemSeparator />
+
+                <exp:ExpanderExWrapper Style="{StaticResource WrapperInExpanderContentStyle}">
+                    <exp:ExpanderExWrapper.MainContent>
+                        <TextBlock VerticalAlignment="Center" Text="{loc:Locale Name=AutoPlayWhenLoaded}" />
+                    </exp:ExpanderExWrapper.MainContent>
+                    <exp:ExpanderExWrapper.WrapContent>
+                        <ToggleSwitch Style="{StaticResource RightAlignedCompactToggleSwitchStyle}" IsOn="{x:Bind ViewModel.IsAutoPlayWhenLoaded, Mode=TwoWay}" />
+                    </exp:ExpanderExWrapper.WrapContent>
+                </exp:ExpanderExWrapper>
+
+                <exp:ExpanderExItemSeparator />
 
                 <exp:ExpanderExWrapper Style="{StaticResource WrapperInExpanderContentStyle}">
                     <exp:ExpanderExWrapper.MainContent>
@@ -96,21 +118,6 @@
                     </exp:ExpanderExWrapper.MainContent>
                     <exp:ExpanderExWrapper.WrapContent>
                         <ToggleSwitch Style="{StaticResource RightAlignedCompactToggleSwitchStyle}" IsOn="{x:Bind ViewModel.IsContinusPlay, Mode=TwoWay}" />
-                    </exp:ExpanderExWrapper.WrapContent>
-                </exp:ExpanderExWrapper>
-
-                <exp:ExpanderExItemSeparator />
-
-                <exp:ExpanderExWrapper Style="{StaticResource WrapperInExpanderContentStyle}">
-                    <exp:ExpanderExWrapper.MainContent>
-                        <exp:ExpanderExDescriptor
-                            Title="{loc:Locale Name=PreferHighQuality}"
-                            Description="{loc:Locale Name=PreferHighQualityDescription}"
-                            IconVisibility="Collapsed"
-                            IsAutoHideIcon="False" />
-                    </exp:ExpanderExWrapper.MainContent>
-                    <exp:ExpanderExWrapper.WrapContent>
-                        <ToggleSwitch Style="{StaticResource RightAlignedCompactToggleSwitchStyle}" IsOn="{x:Bind ViewModel.IsPreferHighQuality, Mode=TwoWay}" />
                     </exp:ExpanderExWrapper.WrapContent>
                 </exp:ExpanderExWrapper>
 

--- a/src/App/Resources/Converter/PreferQualityConverter.cs
+++ b/src/App/Resources/Converter/PreferQualityConverter.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Richasy. All rights reserved.
+
+using System;
+using Bili.Models.Enums.Player;
+using Bili.Toolkit.Interfaces;
+using Splat;
+using Windows.UI.Xaml.Data;
+
+namespace Bili.App.Resources.Converter
+{
+    /// <summary>
+    /// 偏好画质的可读文本转换器.
+    /// </summary>
+    internal sealed class PreferQualityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            if(value is PreferQuality quality)
+            {
+                var resToolkit = Locator.Current.GetService<IResourceToolkit>();
+                return quality switch
+                {
+                    PreferQuality.HDFirst => resToolkit.GetLocaleString(Models.Enums.LanguageNames.HDFirst),
+                    PreferQuality.HighQuality => resToolkit.GetLocaleString(Models.Enums.LanguageNames.PreferHighQuality),
+                    _ => resToolkit.GetLocaleString(Models.Enums.LanguageNames.Automatic),
+                };
+            }
+
+            return string.Empty;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language) => throw new NotImplementedException();
+    }
+}

--- a/src/App/Resources/Strings/zh-Hans/Resources.resw
+++ b/src/App/Resources/Strings/zh-Hans/Resources.resw
@@ -701,6 +701,9 @@ UGC优先级：分P &gt; 播放列表 &gt; 合集视频 &gt; 关联视频 (如�
   <data name="HasUpdate" xml:space="preserve">
     <value>新版本发布</value>
   </data>
+  <data name="HDFirst" xml:space="preserve">
+    <value>高清（1080P）优先</value>
+  </data>
   <data name="HelpAndSupport" xml:space="preserve">
     <value>帮助 &amp; 支持</value>
   </data>
@@ -1127,6 +1130,9 @@ UGC优先级：分P &gt; 播放列表 &gt; 合集视频 &gt; 关联视频 (如�
   </data>
   <data name="PreferHighQualityDescription" xml:space="preserve">
     <value>优先播放最高清画质的视频源</value>
+  </data>
+  <data name="PreferQuality" xml:space="preserve">
+    <value>画质偏好</value>
   </data>
   <data name="Prelaunch" xml:space="preserve">
     <value>预启动</value>

--- a/src/App/Resources/Strings/zh-Hant/Resources.resw
+++ b/src/App/Resources/Strings/zh-Hant/Resources.resw
@@ -702,6 +702,9 @@ UGC優先級：分P &gt; 播放列表 &gt; 合集影片 &gt; 關聯影片 (如�
   <data name="HasUpdate" xml:space="preserve">
     <value>新版本發布</value>
   </data>
+  <data name="HDFirst" xml:space="preserve">
+    <value>高清（1080P）優先</value>
+  </data>
   <data name="HelpAndSupport" xml:space="preserve">
     <value>支援 &amp; 協助</value>
   </data>
@@ -1128,6 +1131,9 @@ UGC優先級：分P &gt; 播放列表 &gt; 合集影片 &gt; 關聯影片 (如�
   </data>
   <data name="PreferHighQualityDescription" xml:space="preserve">
     <value>優先播放最高畫質的影片來源</value>
+  </data>
+  <data name="PreferQuality" xml:space="preserve">
+    <value>畫質偏好</value>
   </data>
   <data name="Prelaunch" xml:space="preserve">
     <value>預先啟動</value>

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -537,6 +537,8 @@ namespace Bili.Models.Enums
         FFmpegPlayer,
         PlayerType,
         PlayerTypeDescription,
+        HDFirst,
+        PreferQuality,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/Models/Models.Enums/App/SettingNames.cs
+++ b/src/Models/Models.Enums/App/SettingNames.cs
@@ -15,7 +15,6 @@ namespace Bili.Models.Enums
         IsStartup,
         IsAutoPlayWhenLoaded,
         DefaultPlayerDisplayMode,
-        IsPreferHighQuality,
         PreferCodec,
         SingleFastForwardAndRewindSpan,
         DefaultMTCControlMode,
@@ -81,6 +80,7 @@ namespace Bili.Models.Enums
         IsFullTraditionalChinese,
         DecodeType,
         PlayerType,
+        PreferQuality,
 #pragma warning disable SA1602 // Enumeration items should be documented
     }
 }

--- a/src/Models/Models.Enums/Player/PreferQuality.cs
+++ b/src/Models/Models.Enums/Player/PreferQuality.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Richasy. All rights reserved.
+
+namespace Bili.Models.Enums.Player
+{
+    /// <summary>
+    /// 偏好的画质类型.
+    /// </summary>
+    public enum PreferQuality
+    {
+        /// <summary>
+        /// 自动，会根据上一次播放的清晰度进行选择.
+        /// </summary>
+        Auto,
+
+        /// <summary>
+        /// 优先播放 1080P 的片源，如果没有，则播放次一级的片源.
+        /// </summary>
+        HDFirst,
+
+        /// <summary>
+        /// 画质优先，会优先选取最高清晰度的片源.
+        /// </summary>
+        HighQuality,
+    }
+}

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Live.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Live.cs
@@ -60,14 +60,7 @@ namespace Bili.ViewModels.Uwp.Core
                 }
             }
 
-            var formatId = _settingsToolkit.ReadLocalSetting(SettingNames.IsPreferHighQuality, false)
-                ? Formats.Where(p => !p.IsLimited).Max(p => p.Quality)
-                : _settingsToolkit.ReadLocalSetting(SettingNames.DefaultLiveFormat, 400);
-            if (!Formats.Any(p => p.Quality == formatId))
-            {
-                formatId = Formats.Where(p => !p.IsLimited).Max(p => p.Quality);
-            }
-
+            var formatId = GetFormatId(true);
             await SelectLiveFormatAsync(Formats.First(p => p.Quality == formatId));
         }
 

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
@@ -107,14 +107,7 @@ namespace Bili.ViewModels.Uwp.Core
                 }
             }
 
-            var formatId = _settingsToolkit.ReadLocalSetting(SettingNames.IsPreferHighQuality, false)
-                ? Formats.Where(p => !p.IsLimited).Max(p => p.Quality)
-                : _settingsToolkit.ReadLocalSetting(SettingNames.DefaultVideoFormat, 64);
-            if (!Formats.Any(p => p.Quality == formatId))
-            {
-                formatId = Formats.Where(p => !p.IsLimited).Max(p => p.Quality);
-            }
-
+            var formatId = GetFormatId();
             await SelectVideoFormatAsync(Formats.First(p => p.Quality == formatId));
         }
 
@@ -158,7 +151,7 @@ namespace Bili.ViewModels.Uwp.Core
             try
             {
                 var playerType = _settingsToolkit.ReadLocalSetting(SettingNames.PlayerType, PlayerType.Native);
-                if(playerType == PlayerType.Native)
+                if (playerType == PlayerType.Native)
                 {
                     await LoadDashVideoSourceFromNativeAsync();
                 }

--- a/src/ViewModels/ViewModels.Uwp/Home/SettingsPageViewModel/SettingsPageViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Home/SettingsPageViewModel/SettingsPageViewModel.Properties.cs
@@ -29,26 +29,27 @@ namespace Bili.ViewModels.Uwp.Home
         /// <summary>
         /// 播放器显示模式可选集合.
         /// </summary>
-        [Reactive]
-        public ObservableCollection<PlayerDisplayMode> PlayerDisplayModeCollection { get; set; }
+        public ObservableCollection<PlayerDisplayMode> PlayerDisplayModeCollection { get; }
 
         /// <summary>
         /// 偏好的解码模式可选集合.
         /// </summary>
-        [Reactive]
-        public ObservableCollection<PreferCodec> PreferCodecCollection { get; set; }
+        public ObservableCollection<PreferCodec> PreferCodecCollection { get; }
 
         /// <summary>
         /// 解码类型可选集合.
         /// </summary>
-        [Reactive]
-        public ObservableCollection<DecodeType> DecodeTypeCollection { get; set; }
+        public ObservableCollection<DecodeType> DecodeTypeCollection { get; }
 
         /// <summary>
         /// 播放器类型可选集合.
         /// </summary>
-        [Reactive]
-        public ObservableCollection<PlayerType> PlayerTypeCollection { get; set; }
+        public ObservableCollection<PlayerType> PlayerTypeCollection { get; }
+
+        /// <summary>
+        /// 偏好的画质可选集合.
+        /// </summary>
+        public ObservableCollection<PreferQuality> PreferQualities { get; }
 
         /// <summary>
         /// 应用主题.
@@ -99,12 +100,6 @@ namespace Bili.ViewModels.Uwp.Home
         public PlayerDisplayMode DefaultPlayerDisplayMode { get; set; }
 
         /// <summary>
-        /// 优先高画质.
-        /// </summary>
-        [Reactive]
-        public bool IsPreferHighQuality { get; set; }
-
-        /// <summary>
         /// 禁用 P2P CDN.
         /// </summary>
         [Reactive]
@@ -133,6 +128,12 @@ namespace Bili.ViewModels.Uwp.Home
         /// </summary>
         [Reactive]
         public PlayerType PlayerType { get; set; }
+
+        /// <summary>
+        /// 偏好的画质选择.
+        /// </summary>
+        [Reactive]
+        public PreferQuality PreferQuality { get; set; }
 
         /// <summary>
         /// 单次快进/快退时长.

--- a/src/ViewModels/ViewModels.Uwp/Home/SettingsPageViewModel/SettingsPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Home/SettingsPageViewModel/SettingsPageViewModel.cs
@@ -36,6 +36,12 @@ namespace Bili.ViewModels.Uwp.Home
             _resourceToolkit = resourceToolkit;
             _appToolkit = appToolkit;
 
+            PlayerDisplayModeCollection = new ObservableCollection<PlayerDisplayMode>();
+            PreferCodecCollection = new ObservableCollection<PreferCodec>();
+            DecodeTypeCollection = new ObservableCollection<DecodeType>();
+            PlayerTypeCollection = new ObservableCollection<PlayerType>();
+            PreferQualities = new ObservableCollection<PreferQuality>();
+
             InitializeCommand = ReactiveCommand.Create(InitializeSettings, outputScheduler: RxApp.MainThreadScheduler);
 
             InitializeSettings();
@@ -52,7 +58,6 @@ namespace Bili.ViewModels.Uwp.Home
             IsPrelaunch = ReadSetting(SettingNames.IsPrelaunch, true);
             IsAutoPlayWhenLoaded = ReadSetting(SettingNames.IsAutoPlayWhenLoaded, true);
             IsAutoPlayNextRelatedVideo = ReadSetting(SettingNames.IsAutoPlayNextRelatedVideo, false);
-            IsPreferHighQuality = ReadSetting(SettingNames.IsPreferHighQuality, false);
             DisableP2PCdn = ReadSetting(SettingNames.DisableP2PCdn, false);
             IsContinusPlay = ReadSetting(SettingNames.IsContinusPlay, true);
             SingleFastForwardAndRewindSpan = ReadSetting(SettingNames.SingleFastForwardAndRewindSpan, 30d);
@@ -69,6 +74,7 @@ namespace Bili.ViewModels.Uwp.Home
             BackgroundTaskInitAsync();
             RoamingInit();
             PlayerTypeInit();
+            PreferQualityInit();
 
             Version = _appToolkit.GetPackageVersion();
             PropertyChanged += OnPropertyChangedAsync;
@@ -95,9 +101,6 @@ namespace Bili.ViewModels.Uwp.Home
                     break;
                 case nameof(DefaultPlayerDisplayMode):
                     WriteSetting(SettingNames.DefaultPlayerDisplayMode, DefaultPlayerDisplayMode);
-                    break;
-                case nameof(IsPreferHighQuality):
-                    WriteSetting(SettingNames.IsPreferHighQuality, IsPreferHighQuality);
                     break;
                 case nameof(DisableP2PCdn):
                     WriteSetting(SettingNames.DisableP2PCdn, DisableP2PCdn);
@@ -158,6 +161,9 @@ namespace Bili.ViewModels.Uwp.Home
                     WriteSetting(SettingNames.PlayerType, PlayerType);
                     IsFFmpegPlayer = PlayerType == PlayerType.FFmpeg;
                     break;
+                case nameof(PreferQuality):
+                    WriteSetting(SettingNames.PreferQuality, PreferQuality);
+                    break;
                 default:
                     break;
             }
@@ -179,13 +185,10 @@ namespace Bili.ViewModels.Uwp.Home
 
         private void PlayerModeInit()
         {
-            if (PlayerDisplayModeCollection == null || PlayerDisplayModeCollection.Count == 0)
+            if (PlayerDisplayModeCollection.Count == 0)
             {
-                PlayerDisplayModeCollection = new ObservableCollection<PlayerDisplayMode>
-                {
-                    PlayerDisplayMode.Default,
-                    PlayerDisplayMode.FullScreen,
-                };
+                PlayerDisplayModeCollection.Add(PlayerDisplayMode.Default);
+                PlayerDisplayModeCollection.Add(PlayerDisplayMode.FullScreen);
 
                 if (!_appViewModel.IsXbox)
                 {
@@ -198,14 +201,11 @@ namespace Bili.ViewModels.Uwp.Home
 
         private void PreferCodecInit()
         {
-            if (PreferCodecCollection == null || PreferCodecCollection.Count == 0)
+            if (PreferCodecCollection.Count == 0)
             {
-                PreferCodecCollection = new ObservableCollection<PreferCodec>
-                {
-                    PreferCodec.H264,
-                    PreferCodec.H265,
-                    PreferCodec.Av1,
-                };
+                PreferCodecCollection.Add(PreferCodec.H264);
+                PreferCodecCollection.Add(PreferCodec.H265);
+                PreferCodecCollection.Add(PreferCodec.Av1);
             }
 
             PreferCodec = ReadSetting(SettingNames.PreferCodec, PreferCodec.H264);
@@ -213,14 +213,11 @@ namespace Bili.ViewModels.Uwp.Home
 
         private void DecodeInit()
         {
-            if (DecodeTypeCollection == null || DecodeTypeCollection.Count == 0)
+            if (DecodeTypeCollection.Count == 0)
             {
-                DecodeTypeCollection = new ObservableCollection<DecodeType>
-                {
-                    DecodeType.Automatic,
-                    DecodeType.HardwareDecode,
-                    DecodeType.SoftwareDecode,
-                };
+                DecodeTypeCollection.Add(DecodeType.Automatic);
+                DecodeTypeCollection.Add(DecodeType.HardwareDecode);
+                DecodeTypeCollection.Add(DecodeType.SoftwareDecode);
             }
 
             DecodeType = ReadSetting(SettingNames.DecodeType, DecodeType.Automatic);
@@ -228,17 +225,27 @@ namespace Bili.ViewModels.Uwp.Home
 
         private void PlayerTypeInit()
         {
-            if (PlayerTypeCollection == null || PlayerTypeCollection.Count == 0)
+            if (PlayerTypeCollection.Count == 0)
             {
-                PlayerTypeCollection = new ObservableCollection<PlayerType>
-                {
-                    PlayerType.Native,
-                    PlayerType.FFmpeg,
-                };
+                PlayerTypeCollection.Add(PlayerType.Native);
+                PlayerTypeCollection.Add(PlayerType.FFmpeg);
             }
 
             PlayerType = ReadSetting(SettingNames.PlayerType, PlayerType.Native);
             IsFFmpegPlayer = PlayerType == PlayerType.FFmpeg;
+        }
+
+        private void PreferQualityInit()
+        {
+            if(PreferQualities.Count == 0)
+            {
+                PreferQualities.Add(PreferQuality.Auto);
+                PreferQualities.Add(PreferQuality.HDFirst);
+                PreferQualities.Add(PreferQuality.HighQuality);
+            }
+
+            var defaultQuality = _appViewModel.IsXbox ? PreferQuality.HDFirst : PreferQuality.Auto;
+            PreferQuality = ReadSetting(SettingNames.PreferQuality, defaultQuality);
         }
 
         private void RoamingInit()


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

在 Xbox 上播放视频时，如果播放的是 4K 高清（很多情况下，它是默认选择），硬件解码会出现一些问题，导致不能正常播放，且应用会崩溃。为了解决这个问题（治标不治本），于是加上这个画质选择，让 XBOX 默认以 1080P 及以下的清晰度播放视频，从而变相提高播放体验（只要你不去设置里改）

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

仅支持自动设置和始终高画质两种画质偏好

## 新的行为是什么？

提供仅播放1080P及以下片源的画质设置

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

哎……解码这种事情，超过我目前的能力范围了，只能先尝试治治标
