### PR TITLE
修复播放控制器隐藏条件不一致的问题

### DIFF
--- a/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Handlers.cs
+++ b/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Handlers.cs
@@ -29,16 +29,16 @@ namespace Bili.App.Controls.Player
             => await ShowAndResetMediaTransportAsync(e.Pointer.PointerDeviceType == Windows.Devices.Input.PointerDeviceType.Mouse);
 
         /// <inheritdoc/>
-        protected override async void OnPointerExited(PointerRoutedEventArgs e)
-            => await HideAndResetMediaTransportAsync(e.Pointer.PointerDeviceType == Windows.Devices.Input.PointerDeviceType.Mouse);
+        protected override void OnPointerExited(PointerRoutedEventArgs e)
+            => HideAndResetMediaTransport();
 
         /// <inheritdoc/>
-        protected override async void OnPointerCanceled(PointerRoutedEventArgs e)
-            => await HideAndResetMediaTransportAsync(e.Pointer.PointerDeviceType == Windows.Devices.Input.PointerDeviceType.Mouse);
+        protected override void OnPointerCanceled(PointerRoutedEventArgs e)
+            => HideAndResetMediaTransport();
 
         /// <inheritdoc/>
-        protected override async void OnPointerCaptureLost(PointerRoutedEventArgs e)
-            => await HideAndResetMediaTransportAsync(e.Pointer.PointerDeviceType == Windows.Devices.Input.PointerDeviceType.Mouse);
+        protected override void OnPointerCaptureLost(PointerRoutedEventArgs e)
+            => HideAndResetMediaTransport();
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
         {

--- a/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Methods.cs
+++ b/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Methods.cs
@@ -65,7 +65,7 @@ namespace Bili.App.Controls.Player
 
         private void HandleTransportAutoHide()
         {
-            if (_transportStayTime > 1.5)
+            if (_transportStayTime > 1.2)
             {
                 _transportStayTime = 0;
                 if (!_mediaTransportControls.IsDanmakuBoxFocused
@@ -84,7 +84,7 @@ namespace Bili.App.Controls.Player
 
         private void HandleCursorAutoHide()
         {
-            if (_cursorStayTime > 2
+            if (_cursorStayTime > 1.5
                 && !ViewModel.IsShowMediaTransport
                 && IsCursorInMediaElement())
             {
@@ -133,19 +133,9 @@ namespace Bili.App.Controls.Player
             _isCursorInPlayer = true;
         }
 
-        private async Task HideAndResetMediaTransportAsync(bool isMouse)
+        private void HideAndResetMediaTransport()
         {
             Window.Current.CoreWindow.PointerCursor = new Windows.UI.Core.CoreCursor(Windows.UI.Core.CoreCursorType.Arrow, 0);
-
-            if (isMouse
-                && ViewModel.IsShowMediaTransport
-                && !IsCursorInTransportControls())
-            {
-                await Dispatcher.TryRunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
-                {
-                    ViewModel.IsShowMediaTransport = false;
-                });
-            }
 
             _cursorStayTime = 0;
             _transportStayTime = 0;

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
@@ -243,18 +243,6 @@ namespace Bili.ViewModels.Uwp.Core
                     Status = PlayerStatus.NotLoad;
                 }
 
-                if (Status == PlayerStatus.Opened
-                && _isInitializePlaying)
-                {
-                    SeekTo(TimeSpan.Zero);
-                    _isInitializePlaying = false;
-                }
-
-                if(Status == PlayerStatus.Playing && _isInitializePlaying)
-                {
-                    _isInitializePlaying = false;
-                }
-
                 StateChanged?.Invoke(this, new MediaStateChangedEventArgs(Status, string.Empty));
             });
         }
@@ -271,20 +259,6 @@ namespace Bili.ViewModels.Uwp.Core
                 {
                     session.PositionChanged += OnPlayerPositionChangedAsync;
                 }
-
-                var autoPlay = _settingsToolkit.ReadLocalSetting(SettingNames.IsAutoPlayWhenLoaded, true);
-                if (autoPlay)
-                {
-                    if (_mediaTimelineController != null)
-                    {
-                        _mediaTimelineController.Resume();
-                    }
-                    else
-                    {
-                        _videoPlayer.AutoPlay = true;
-                        _videoPlayer.Play();
-                    }
-                }
             }
 
             MediaOpened?.Invoke(this, EventArgs.Empty);
@@ -292,8 +266,9 @@ namespace Bili.ViewModels.Uwp.Core
 
         private async void OnPlayerPositionChangedAsync(MediaPlaybackSession sender, object args)
         {
-            if (_isInitializePlaying)
+            if (_shouldPreventSkip && Position != TimeSpan.Zero)
             {
+                _shouldPreventSkip = false;
                 return;
             }
 
@@ -307,7 +282,7 @@ namespace Bili.ViewModels.Uwp.Core
                 var duration = _videoCurrentSession?.NaturalDuration.TotalSeconds;
                 var progress = _videoCurrentSession?.Position.TotalSeconds;
 
-                if (progress >= duration)
+                if (progress > duration)
                 {
                     if (_mediaTimelineController != null)
                     {
@@ -319,12 +294,6 @@ namespace Bili.ViewModels.Uwp.Core
                     && _videoPlayer.TimelineController == null)
                     {
                         _videoPlayer.Pause();
-                    }
-
-                    if (progress == duration)
-                    {
-                        Status = PlayerStatus.End;
-                        StateChanged?.Invoke(this, new MediaStateChangedEventArgs(Status, string.Empty));
                     }
 
                     return;

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
@@ -332,6 +332,12 @@ namespace Bili.ViewModels.Uwp.Core
             _audioHttpClient?.Dispose();
             _audioHttpClient = null;
 
+            if (mediaPlayer.TimelineController != null)
+            {
+                mediaPlayer.TimelineController = null;
+                mediaPlayer.CommandManager.IsEnabled = true;
+            }
+
             playback?.Source?.Dispose();
             source?.Dispose();
             stream?.Dispose();

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Properties.cs
@@ -42,7 +42,7 @@ namespace Bili.ViewModels.Uwp.Core
         private MediaPlaybackSession _videoCurrentSession;
         private int _liveRetryCount;
         private int _videoRetryCount;
-        private bool _isInitializePlaying;
+        private bool _shouldPreventSkip;
 
         /// <inheritdoc/>
         public event EventHandler MediaOpened;
@@ -60,9 +60,7 @@ namespace Bili.ViewModels.Uwp.Core
         public ReactiveCommand<Unit, Unit> ClearCommand { get; }
 
         /// <inheritdoc/>
-        public TimeSpan Position => _mediaTimelineController == null
-            ? _videoCurrentSession?.Position ?? TimeSpan.Zero
-            : _mediaTimelineController.Position;
+        public TimeSpan Position => _videoCurrentSession?.Position ?? TimeSpan.Zero;
 
         /// <inheritdoc/>
         public TimeSpan Duration => _videoFFSource != null

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.cs
@@ -46,11 +46,7 @@ namespace Bili.ViewModels.Uwp.Core
             _video = video;
             _audio = audio;
             _videoRetryCount = 0;
-            _isInitializePlaying = true;
-            if (_mediaTimelineController != null && _mediaTimelineController.Position > TimeSpan.Zero)
-            {
-                _mediaTimelineController.Position = TimeSpan.Zero;
-            }
+            _shouldPreventSkip = true;
 
             await LoadDashVideoSourceAsync();
         }
@@ -61,11 +57,6 @@ namespace Bili.ViewModels.Uwp.Core
             _video = null;
             _audio = null;
             _liveRetryCount = 0;
-            _isInitializePlaying = true;
-            if (_mediaTimelineController != null && _mediaTimelineController.Position > TimeSpan.Zero)
-            {
-                _mediaTimelineController.Position = TimeSpan.Zero;
-            }
 
             await LoadDashLiveSourceAsync(url);
         }
@@ -75,11 +66,6 @@ namespace Bili.ViewModels.Uwp.Core
         {
             if (_mediaTimelineController != null)
             {
-                if (_mediaTimelineController.Position != Position)
-                {
-                    _mediaTimelineController.Position -= TimeSpan.FromMilliseconds(500);
-                }
-
                 _mediaTimelineController.Pause();
             }
             else

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Controls.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Controls.cs
@@ -222,7 +222,9 @@ namespace Bili.ViewModels.Uwp.Core
         private void ChangeProgress(double seconds)
         {
             var ts = TimeSpan.FromSeconds(seconds);
-            if (_player == null || Math.Abs(ts.TotalSeconds - _player.Position.TotalSeconds) < 1)
+            if (_player == null
+                || Math.Abs(ts.TotalSeconds - _player.Position.TotalSeconds) < 1
+                || ts > _player.Duration)
             {
                 if (Math.Abs(ProgressSeconds - ts.TotalSeconds) > 1)
                 {

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
@@ -364,6 +364,12 @@ namespace Bili.ViewModels.Uwp.Core
             ChangePlayRateCommand.Execute(PlaybackRate).Subscribe();
             ChangeVolumeCommand.Execute(Volume).Subscribe();
             InitializeDisplayInformation();
+
+            var autoPlay = _settingsToolkit.ReadLocalSetting(SettingNames.IsAutoPlayWhenLoaded, true);
+            if (autoPlay)
+            {
+                _player.Play();
+            }
         }
 
         private void OnProgressTimerTick(object sender, object e)

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
@@ -87,10 +87,7 @@ namespace Bili.ViewModels.Uwp.Core
                 _player.MediaPlayerChanged -= OnMediaPlayerChanged;
                 _player.PositionChanged -= OnMediaPositionChanged;
                 _player.StateChanged -= OnMediaStateChanged;
-                _player.ClearCommand.Execute().Subscribe(_ =>
-                {
-                    _player = null;
-                });
+                _player.ClearCommand.Execute().Subscribe();
             }
 
             _lastReportProgress = TimeSpan.Zero;

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
@@ -47,18 +47,9 @@ namespace Bili.ViewModels.Uwp.Core
             {
                 var history = view.Progress.Identifier;
 
-                if (_currentPart.Id == history.Id)
-                {
-                    var ts = TimeSpan.FromSeconds(view.Progress.Progress);
-                    _initializeProgress = ts;
-                    view.Progress = null;
-                }
-                else
-                {
-                    var ts = TimeSpan.FromSeconds(view.Progress.Progress);
-                    IsShowProgressTip = true;
-                    ProgressTip = $"{_resourceToolkit.GetLocaleString(LanguageNames.PreviousView)}{history.Title} {ts}";
-                }
+                var ts = TimeSpan.FromSeconds(view.Progress.Progress);
+                IsShowProgressTip = true;
+                ProgressTip = $"{_resourceToolkit.GetLocaleString(LanguageNames.PreviousView)}{history.Title} {ts}";
             }
         }
 

--- a/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
@@ -229,6 +229,8 @@ namespace Bili.ViewModels.Uwp.Core
             {
                 _videoPlayer.Pause();
                 _videoPlayer.PlaybackSession.PositionChanged -= OnPlayerPositionChangedAsync;
+                _videoPlayer.PlaybackSession.Position = TimeSpan.Zero;
+                _videoPlayer.CommandManager.IsEnabled = true;
             }
 
             if (_videoSource != null)

--- a/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
@@ -191,13 +191,6 @@ namespace Bili.ViewModels.Uwp.Core
                 {
                     session.PositionChanged += OnPlayerPositionChangedAsync;
                 }
-
-                var autoPlay = _settingsToolkit.ReadLocalSetting(SettingNames.IsAutoPlayWhenLoaded, true);
-                if (autoPlay)
-                {
-                    _videoPlayer.AutoPlay = true;
-                    _videoPlayer.Play();
-                }
             }
 
             MediaOpened?.Invoke(this, EventArgs.Empty);


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1395 

现在确定光标从任意方向离开播放器，控制器都会在1.5秒后消失，而不是之前的立即消失

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

光标在部分方向上离开播放器，控制器会立刻隐藏，但部分方向上不会，具体见 Bug

## 新的行为是什么？

光标从任意方向离开播放器，1.5秒后控制器隐藏

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

观察到播放进度保留的问题仍然存在，在这个PR中进行了增补修复
