### PR TITLE
修复上一个视频的播放进度会保留至下一个视频的问题

### DIFF
--- a/src/Models/Models.Enums/App/PlayerStatus.cs
+++ b/src/Models/Models.Enums/App/PlayerStatus.cs
@@ -23,6 +23,11 @@ namespace Bili.Models.Enums
         Pause,
 
         /// <summary>
+        /// 已打开媒体流.
+        /// </summary>
+        Opened,
+
+        /// <summary>
         /// 缓冲中.
         /// </summary>
         Buffering,

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Properties.cs
@@ -39,8 +39,10 @@ namespace Bili.ViewModels.Uwp.Core
         private MediaPlaybackItem _videoPlaybackItem;
         private MediaPlaybackItem _audioPlaybackItem;
         private MediaTimelineController _mediaTimelineController;
+        private MediaPlaybackSession _videoCurrentSession;
         private int _liveRetryCount;
         private int _videoRetryCount;
+        private bool _isInitializePlaying;
 
         /// <inheritdoc/>
         public event EventHandler MediaOpened;
@@ -58,7 +60,9 @@ namespace Bili.ViewModels.Uwp.Core
         public ReactiveCommand<Unit, Unit> ClearCommand { get; }
 
         /// <inheritdoc/>
-        public TimeSpan Position => _videoPlayer?.PlaybackSession?.Position ?? TimeSpan.Zero;
+        public TimeSpan Position => _mediaTimelineController == null
+            ? _videoCurrentSession?.Position ?? TimeSpan.Zero
+            : _mediaTimelineController.Position;
 
         /// <inheritdoc/>
         public TimeSpan Duration => _videoFFSource != null

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.cs
@@ -46,6 +46,12 @@ namespace Bili.ViewModels.Uwp.Core
             _video = video;
             _audio = audio;
             _videoRetryCount = 0;
+            _isInitializePlaying = true;
+            if (_mediaTimelineController != null && _mediaTimelineController.Position > TimeSpan.Zero)
+            {
+                _mediaTimelineController.Position = TimeSpan.Zero;
+            }
+
             await LoadDashVideoSourceAsync();
         }
 
@@ -55,6 +61,12 @@ namespace Bili.ViewModels.Uwp.Core
             _video = null;
             _audio = null;
             _liveRetryCount = 0;
+            _isInitializePlaying = true;
+            if (_mediaTimelineController != null && _mediaTimelineController.Position > TimeSpan.Zero)
+            {
+                _mediaTimelineController.Position = TimeSpan.Zero;
+            }
+
             await LoadDashLiveSourceAsync(url);
         }
 
@@ -63,11 +75,17 @@ namespace Bili.ViewModels.Uwp.Core
         {
             if (_mediaTimelineController != null)
             {
+                if (_mediaTimelineController.Position != Position)
+                {
+                    _mediaTimelineController.Position -= TimeSpan.FromMilliseconds(500);
+                }
+
                 _mediaTimelineController.Pause();
             }
             else
             {
                 if (_audioPlayer != null
+                    && _audioPlayer.TimelineController == null
                     && _audioPlayer.PlaybackSession != null
                     && _audioPlayer.PlaybackSession.CanPause)
                 {

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Controls.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Controls.cs
@@ -224,6 +224,11 @@ namespace Bili.ViewModels.Uwp.Core
             var ts = TimeSpan.FromSeconds(seconds);
             if (_player == null || Math.Abs(ts.TotalSeconds - _player.Position.TotalSeconds) < 1)
             {
+                if (Math.Abs(ProgressSeconds - ts.TotalSeconds) > 1)
+                {
+                    _player.SeekTo(TimeSpan.FromSeconds(ProgressSeconds));
+                }
+
                 return;
             }
 

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Episode.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Episode.cs
@@ -58,8 +58,8 @@ namespace Bili.ViewModels.Uwp.Core
             SubtitleViewModel.SetData(_currentEpisode.VideoId, _currentEpisode.PartId);
             DanmakuViewModel.SetData(_currentEpisode.VideoId, _currentEpisode.PartId, _videoType);
             await InitializeEpisodeMediaInformationAsync();
-            await InitializeOrginalVideoSourceAsync();
             CheckEpisodeHistory();
+            await InitializeOrginalVideoSourceAsync();
         }
 
         private void CheckEpisodeHistory()
@@ -70,7 +70,7 @@ namespace Bili.ViewModels.Uwp.Core
                 var history = view.Progress.Identifier;
                 if (_currentEpisode != null && history.Id == _currentEpisode.Identifier.Id)
                 {
-                    ChangeProgress(view.Progress.Progress);
+                    _initializeProgress = TimeSpan.FromSeconds(view.Progress.Progress);
                 }
                 else
                 {

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
@@ -36,8 +36,8 @@ namespace Bili.ViewModels.Uwp.Core
         {
             InitializeVideoInformation();
             await InitializeVideoMediaInformationAsync();
-            await InitializeOrginalVideoSourceAsync();
             CheckVideoHistory();
+            await InitializeOrginalVideoSourceAsync();
         }
 
         private void CheckVideoHistory()
@@ -49,7 +49,8 @@ namespace Bili.ViewModels.Uwp.Core
 
                 if (_currentPart.Id == history.Id)
                 {
-                    ChangeProgress(view.Progress.Progress);
+                    var ts = TimeSpan.FromSeconds(view.Progress.Progress);
+                    _initializeProgress = ts;
                     view.Progress = null;
                 }
                 else

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
@@ -66,6 +66,7 @@ namespace Bili.ViewModels.Uwp.Core
             InteractionViewModel = interactionModuleViewModel;
             ApplicationView.GetForCurrentView().VisibleBoundsChanged += OnViewVisibleBoundsChanged;
             InteractionViewModel.NoMoreChoices += OnInteractionModuleNoMoreChoices;
+            PropertyChanged += OnPropertyChanged;
 
             Volume = _settingsToolkit.ReadLocalSetting(SettingNames.Volume, 100d);
             PlaybackRate = _settingsToolkit.ReadLocalSetting(SettingNames.PlaybackRate, 1d);
@@ -141,10 +142,6 @@ namespace Bili.ViewModels.Uwp.Core
 
                     CheckExitFullPlayerButtonVisibility();
                 });
-
-            this.WhenAnyValue(p => p.ProgressSeconds)
-                .ObserveOn(RxApp.MainThreadScheduler)
-                .InvokeCommand(ChangeProgressCommand);
 
             this.WhenAnyValue(p => p.IsShowMediaTransport)
                 .ObserveOn(RxApp.MainThreadScheduler)
@@ -300,7 +297,6 @@ namespace Bili.ViewModels.Uwp.Core
 
         private void ResetProgressHistory()
         {
-            _initializeProgress = TimeSpan.Zero;
             if (_videoType == VideoType.Video && _viewData is VideoPlayerView videoView)
             {
                 videoView.Progress = null;
@@ -314,7 +310,7 @@ namespace Bili.ViewModels.Uwp.Core
         private void InitializePlayer()
         {
             var playerType = _settingsToolkit.ReadLocalSetting(SettingNames.PlayerType, PlayerType.Native);
-            if(_videoType == VideoType.Live)
+            if (_videoType == VideoType.Live)
             {
                 _player = Locator.Current.GetService<IFFmpegPlayerViewModel>();
             }
@@ -330,7 +326,7 @@ namespace Bili.ViewModels.Uwp.Core
             _player.MediaOpened += OnMediaOpened;
             _player.MediaPlayerChanged += OnMediaPlayerChanged;
             _player.PositionChanged += OnMediaPositionChanged;
-            _player.StateChanged += OnMediaStateChangedAsync;
+            _player.StateChanged += OnMediaStateChanged;
         }
 
         private void InitializeSmtc()

--- a/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
@@ -156,7 +156,7 @@ namespace Bili.ViewModels.Uwp.Core
                 {
                     Status = sender.PlaybackSession.PlaybackState switch
                     {
-                        MediaPlaybackState.Opening => PlayerStatus.Buffering,
+                        MediaPlaybackState.Opening => PlayerStatus.Opened,
                         MediaPlaybackState.Playing => PlayerStatus.Playing,
                         MediaPlaybackState.Buffering => PlayerStatus.Buffering,
                         MediaPlaybackState.Paused => PlayerStatus.Pause,
@@ -166,6 +166,14 @@ namespace Bili.ViewModels.Uwp.Core
                 catch (Exception)
                 {
                     Status = PlayerStatus.NotLoad;
+                }
+
+                if (Status == PlayerStatus.Opened
+                && _isInitializePlaying
+                && _videoPlayer.PlaybackSession.Position != TimeSpan.Zero)
+                {
+                    SeekTo(TimeSpan.Zero);
+                    _isInitializePlaying = false;
                 }
 
                 StateChanged?.Invoke(this, new MediaStateChangedEventArgs(Status, string.Empty));

--- a/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Properties.cs
@@ -29,6 +29,7 @@ namespace Bili.ViewModels.Uwp.Core
         private MediaSource _videoSource;
         private MediaPlaybackItem _videoPlaybackItem;
         private HttpRandomAccessStream _liveStream;
+        private bool _isInitializePlaying;
 
         /// <inheritdoc/>
         public event EventHandler MediaOpened;

--- a/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.cs
@@ -39,6 +39,7 @@ namespace Bili.ViewModels.Uwp.Core
         {
             _video = video;
             _audio = audio;
+            _isInitializePlaying = true;
             await LoadDashVideoSourceAsync();
         }
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1396 

修复播放视频时会保留上一个视频播放进度的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

顺序打开两个视频，上一个视频的播放进度有概率保留到下一个视频

## 新的行为是什么？

在播放前进行数值判断，阻止不合理的进度跳转

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
