### PR TITLE
修复FFmpeg播放的一些问题，并手动集成SMTC

### DIFF
--- a/src/Adapter/Adapter.Implementation/UserAdapter.cs
+++ b/src/Adapter/Adapter.Implementation/UserAdapter.cs
@@ -151,7 +151,7 @@ namespace Bili.Adapter
         }
 
         /// <inheritdoc/>
-        public UserProfile ConvertToUserProfile(int userId, string userName, string avatar, AvatarSize avatarSize)
+        public UserProfile ConvertToUserProfile(long userId, string userName, string avatar, AvatarSize avatarSize)
         {
             var size = int.Parse(avatarSize.ToString().Replace("Size", string.Empty));
             var image = _imageAdapter.ConvertToImage(avatar, size, size);

--- a/src/Adapter/Adapter.Interfaces/IUserAdapter.cs
+++ b/src/Adapter/Adapter.Interfaces/IUserAdapter.cs
@@ -22,7 +22,7 @@ namespace Bili.Adapter.Interfaces
         /// <param name="avatar">封面.</param>
         /// <param name="avatarSize">头像尺寸.</param>
         /// <returns><see cref="UserProfile"/>.</returns>
-        UserProfile ConvertToUserProfile(int userId, string userName, string avatar, AvatarSize avatarSize);
+        UserProfile ConvertToUserProfile(long userId, string userName, string avatar, AvatarSize avatarSize);
 
         /// <summary>
         /// 将 <see cref="PublisherInfo"/> 转换为发布者资料.

--- a/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Handlers.cs
+++ b/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Handlers.cs
@@ -48,7 +48,7 @@ namespace Bili.App.Controls.Player
             ViewModel.DanmakuViewModel.RequestClearDanmaku -= OnRequestClearDanmaku;
             ViewModel.MediaPlayerChanged -= OnMediaPlayerChangedAsync;
             ViewModel.RequestShowTempMessage -= OnRequestShowTempMessage;
-            ViewModel.PropertyChanged += OnViewModelPropertyChanged;
+            ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)

--- a/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.Fields.cs
+++ b/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.Fields.cs
@@ -13,19 +13,11 @@ namespace Bili.App.Controls.Player
         private const string VolumeSliderName = "VolumeSlider";
         private const string FormatListViewName = "FormatListView";
         private const string PlayPauseButtonName = "PlayPauseButton";
-        private const string NormalProgressContainerName = "NormalProgressContainer";
-        private const string InteractionProgressContainerName = "InteractionProgressContainer";
-        private const string InteractionProgressSliderName = "InteractionProgressSlider";
         private const string DanmakuBoxName = "DanmakuBox";
 
         private Slider _volumeSlider;
         private ListView _formatListView;
         private Button _playPauseButton;
-        private Panel _normalProgressContainer;
-        private Panel _interactionProgressContainer;
-        private Slider _interactionProgressSlider;
         private DanmakuBox _danmakuBox;
-
-        private bool _isInteractionProgressAutoAssign;
     }
 }

--- a/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.Handlers.cs
+++ b/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.Handlers.cs
@@ -6,7 +6,6 @@ using Bili.Models.Data.Player;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Input;
 
 namespace Bili.App.Controls.Player
 {
@@ -55,10 +54,6 @@ namespace Bili.App.Controls.Player
             {
                 _playPauseButton?.Focus(FocusState.Programmatic);
             }
-            else if (e.PropertyName == nameof(ViewModel.InteractionProgressSeconds) && !ViewModel.IsShowInteractionProgress)
-            {
-                _interactionProgressSlider.Value = ViewModel.InteractionProgressSeconds;
-            }
         }
 
         private void OnVolumeSliderValueChanged(object sender, RangeBaseValueChangedEventArgs e)
@@ -76,37 +71,6 @@ namespace Bili.App.Controls.Player
             {
                 ViewModel.ChangeFormatCommand.Execute(info).Subscribe();
             }
-        }
-
-        private void OnNormalProgressContainerPointerEntered(object sender, PointerRoutedEventArgs e)
-        {
-            ViewModel.IsShowInteractionProgress = true;
-            _isInteractionProgressAutoAssign = true;
-            if (_interactionProgressSlider != null)
-            {
-                _interactionProgressSlider.Value = ViewModel.InteractionProgressSeconds;
-                _interactionProgressSlider.Maximum = ViewModel.DurationSeconds;
-            }
-
-            _isInteractionProgressAutoAssign = false;
-        }
-
-        private void OnInteractionProgressContainerPointerExited(object sender, PointerRoutedEventArgs e)
-            => ViewModel.IsShowInteractionProgress = false;
-
-        private void OnInteractionProgressSliderValueChanged(object sender, RangeBaseValueChangedEventArgs e)
-        {
-            if (!ViewModel.IsShowInteractionProgress)
-            {
-                return;
-            }
-            else if (_isInteractionProgressAutoAssign)
-            {
-                _isInteractionProgressAutoAssign = false;
-                return;
-            }
-
-            ViewModel.ChangeProgressCommand.Execute(e.NewValue).Subscribe();
         }
     }
 }

--- a/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.cs
+++ b/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.cs
@@ -40,9 +40,6 @@ namespace Bili.App.Controls.Player
             _volumeSlider = GetTemplateChild(VolumeSliderName) as Slider;
             _formatListView = GetTemplateChild(FormatListViewName) as ListView;
             _playPauseButton = GetTemplateChild(PlayPauseButtonName) as Button;
-            _normalProgressContainer = GetTemplateChild(NormalProgressContainerName) as Panel;
-            _interactionProgressContainer = GetTemplateChild(InteractionProgressContainerName) as Panel;
-            _interactionProgressSlider = GetTemplateChild(InteractionProgressSliderName) as Slider;
             _danmakuBox = GetTemplateChild(DanmakuBoxName) as DanmakuBox;
 
             if (_formatListView != null)
@@ -53,22 +50,6 @@ namespace Bili.App.Controls.Player
             if (_volumeSlider != null)
             {
                 _volumeSlider.ValueChanged += OnVolumeSliderValueChanged;
-            }
-
-            if (_normalProgressContainer != null)
-            {
-                _normalProgressContainer.PointerEntered += OnNormalProgressContainerPointerEntered;
-            }
-
-            if (_interactionProgressContainer != null)
-            {
-                _interactionProgressContainer.PointerExited += OnInteractionProgressContainerPointerExited;
-                _interactionProgressContainer.PointerCanceled += OnInteractionProgressContainerPointerExited;
-            }
-
-            if (_interactionProgressSlider != null)
-            {
-                _interactionProgressSlider.ValueChanged += OnInteractionProgressSliderValueChanged;
             }
         }
 

--- a/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.xaml
+++ b/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.xaml
@@ -281,6 +281,16 @@
                                         <uwp:RegularFluentIcon Symbol="Next20" />
                                     </Button.Content>
                                 </Button>
+                                <Button
+                                    x:Name="RefreshButton"
+                                    AutomationProperties.Name="{loc:Locale Name=Refresh}"
+                                    Style="{StaticResource PlayerButtonStyle}"
+                                    Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.ReloadCommand}"
+                                    ToolTipService.ToolTip="{loc:Locale Name=Refresh}">
+                                    <Button.Content>
+                                        <uwp:RegularFluentIcon Symbol="ArrowSync16" />
+                                    </Button.Content>
+                                </Button>
                             </StackPanel>
 
                             <Grid
@@ -672,6 +682,16 @@
                                             Visibility="Collapsed" />
                                     </Grid>
                                 </Button>
+                                <Button
+                                    x:Name="RefreshButton"
+                                    AutomationProperties.Name="{loc:Locale Name=Refresh}"
+                                    Style="{StaticResource PlayerButtonStyle}"
+                                    Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.ReloadCommand}"
+                                    ToolTipService.ToolTip="{loc:Locale Name=Refresh}">
+                                    <Button.Content>
+                                        <uwp:RegularFluentIcon Symbol="ArrowSync16" />
+                                    </Button.Content>
+                                </Button>
                             </StackPanel>
 
                             <Grid
@@ -969,17 +989,23 @@
                                         <uwp:RegularFluentIcon Symbol="Next20" />
                                     </Button.Content>
                                 </Button>
+                                <Button
+                                    x:Name="RefreshButton"
+                                    AutomationProperties.Name="{loc:Locale Name=Refresh}"
+                                    Style="{StaticResource PlayerButtonStyle}"
+                                    Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.ReloadCommand}"
+                                    ToolTipService.ToolTip="{loc:Locale Name=Refresh}">
+                                    <Button.Content>
+                                        <uwp:RegularFluentIcon Symbol="ArrowSync16" />
+                                    </Button.Content>
+                                </Button>
                             </StackPanel>
 
                             <Grid
-                                x:Name="NormalProgressContainer"
+                                x:Name="InteractionProgressContainer"
                                 Grid.Column="1"
-                                Background="{ThemeResource TransparentBackground}"
-                                Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsShowInteractionProgress, Converter={StaticResource BoolToVisibilityReverseConverter}}">
-                                <StackPanel
-                                    Margin="0,-8,0,0"
-                                    VerticalAlignment="Center"
-                                    Spacing="4">
+                                Background="{ThemeResource TransparentBackground}">
+                                <StackPanel Margin="0,-8" VerticalAlignment="Center">
                                     <TextBlock
                                         Style="{StaticResource CaptionTextBlockStyle}"
                                         HorizontalAlignment="Left"
@@ -988,41 +1014,13 @@
                                         <Run Text="/" />
                                         <Run Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.DurationText}" />
                                     </TextBlock>
-                                    <controls:ProgressBar
-                                        HorizontalAlignment="Stretch"
-                                        VerticalAlignment="Center"
-                                        Maximum="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.DurationSeconds}"
-                                        ShowError="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsError}"
-                                        ShowPaused="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsMediaPause}"
-                                        Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.ProgressSeconds}">
-                                        <controls:ProgressBar.Resources>
-                                            <x:Double x:Key="ProgressBarTrackHeight">4</x:Double>
-                                            <CornerRadius x:Key="ProgressBarCornerRadius">2</CornerRadius>
-                                            <CornerRadius x:Key="ProgressBarTrackCornerRadius">2</CornerRadius>
-                                        </controls:ProgressBar.Resources>
-                                    </controls:ProgressBar>
-                                </StackPanel>
-                            </Grid>
-
-                            <Grid
-                                x:Name="InteractionProgressContainer"
-                                Grid.Column="1"
-                                Background="{ThemeResource TransparentBackground}"
-                                Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsShowInteractionProgress}">
-                                <StackPanel Margin="0,-8" VerticalAlignment="Center">
-                                    <TextBlock
-                                        Style="{StaticResource CaptionTextBlockStyle}"
-                                        HorizontalAlignment="Left"
-                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}">
-                                        <Run Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.InteractionProgressText}" />
-                                        <Run Text="/" />
-                                        <Run Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.DurationText}" />
-                                    </TextBlock>
                                     <Slider
                                         x:Name="InteractionProgressSlider"
                                         Margin="0,-4"
                                         HorizontalAlignment="Stretch"
-                                        IsThumbToolTipEnabled="False" />
+                                        IsThumbToolTipEnabled="False"
+                                        Maximum="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.DurationSeconds, Mode=OneWay}"
+                                        Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.ProgressSeconds, Mode=TwoWay}" />
                                 </StackPanel>
                             </Grid>
 
@@ -1262,6 +1260,16 @@
                                             Symbol="Pause16"
                                             Visibility="Collapsed" />
                                     </Grid>
+                                </Button>
+                                <Button
+                                    x:Name="RefreshButton"
+                                    AutomationProperties.Name="{loc:Locale Name=Refresh}"
+                                    Style="{StaticResource PlayerButtonStyle}"
+                                    Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.ReloadCommand}"
+                                    ToolTipService.ToolTip="{loc:Locale Name=Refresh}">
+                                    <Button.Content>
+                                        <uwp:RegularFluentIcon Symbol="ArrowSync16" />
+                                    </Button.Content>
                                 </Button>
                             </StackPanel>
 

--- a/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.xaml
+++ b/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.xaml
@@ -284,14 +284,10 @@
                             </StackPanel>
 
                             <Grid
-                                x:Name="NormalProgressContainer"
+                                x:Name="InteractionProgressContainer"
                                 Grid.Column="1"
-                                Background="{ThemeResource TransparentBackground}"
-                                Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsShowInteractionProgress, Converter={StaticResource BoolToVisibilityReverseConverter}}">
-                                <StackPanel
-                                    Margin="0,-8,0,0"
-                                    VerticalAlignment="Center"
-                                    Spacing="4">
+                                Background="{ThemeResource TransparentBackground}">
+                                <StackPanel Margin="0,-8" VerticalAlignment="Center">
                                     <TextBlock
                                         Style="{StaticResource CaptionTextBlockStyle}"
                                         HorizontalAlignment="Left"
@@ -300,41 +296,13 @@
                                         <Run Text="/" />
                                         <Run Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.DurationText}" />
                                     </TextBlock>
-                                    <controls:ProgressBar
-                                        HorizontalAlignment="Stretch"
-                                        VerticalAlignment="Center"
-                                        Maximum="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.DurationSeconds}"
-                                        ShowError="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsError}"
-                                        ShowPaused="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsMediaPause}"
-                                        Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.ProgressSeconds}">
-                                        <controls:ProgressBar.Resources>
-                                            <x:Double x:Key="ProgressBarTrackHeight">4</x:Double>
-                                            <CornerRadius x:Key="ProgressBarCornerRadius">2</CornerRadius>
-                                            <CornerRadius x:Key="ProgressBarTrackCornerRadius">2</CornerRadius>
-                                        </controls:ProgressBar.Resources>
-                                    </controls:ProgressBar>
-                                </StackPanel>
-                            </Grid>
-
-                            <Grid
-                                x:Name="InteractionProgressContainer"
-                                Grid.Column="1"
-                                Background="{ThemeResource TransparentBackground}"
-                                Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsShowInteractionProgress}">
-                                <StackPanel Margin="0,-8" VerticalAlignment="Center">
-                                    <TextBlock
-                                        Style="{StaticResource CaptionTextBlockStyle}"
-                                        HorizontalAlignment="Left"
-                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}">
-                                        <Run Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.InteractionProgressText}" />
-                                        <Run Text="/" />
-                                        <Run Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.DurationText}" />
-                                    </TextBlock>
                                     <Slider
                                         x:Name="InteractionProgressSlider"
                                         Margin="0,-4"
                                         HorizontalAlignment="Stretch"
-                                        IsThumbToolTipEnabled="False" />
+                                        IsThumbToolTipEnabled="False"
+                                        Maximum="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.DurationSeconds, Mode=OneWay}"
+                                        Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.ProgressSeconds, Mode=TwoWay}" />
                                 </StackPanel>
                             </Grid>
 

--- a/src/Lib/DI.App/DIFactory.cs
+++ b/src/Lib/DI.App/DIFactory.cs
@@ -130,6 +130,7 @@ namespace Bili.DI.App
 
             SplatRegistrations.Register<INativePlayerViewModel, NativePlayerViewModel>();
             SplatRegistrations.Register<IFFmpegPlayerViewModel, FFmpegPlayerViewModel>();
+            SplatRegistrations.Register<MediaPlayerViewModel>();
             SplatRegistrations.Register<VideoItemViewModel>();
             SplatRegistrations.Register<EpisodeItemViewModel>();
             SplatRegistrations.Register<SeasonItemViewModel>();
@@ -147,7 +148,7 @@ namespace Bili.DI.App
             SplatRegistrations.Register<DanmakuModuleViewModel>();
             SplatRegistrations.Register<InteractionModuleViewModel>();
             SplatRegistrations.Register<DownloadModuleViewModel>();
-            SplatRegistrations.Register<MediaPlayerViewModel>();
+
             SplatRegistrations.SetupIOC();
         }
 

--- a/src/ViewModels/ViewModels.Interfaces/IPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Interfaces/IPlayerViewModel.cs
@@ -111,15 +111,6 @@ namespace Bili.ViewModels.Interfaces
         void SetLoop(bool isLoop);
 
         /// <summary>
-        /// 设置显示在 SMTC 上的播放信息.
-        /// </summary>
-        /// <param name="cover">视频封面.</param>
-        /// <param name="title">标题.</param>
-        /// <param name="subtitle">副标题（说明文字）.</param>
-        /// <param name="videoType">视频类型.</param>
-        void SetDisplayProperties(string cover, string title, string subtitle, string videoType);
-
-        /// <summary>
         /// 设置播放源.
         /// </summary>
         /// <param name="video">视频源.</param>

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
@@ -282,7 +282,10 @@ namespace Bili.ViewModels.Uwp.Core
                     {
                         _mediaTimelineController.Pause();
                     }
-                    else if (_videoPlayer != null && _videoPlayer.PlaybackSession != null && _videoPlayer.PlaybackSession.CanPause)
+                    else if (_videoPlayer != null
+                    && _videoPlayer.PlaybackSession != null
+                    && _videoPlayer.PlaybackSession.CanPause
+                    && _videoPlayer.TimelineController == null)
                     {
                         _videoPlayer.Pause();
                     }

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
@@ -63,7 +63,11 @@ namespace Bili.ViewModels.Uwp.Core
             await Task.WhenAll(tasks);
             _videoPlaybackItem = _videoFFSource.CreateMediaPlaybackItem();
 
-            _videoPlayer = GetVideoPlayer();
+            if (_videoPlayer == null)
+            {
+                _videoPlayer = GetVideoPlayer();
+            }
+
             _videoPlayer.Source = _videoPlaybackItem;
 
             if (hasAudio)
@@ -72,10 +76,19 @@ namespace Bili.ViewModels.Uwp.Core
                 _mediaTimelineController = GetTimelineController();
                 _videoPlayer.CommandManager.IsEnabled = false;
                 _videoPlayer.TimelineController = _mediaTimelineController;
-                _audioPlayer = new MediaPlayer();
+
+                if (_audioPlayer == null)
+                {
+                    _audioPlayer = GetVideoPlayer();
+                }
+
                 _audioPlayer.CommandManager.IsEnabled = false;
                 _audioPlayer.Source = _audioPlaybackItem;
                 _audioPlayer.TimelineController = _mediaTimelineController;
+            }
+            else
+            {
+                _audioPlayer = null;
             }
 
             MediaPlayerChanged?.Invoke(this, _videoPlayer);
@@ -102,7 +115,11 @@ namespace Bili.ViewModels.Uwp.Core
 
                 _videoPlaybackItem = _videoFFSource.CreateMediaPlaybackItem();
 
-                _videoPlayer = GetVideoPlayer();
+                if (_videoPlayer == null)
+                {
+                    _videoPlayer = GetVideoPlayer();
+                }
+
                 _videoPlayer.Source = _videoPlaybackItem;
 
                 MediaPlayerChanged?.Invoke(this, _videoPlayer);
@@ -259,15 +276,21 @@ namespace Bili.ViewModels.Uwp.Core
             {
                 var duration = sender.NaturalDuration.TotalSeconds;
                 var progress = sender.Position.TotalSeconds;
-                if (progress > duration)
+                if (progress >= duration)
                 {
                     if (_mediaTimelineController != null)
                     {
                         _mediaTimelineController.Pause();
                     }
-                    else
+                    else if (_videoPlayer != null && _videoPlayer.PlaybackSession != null && _videoPlayer.PlaybackSession.CanPause)
                     {
                         _videoPlayer.Pause();
+                    }
+
+                    if (progress == duration)
+                    {
+                        Status = PlayerStatus.End;
+                        StateChanged?.Invoke(this, new MediaStateChangedEventArgs(Status, string.Empty));
                     }
 
                     return;
@@ -318,7 +341,6 @@ namespace Bili.ViewModels.Uwp.Core
             source = null;
 
             mediaPlayer.Source = null;
-            mediaPlayer = null;
 
             if (stream != null)
             {
@@ -332,6 +354,7 @@ namespace Bili.ViewModels.Uwp.Core
             if (_mediaTimelineController != null)
             {
                 _mediaTimelineController.Pause();
+                _mediaTimelineController.Position = TimeSpan.Zero;
                 _mediaTimelineController = null;
             }
 

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Properties.cs
@@ -60,8 +60,8 @@ namespace Bili.ViewModels.Uwp.Core
             : _videoPlayer?.PlaybackSession?.Position ?? TimeSpan.Zero;
 
         /// <inheritdoc/>
-        public TimeSpan Duration => _mediaTimelineController != null
-            ? _mediaTimelineController.Duration ?? TimeSpan.Zero
+        public TimeSpan Duration => _videoFFSource != null
+            ? _videoFFSource.Duration
             : _videoPlayer?.PlaybackSession?.NaturalDuration ?? TimeSpan.Zero;
 
         /// <inheritdoc/>

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.cs
@@ -190,22 +190,5 @@ namespace Bili.ViewModels.Uwp.Core
                 await rendertarget.SaveAsync(stream, CanvasBitmapFileFormat.Png);
             }
         }
-
-        /// <inheritdoc/>
-        public void SetDisplayProperties(string cover, string title, string subtitle, string videoType)
-        {
-            if (_videoPlaybackItem == null)
-            {
-                return;
-            }
-
-            var props = _videoPlaybackItem.GetDisplayProperties();
-            props.Type = Windows.Media.MediaPlaybackType.Video;
-            props.Thumbnail = Windows.Storage.Streams.RandomAccessStreamReference.CreateFromUri(new Uri(cover));
-            props.VideoProperties.Title = title;
-            props.VideoProperties.Subtitle = subtitle;
-            props.VideoProperties.Genres.Add(videoType);
-            _videoPlaybackItem.ApplyDisplayProperties(props);
-        }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Controls.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Controls.cs
@@ -222,15 +222,12 @@ namespace Bili.ViewModels.Uwp.Core
         private void ChangeProgress(double seconds)
         {
             var ts = TimeSpan.FromSeconds(seconds);
-            if (ts.TotalSeconds == _interactionProgress.TotalSeconds)
+            if (_player == null || Math.Abs(ts.TotalSeconds - _player.Position.TotalSeconds) < 1)
             {
                 return;
             }
 
-            InteractionProgressSeconds = seconds;
-            _interactionProgress = ts;
-            _isInteractionProgressChanged = true;
-
+            _player.SeekTo(ts);
             var msg = $"{_resourceToolkit.GetLocaleString(LanguageNames.CurrentProgress)}: {TimeSpan.FromSeconds(seconds):g}";
             RequestShowTempMessage?.Invoke(this, msg);
         }

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Episode.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Episode.cs
@@ -59,7 +59,6 @@ namespace Bili.ViewModels.Uwp.Core
             DanmakuViewModel.SetData(_currentEpisode.VideoId, _currentEpisode.PartId, _videoType);
             await InitializeEpisodeMediaInformationAsync();
             await InitializeOrginalVideoSourceAsync();
-            FillEpisodePlaybackProperties();
             CheckEpisodeHistory();
         }
 
@@ -96,7 +95,7 @@ namespace Bili.ViewModels.Uwp.Core
 
         private void FillEpisodePlaybackProperties()
         {
-            _player.SetDisplayProperties(
+            SetDisplayProperties(
                 _currentEpisode.Identifier.Cover.GetSourceUri().ToString() + "@100w_100h_1c_100q.jpg",
                 _currentEpisode.Identifier.Title,
                 _currentEpisode.PublishTime.ToString("yyyy/MM/dd HH:mm"),

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Live.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Live.cs
@@ -20,7 +20,6 @@ namespace Bili.ViewModels.Uwp.Core
         {
             await InitializeLiveMediaInformationAsync();
             await InitializeOrginalLiveSourceAsync();
-            FillLivePlaybackProperties();
         }
 
         private async Task InitializeLiveMediaInformationAsync()
@@ -112,7 +111,7 @@ namespace Bili.ViewModels.Uwp.Core
         private void FillLivePlaybackProperties()
         {
             var view = _viewData as LivePlayerView;
-            _player.SetDisplayProperties(
+            SetDisplayProperties(
                 view.Information.User.Avatar.GetSourceUri() + "@100w_100h_1c_100q.jpg",
                 view.Information.Identifier.Title,
                 string.Join(string.Empty, view.Information.Description.Take(20)),

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
@@ -25,7 +25,6 @@ namespace Bili.ViewModels.Uwp.Core
             TryClear(Formats);
             TryClear(PlaybackRates);
             IsShowProgressTip = false;
-            IsShowInteractionProgress = false;
             IsShowMediaTransport = false;
             ProgressTip = default;
             _video = null;
@@ -36,13 +35,9 @@ namespace Bili.ViewModels.Uwp.Core
             DurationText = "--";
             ProgressSeconds = 0;
             ProgressText = "--";
-            InteractionProgressSeconds = 0;
-            InteractionProgressText = "--";
             Volume = _settingsToolkit.ReadLocalSetting(SettingNames.Volume, 100d);
             _lastReportProgress = TimeSpan.Zero;
             _initializeProgress = TimeSpan.Zero;
-            _interactionProgress = TimeSpan.Zero;
-            _isInteractionProgressChanged = false;
             _originalPlayRate = 0;
             IsInteractionEnd = false;
             IsInteractionVideo = false;
@@ -286,11 +281,6 @@ namespace Bili.ViewModels.Uwp.Core
             DurationSeconds = e.Duration.TotalSeconds;
             ProgressSeconds = e.Position.TotalSeconds;
 
-            if (!IsShowInteractionProgress)
-            {
-                InteractionProgressSeconds = ProgressSeconds;
-            }
-
             DurationText = _numberToolkit.FormatDurationText(e.Duration, e.Duration.Hours > 0);
             ProgressText = _numberToolkit.FormatDurationText(e.Position, e.Duration.Hours > 0);
 
@@ -334,13 +324,6 @@ namespace Bili.ViewModels.Uwp.Core
 
         private async void OnUnitTimerTickAsync(object sender, object e)
         {
-            if (_isInteractionProgressChanged)
-            {
-                _isInteractionProgressChanged = false;
-                _player.SeekTo(_interactionProgress);
-                _interactionProgress = TimeSpan.Zero;
-            }
-
             _presetVolumeHoldTime += 100;
             if (_presetVolumeHoldTime > 300)
             {

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
@@ -78,7 +78,7 @@ namespace Bili.ViewModels.Uwp.Core
                 _player.MediaOpened -= OnMediaOpened;
                 _player.MediaPlayerChanged -= OnMediaPlayerChanged;
                 _player.PositionChanged -= OnMediaPositionChanged;
-                _player.StateChanged -= OnMediaStateChanged;
+                _player.StateChanged -= OnMediaStateChangedAsync;
                 _player.ClearCommand.Execute().Subscribe(_ =>
                 {
                     _player = null;
@@ -239,7 +239,7 @@ namespace Bili.ViewModels.Uwp.Core
             IsShowExitFullPlayerButton = isFullPlayer && (IsError || IsShowMediaTransport);
         }
 
-        private void OnMediaStateChanged(object sender, MediaStateChangedEventArgs e)
+        private async void OnMediaStateChangedAsync(object sender, MediaStateChangedEventArgs e)
         {
             IsError = e.Status == PlayerStatus.Failed;
             Status = e.Status;
@@ -253,6 +253,7 @@ namespace Bili.ViewModels.Uwp.Core
             {
                 if (_player.Position < _initializeProgress)
                 {
+                    await Task.Delay(400);
                     _player.SeekTo(_initializeProgress);
                     _initializeProgress = TimeSpan.Zero;
                 }

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Properties.cs
@@ -52,8 +52,6 @@ namespace Bili.ViewModels.Uwp.Core
         private SegmentInformation _audio;
         private TimeSpan _lastReportProgress;
         private TimeSpan _initializeProgress;
-        private TimeSpan _interactionProgress;
-        private bool _isInteractionProgressChanged;
         private Action _playNextAction;
 
         private DispatcherTimer _unitTimer;
@@ -226,24 +224,6 @@ namespace Bili.ViewModels.Uwp.Core
         /// </summary>
         [Reactive]
         public string CompactOverlayText { get; set; }
-
-        /// <summary>
-        /// 是否显示互动播放进度条.
-        /// </summary>
-        [Reactive]
-        public bool IsShowInteractionProgress { get; set; }
-
-        /// <summary>
-        /// [互动进度条] 当前已播放的秒数.
-        /// </summary>
-        [Reactive]
-        public double InteractionProgressSeconds { get; set; }
-
-        /// <summary>
-        /// [互动进度条] 当前已播放的秒数的可读文本.
-        /// </summary>
-        [Reactive]
-        public string InteractionProgressText { get; set; }
 
         /// <summary>
         /// 是否显示媒体传输控件.

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Properties.cs
@@ -14,6 +14,7 @@ using Bili.ViewModels.Uwp.Account;
 using Bili.ViewModels.Uwp.Common;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
+using Windows.Media;
 using Windows.Media.Playback;
 using Windows.System.Display;
 using Windows.UI.Core;
@@ -53,6 +54,7 @@ namespace Bili.ViewModels.Uwp.Core
         private TimeSpan _lastReportProgress;
         private TimeSpan _initializeProgress;
         private Action _playNextAction;
+        private SystemMediaTransportControls _systemMediaTransportControls;
 
         private DispatcherTimer _unitTimer;
         private DispatcherTimer _progressTimer;

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
@@ -37,7 +37,6 @@ namespace Bili.ViewModels.Uwp.Core
             InitializeVideoInformation();
             await InitializeVideoMediaInformationAsync();
             await InitializeOrginalVideoSourceAsync();
-            FillVideoPlaybackProperties();
             CheckVideoHistory();
         }
 
@@ -197,7 +196,7 @@ namespace Bili.ViewModels.Uwp.Core
         private void FillVideoPlaybackProperties()
         {
             var view = _viewData as VideoPlayerView;
-            _player.SetDisplayProperties(
+            SetDisplayProperties(
                 view.Information.Identifier.Cover.GetSourceUri().ToString() + "@100w_100h_1c_100q.jpg",
                 view.Information.Identifier.Title,
                 string.Join(string.Empty, view.Information.Description.Take(20)),

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
@@ -156,7 +156,7 @@ namespace Bili.ViewModels.Uwp.Core
             catch (Exception ex)
             {
                 IsError = true;
-                ErrorText = _resourceToolkit.GetLocaleString(Models.Enums.LanguageNames.RequestVideoFailed);
+                ErrorText = _resourceToolkit.GetLocaleString(LanguageNames.RequestVideoFailed);
                 LogException(ex);
             }
         }

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
@@ -239,8 +239,8 @@ namespace Bili.ViewModels.Uwp.Core
                 CurrentFormat = null;
             }
 
-            ResetPlayer();
             ResetMediaData();
+            ResetPlayer();
             ResetVideoData();
             ResetLiveData();
             InitializePlaybackRates();
@@ -327,7 +327,7 @@ namespace Bili.ViewModels.Uwp.Core
             _player.MediaOpened += OnMediaOpened;
             _player.MediaPlayerChanged += OnMediaPlayerChanged;
             _player.PositionChanged += OnMediaPositionChanged;
-            _player.StateChanged += OnMediaStateChanged;
+            _player.StateChanged += OnMediaStateChangedAsync;
         }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
@@ -17,6 +17,7 @@ using Bili.ViewModels.Uwp.Account;
 using Bili.ViewModels.Uwp.Common;
 using ReactiveUI;
 using Splat;
+using Windows.Media;
 using Windows.System.Display;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
@@ -261,6 +262,8 @@ namespace Bili.ViewModels.Uwp.Core
             {
                 await LoadLiveAsync();
             }
+
+            InitializeSmtc();
         }
 
         private async Task ChangePartAsync(VideoIdentifier part)
@@ -328,6 +331,16 @@ namespace Bili.ViewModels.Uwp.Core
             _player.MediaPlayerChanged += OnMediaPlayerChanged;
             _player.PositionChanged += OnMediaPositionChanged;
             _player.StateChanged += OnMediaStateChangedAsync;
+        }
+
+        private void InitializeSmtc()
+        {
+            _systemMediaTransportControls = SystemMediaTransportControls.GetForCurrentView();
+            _systemMediaTransportControls.IsEnabled = true;
+            _systemMediaTransportControls.IsPlayEnabled = true;
+            _systemMediaTransportControls.IsPauseEnabled = true;
+            _systemMediaTransportControls.ButtonPressed -= OnSystemControlsButtonPressedAsync;
+            _systemMediaTransportControls.ButtonPressed += OnSystemControlsButtonPressedAsync;
         }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
@@ -141,12 +141,9 @@ namespace Bili.ViewModels.Uwp.Core
                     CheckExitFullPlayerButtonVisibility();
                 });
 
-            this.WhenAnyValue(p => p.InteractionProgressSeconds)
+            this.WhenAnyValue(p => p.ProgressSeconds)
                 .ObserveOn(RxApp.MainThreadScheduler)
-                .Subscribe(x =>
-                {
-                    InteractionProgressText = _numberToolkit.FormatDurationText(TimeSpan.FromSeconds(x), DurationSeconds > 3600);
-                });
+                .InvokeCommand(ChangeProgressCommand);
 
             this.WhenAnyValue(p => p.IsShowMediaTransport)
                 .ObserveOn(RxApp.MainThreadScheduler)

--- a/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
@@ -84,6 +84,7 @@ namespace Bili.ViewModels.Uwp.Core
         private MediaPlayer GetVideoPlayer()
         {
             var player = new MediaPlayer();
+            player.CommandManager.IsEnabled = false;
             player.MediaOpened += OnMediaPlayerOpened;
             player.CurrentStateChanged += OnMediaPlayerCurrentStateChangedAsync;
             player.MediaEnded += OnMediaPlayerEndedAsync;

--- a/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.cs
@@ -129,22 +129,5 @@ namespace Bili.ViewModels.Uwp.Core
                 await rendertarget.SaveAsync(stream, CanvasBitmapFileFormat.Png);
             }
         }
-
-        /// <inheritdoc/>
-        public void SetDisplayProperties(string cover, string title, string subtitle, string videoType)
-        {
-            if (_videoPlaybackItem == null)
-            {
-                return;
-            }
-
-            var props = _videoPlaybackItem.GetDisplayProperties();
-            props.Type = Windows.Media.MediaPlaybackType.Video;
-            props.Thumbnail = Windows.Storage.Streams.RandomAccessStreamReference.CreateFromUri(new Uri(cover));
-            props.VideoProperties.Title = title;
-            props.VideoProperties.Subtitle = subtitle;
-            props.VideoProperties.Genres.Add(videoType);
-            _videoPlaybackItem.ApplyDisplayProperties(props);
-        }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/HttpRandomAccessStream.cs
+++ b/src/ViewModels/ViewModels.Uwp/HttpRandomAccessStream.cs
@@ -47,7 +47,7 @@ namespace Bili.ViewModels.Uwp
 
             return AsyncInfo.Run(async (cancellationToken) =>
             {
-                await randomStream.SendRequesAsync().ConfigureAwait(false);
+                await randomStream.SendRequesAsync();
                 return randomStream;
             });
         }
@@ -99,7 +99,7 @@ namespace Bili.ViewModels.Uwp
                 {
                     if (_inputStream == null)
                     {
-                        await SendRequesAsync().ConfigureAwait(false);
+                        await SendRequesAsync();
                     }
                 }
                 catch (Exception ex)
@@ -107,7 +107,7 @@ namespace Bili.ViewModels.Uwp
                     Debug.WriteLine(ex);
                 }
 
-                var result = await _inputStream.ReadAsync(buffer, count, options).AsTask(cancellationToken, progress).ConfigureAwait(false);
+                var result = await _inputStream.ReadAsync(buffer, count, options).AsTask(cancellationToken, progress);
 
                 // Move position forward.
                 Position += result.Length;
@@ -129,6 +129,7 @@ namespace Bili.ViewModels.Uwp
             request = new HttpRequestMessage(HttpMethod.Get, _requestedUri);
 
             request.Headers.Add("Range", string.Format("bytes={0}-", Position));
+            request.Headers.Add("Connection", "Keep-Alive");
 
             if (!string.IsNullOrEmpty(_etagHeader))
             {
@@ -142,7 +143,7 @@ namespace Bili.ViewModels.Uwp
 
             var response = await _client.SendRequestAsync(
                 request,
-                HttpCompletionOption.ResponseHeadersRead).AsTask().ConfigureAwait(false);
+                HttpCompletionOption.ResponseHeadersRead).AsTask();
 
             if (response.Content.Headers.ContentType != null)
             {
@@ -171,7 +172,7 @@ namespace Bili.ViewModels.Uwp
                 ContentType = response.Content.Headers["Content-Type"];
             }
 
-            _inputStream = await response.Content.ReadAsInputStreamAsync().AsTask().ConfigureAwait(false);
+            _inputStream = await response.Content.ReadAsInputStreamAsync().AsTask();
         }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Search/SearchPageViewModel/SearchPageViewModel.Request.cs
+++ b/src/ViewModels/ViewModels.Uwp/Search/SearchPageViewModel/SearchPageViewModel.Request.cs
@@ -169,7 +169,7 @@ namespace Bili.ViewModels.Uwp.Search
         }
 
         private string GetCondition(string id)
-            => CurrentFilters.First(p => p.Filter.Id == id).CurrentCondition.Id;
+            => CurrentFilters.FirstOrDefault(p => p.Filter.Id == id)?.CurrentCondition?.Id ?? string.Empty;
 
         private void ResetModuleEndIdentifier(SearchModuleType type, bool isEnd)
         {


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1381 

1. 移除视频播放中的进度条，只用 Slider.
2. 修复进度跳转的一些问题
3. 集成 SMTC

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

FFmpeg播放不稳定，在跳转时比较容易崩。同时SMTC需要集成才能进行后台播放

## 新的行为是什么？

修复这些问题

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

在控制器中加了一个刷新按钮，用以在视频或音频卡住的时候刷新播放源
