### PR TITLE
修复媒体传输控件没有自动隐藏的问题

### DIFF
--- a/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Methods.cs
+++ b/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Methods.cs
@@ -69,8 +69,9 @@ namespace Bili.App.Controls.Player
             {
                 _transportStayTime = 0;
                 if (!_mediaTransportControls.IsDanmakuBoxFocused
-                && (_isTouch || !IsCursorInTransportControls()))
+                && (_isTouch || !IsCursorInTransportControls() || !IsCursorInMediaElement()))
                 {
+                    ViewModel.IsShowMediaTransport = true;
                     ViewModel.IsShowMediaTransport = false;
                 }
             }

--- a/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.xaml
+++ b/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.xaml
@@ -297,18 +297,20 @@
                                 x:Name="InteractionProgressContainer"
                                 Grid.Column="1"
                                 Background="{ThemeResource TransparentBackground}">
-                                <StackPanel Margin="0,-8" VerticalAlignment="Center">
+                                <StackPanel VerticalAlignment="Center">
                                     <TextBlock
                                         Style="{StaticResource CaptionTextBlockStyle}"
                                         HorizontalAlignment="Left"
-                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}">
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        TextLineBounds="Tight">
                                         <Run Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.ProgressText}" />
                                         <Run Text="/" />
                                         <Run Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.DurationText}" />
                                     </TextBlock>
                                     <Slider
                                         x:Name="InteractionProgressSlider"
-                                        Margin="0,-4"
+                                        MinHeight="0"
+                                        Margin="0,0,0,-8"
                                         HorizontalAlignment="Stretch"
                                         IsThumbToolTipEnabled="False"
                                         Maximum="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.DurationSeconds, Mode=OneWay}"
@@ -1005,18 +1007,20 @@
                                 x:Name="InteractionProgressContainer"
                                 Grid.Column="1"
                                 Background="{ThemeResource TransparentBackground}">
-                                <StackPanel Margin="0,-8" VerticalAlignment="Center">
+                                <StackPanel VerticalAlignment="Center">
                                     <TextBlock
                                         Style="{StaticResource CaptionTextBlockStyle}"
                                         HorizontalAlignment="Left"
-                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}">
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        TextLineBounds="Tight">
                                         <Run Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.ProgressText}" />
                                         <Run Text="/" />
                                         <Run Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.DurationText}" />
                                     </TextBlock>
                                     <Slider
                                         x:Name="InteractionProgressSlider"
-                                        Margin="0,-4"
+                                        MinHeight="0"
+                                        Margin="0,0,0,-8"
                                         HorizontalAlignment="Stretch"
                                         IsThumbToolTipEnabled="False"
                                         Maximum="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.DurationSeconds, Mode=OneWay}"

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
@@ -45,16 +45,16 @@ namespace Bili.ViewModels.Uwp.Core
                 {
                     Task.Run(async () =>
                     {
-                        var client = GetVideoClient();
-                        _videoStream = await HttpRandomAccessStream.CreateAsync(client, new Uri(_video.BaseUrl));
+                        _videoHttpClient = GetVideoClient();
+                        _videoStream = await HttpRandomAccessStream.CreateAsync(_videoHttpClient, new Uri(_video.BaseUrl));
                         _videoFFSource = await FFmpegMediaSource.CreateFromStreamAsync(_videoStream, _videoConfig);
                     }),
                     Task.Run(async () =>
                     {
                         if (hasAudio)
                         {
-                            var client = GetVideoClient();
-                            _audioStream = await HttpRandomAccessStream.CreateAsync(client, new Uri(_audio.BaseUrl));
+                            _audioHttpClient = GetVideoClient();
+                            _audioStream = await HttpRandomAccessStream.CreateAsync(_audioHttpClient, new Uri(_audio.BaseUrl));
                             _audioFFSource = await FFmpegMediaSource.CreateFromStreamAsync(_audioStream, _videoConfig);
                         }
                     }),
@@ -337,19 +337,24 @@ namespace Bili.ViewModels.Uwp.Core
                 mediaPlayer.PlaybackSession.PositionChanged -= OnPlayerPositionChangedAsync;
             }
 
+            _videoHttpClient?.Dispose();
+            _videoHttpClient = null;
+            _audioHttpClient?.Dispose();
+            _audioHttpClient = null;
+
             playback?.Source?.Dispose();
             playback = null;
 
             source?.Dispose();
             source = null;
 
-            mediaPlayer.Source = null;
-
             if (stream != null)
             {
                 stream?.Dispose();
                 stream = null;
             }
+
+            mediaPlayer.Source = null;
         }
 
         private void Clear()

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Properties.cs
@@ -11,6 +11,7 @@ using ReactiveUI;
 using Windows.Media;
 using Windows.Media.Playback;
 using Windows.UI.Core;
+using Windows.Web.Http;
 
 namespace Bili.ViewModels.Uwp.Core
 {
@@ -29,6 +30,8 @@ namespace Bili.ViewModels.Uwp.Core
         private SegmentInformation _audio;
         private FFmpegMediaSource _videoFFSource;
         private FFmpegMediaSource _audioFFSource;
+        private HttpClient _videoHttpClient;
+        private HttpClient _audioHttpClient;
         private HttpRandomAccessStream _videoStream;
         private HttpRandomAccessStream _audioStream;
         private MediaPlayer _videoPlayer;
@@ -55,9 +58,7 @@ namespace Bili.ViewModels.Uwp.Core
         public ReactiveCommand<Unit, Unit> ClearCommand { get; }
 
         /// <inheritdoc/>
-        public TimeSpan Position => _mediaTimelineController != null
-            ? _mediaTimelineController.Position
-            : _videoPlayer?.PlaybackSession?.Position ?? TimeSpan.Zero;
+        public TimeSpan Position => _videoPlayer?.PlaybackSession?.Position ?? TimeSpan.Zero;
 
         /// <inheritdoc/>
         public TimeSpan Duration => _videoFFSource != null

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
@@ -168,11 +168,11 @@ namespace Bili.ViewModels.Uwp.Core
         /// </summary>
         private void MarkProgressBreakpoint()
         {
-            var progress = _player?.Position;
+            var progress = TimeSpan.FromSeconds(ProgressSeconds);
 
-            if (progress != null && progress > TimeSpan.FromSeconds(1))
+            if (progress > TimeSpan.FromSeconds(1))
             {
-                _initializeProgress = progress.Value;
+                _initializeProgress = progress;
             }
         }
 

--- a/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Properties.cs
@@ -7,6 +7,7 @@ using Bili.Models.Data.Player;
 using Bili.Models.Enums;
 using Bili.Toolkit.Interfaces;
 using ReactiveUI;
+using Windows.Media.Core;
 using Windows.Media.Playback;
 using Windows.UI.Core;
 
@@ -25,6 +26,7 @@ namespace Bili.ViewModels.Uwp.Core
         private SegmentInformation _video;
         private SegmentInformation _audio;
         private MediaPlayer _videoPlayer;
+        private MediaSource _videoSource;
         private MediaPlaybackItem _videoPlaybackItem;
         private HttpRandomAccessStream _liveStream;
 

--- a/src/ViewModels/ViewModels.Uwp/HttpRandomAccessStream.cs
+++ b/src/ViewModels/ViewModels.Uwp/HttpRandomAccessStream.cs
@@ -12,12 +12,13 @@ namespace Bili.ViewModels.Uwp
 {
     internal class HttpRandomAccessStream : IRandomAccessStreamWithContentType
     {
-        private readonly HttpClient _client;
         private readonly Uri _requestedUri;
+        private HttpClient _client;
         private IInputStream _inputStream;
         private ulong _size;
         private string _etagHeader;
         private string _lastModifiedHeader;
+        private HttpResponseMessage _httpResponseMessage;
 
         // No public constructor, factory methods instead to handle async tasks.
         private HttpRandomAccessStream(HttpClient client, Uri uri)
@@ -86,6 +87,13 @@ namespace Bili.ViewModels.Uwp
             if (_client != null)
             {
                 _client?.Dispose();
+                _client = null;
+            }
+
+            if (_httpResponseMessage != null)
+            {
+                _httpResponseMessage?.Dispose();
+                _httpResponseMessage = null;
             }
         }
 
@@ -148,6 +156,14 @@ namespace Bili.ViewModels.Uwp
             var response = await _client.SendRequestAsync(
                 request,
                 HttpCompletionOption.ResponseHeadersRead).AsTask().ConfigureAwait(false);
+
+            if (_httpResponseMessage != null)
+            {
+                _httpResponseMessage?.Dispose();
+                _httpResponseMessage = null;
+            }
+
+            _httpResponseMessage = response;
 
             if (response.Content.Headers.ContentType != null)
             {


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1363 

RT

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

当进入视频播放页时，若光标没有出现在播放区域内，在不移动光标的情况下，控制器有时不会自动隐藏

## 新的行为是什么？

自动隐藏

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

尝试顺便解决播放资源释放的问题，但FFmpeg不知道到底是哪里没释放
