### PR TITLE
在进入包含历史记录的视频时显示进度提示

### DIFF
--- a/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Fields.cs
+++ b/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Fields.cs
@@ -37,6 +37,7 @@ namespace Bili.App.Controls.Player
         private double _tempMessageStayTime;
         private double _transportStayTime;
         private double _nextVideoStayTime;
+        private double _progressTipStayTime;
 
         private double _manipulationDeltaX = 0d;
         private double _manipulationDeltaY = 0d;

--- a/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Handlers.cs
+++ b/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Handlers.cs
@@ -251,10 +251,16 @@ namespace Bili.App.Controls.Player
                 _nextVideoStayTime += 0.5;
             }
 
+            if (ViewModel.IsShowProgressTip)
+            {
+                _progressTipStayTime += 0.5;
+            }
+
             HandleTransportAutoHide();
             HandleCursorAutoHide();
             HandleTempMessageAutoHide();
             HandleNextVideoAutoHide();
+            HandleProgressTipAutoHide();
         }
 
         private void OnSizeChanged(object sender, SizeChangedEventArgs e)

--- a/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Methods.cs
+++ b/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Methods.cs
@@ -116,6 +116,20 @@ namespace Bili.App.Controls.Player
             }
         }
 
+        private void HandleProgressTipAutoHide()
+        {
+            if (_progressTipStayTime > 5)
+            {
+                _progressTipStayTime = 0;
+                ViewModel.ProgressTipCountdown = 0;
+                ViewModel.IsShowProgressTip = false;
+            }
+            else
+            {
+                ViewModel.ProgressTipCountdown = Math.Ceiling(5 - _progressTipStayTime);
+            }
+        }
+
         private async Task ShowAndResetMediaTransportAsync(bool isMouse)
         {
             Window.Current.CoreWindow.PointerCursor = new Windows.UI.Core.CoreCursor(Windows.UI.Core.CoreCursorType.Arrow, 0);

--- a/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.xaml
+++ b/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.xaml
@@ -74,6 +74,7 @@
                                         Grid.Column="1"
                                         HorizontalAlignment="Right"
                                         ActionContent="{loc:Locale Name=ContinuePreviousView}"
+                                        AdditionalTitle="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.ProgressTipCountdown}"
                                         CloseCommand="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.ClearSourceProgressCommand}"
                                         Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.JumpToLastProgressCommand}"
                                         IsOpen="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.IsShowProgressTip, Mode=TwoWay}"

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
@@ -269,6 +269,7 @@ namespace Bili.ViewModels.Uwp.Core
             if (_shouldPreventSkip && Position != TimeSpan.Zero)
             {
                 _shouldPreventSkip = false;
+                SeekTo(TimeSpan.Zero);
                 return;
             }
 
@@ -350,6 +351,7 @@ namespace Bili.ViewModels.Uwp.Core
             if (_mediaTimelineController != null)
             {
                 _mediaTimelineController.Pause();
+                _mediaTimelineController.Position = TimeSpan.Zero;
                 _mediaTimelineController = null;
             }
 

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Properties.cs
@@ -252,6 +252,12 @@ namespace Bili.ViewModels.Uwp.Core
         public double NextVideoCountdown { get; set; }
 
         /// <summary>
+        /// 自动关闭进度提示的倒计时秒数.
+        /// </summary>
+        [Reactive]
+        public double ProgressTipCountdown { get; set; }
+
+        /// <summary>
         /// 是否为互动视频.
         /// </summary>
         [Reactive]


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

不再直接跳转到视频上次播放的位置，而是显示进度提示

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

视频直接跳转到上次播放的地方

## 新的行为是什么？

显示一个历史提示，用户点击后再跳转

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

依然在修复播放进度延续到下一个视频的问题
