### PR TITLE
修复FFmpeg视频播放中断的问题

### DIFF
--- a/src/Models/Models.BiliBili/Live/LiveAppPlayInformation.cs
+++ b/src/Models/Models.BiliBili/Live/LiveAppPlayInformation.cs
@@ -21,7 +21,7 @@ namespace Bili.Models.BiliBili
         /// 用户Id.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "uid", Required = Required.Default)]
-        public int UserId { get; set; }
+        public long UserId { get; set; }
 
         /// <summary>
         /// 直播状态，1表示正在直播.

--- a/src/Models/Models.BiliBili/Live/LiveRoomBase.cs
+++ b/src/Models/Models.BiliBili/Live/LiveRoomBase.cs
@@ -15,7 +15,7 @@ namespace Bili.Models.BiliBili
         /// 用户Id.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "uid", Required = Required.Default)]
-        public int UserId { get; set; }
+        public long UserId { get; set; }
 
         /// <summary>
         /// 直播间封面.

--- a/src/Models/Models.BiliBili/Live/LiveRoomDetail.cs
+++ b/src/Models/Models.BiliBili/Live/LiveRoomDetail.cs
@@ -33,7 +33,7 @@ namespace Bili.Models.BiliBili
         /// 用户Id.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "uid", Required = Required.Default)]
-        public int UserId { get; set; }
+        public long UserId { get; set; }
 
         /// <summary>
         /// 直播间Id.

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Properties.cs
@@ -37,6 +37,7 @@ namespace Bili.ViewModels.Uwp.Core
         private MediaPlaybackItem _audioPlaybackItem;
         private MediaTimelineController _mediaTimelineController;
         private int _liveRetryCount;
+        private int _videoRetryCount;
 
         /// <inheritdoc/>
         public event EventHandler MediaOpened;

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.cs
@@ -45,6 +45,7 @@ namespace Bili.ViewModels.Uwp.Core
         {
             _video = video;
             _audio = audio;
+            _videoRetryCount = 0;
             await LoadDashVideoSourceAsync();
         }
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1339 

该问题主要发生在视频暂停后继续播放时，网络流会在暂停时中断，导致恢复播放时视频被判定为播放结束

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

暂停后恢复播放，视频会强制结束

## 新的行为是什么？

视频触发结束事件时检查是否真的结束，如果没有则进行重连

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
