### PR TITLE
修复在直播时没有阻止系统休眠的问题

### DIFF
--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Live.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Live.cs
@@ -94,7 +94,10 @@ namespace Bili.ViewModels.Uwp.Core
         }
 
         private async Task InitializeLivePlayerAsync(string url)
-            => await _player.SetSourceAsync(url);
+        {
+            await _player.SetSourceAsync(url);
+            StartTimersAndDisplayRequest();
+        }
 
         private async Task ChangeLiveAudioOnlyAsync(bool isAudioOnly)
         {

--- a/src/ViewModels/ViewModels.Uwp/HttpRandomAccessStream.cs
+++ b/src/ViewModels/ViewModels.Uwp/HttpRandomAccessStream.cs
@@ -105,7 +105,6 @@ namespace Bili.ViewModels.Uwp
                 catch (Exception ex)
                 {
                     Debug.WriteLine(ex);
-                    throw;
                 }
 
                 var result = await _inputStream.ReadAsync(buffer, count, options).AsTask(cancellationToken, progress).ConfigureAwait(false);
@@ -147,7 +146,7 @@ namespace Bili.ViewModels.Uwp
 
             if (response.Content.Headers.ContentType != null)
             {
-                this.ContentType = response.Content.Headers.ContentType.MediaType;
+                ContentType = response.Content.Headers.ContentType.MediaType;
             }
 
             _size = response.Content?.Headers?.ContentLength ?? 0;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1362 

在直播时通过 DisplayRequest 阻止系统进入息屏状态

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

直播时无操作系统会进入息屏状态

## 新的行为是什么？

直播时阻止系统进入息屏

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
