### PR TITLE
修复退出视频后没有释放DisplayRequest的问题

### DIFF
--- a/src/App/Pages/Desktop/Overlay/VideoPlayerPage.xaml.cs
+++ b/src/App/Pages/Desktop/Overlay/VideoPlayerPage.xaml.cs
@@ -44,8 +44,8 @@ namespace Bili.App.Pages.Desktop.Overlay
         /// <inheritdoc/>
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
-            ViewModel.ClearPlaylistCommand.Execute().Subscribe();
             ViewModel.ClearCommand.Execute().Subscribe();
+            ViewModel.ClearPlaylistCommand.Execute().Subscribe();
         }
 
         /// <inheritdoc/>

--- a/src/Lib/DI.App/DIFactory.cs
+++ b/src/Lib/DI.App/DIFactory.cs
@@ -34,7 +34,6 @@ using Bili.ViewModels.Uwp.Video;
 using Splat;
 using Splat.NLog;
 using Windows.Storage;
-using Windows.System.Display;
 using Windows.UI.Xaml;
 
 namespace Bili.DI.App
@@ -188,7 +187,6 @@ namespace Bili.DI.App
         public static void RegisterAppRequiredConstants()
         {
             SplatRegistrations.RegisterConstant(Window.Current.CoreWindow.Dispatcher);
-            SplatRegistrations.RegisterConstant(new DisplayRequest());
             SplatRegistrations.SetupIOC();
         }
     }

--- a/src/ViewModels/ViewModels.Interfaces/Core/IMediaPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Interfaces/Core/IMediaPlayerViewModel.cs
@@ -392,5 +392,15 @@ namespace Bili.ViewModels.Interfaces.Core
         /// </summary>
         /// <param name="action">动作.</param>
         void SetPlayNextAction(Action action);
+
+        /// <summary>
+        /// 激活播放显示（不锁屏）.
+        /// </summary>
+        void ActiveDisplay();
+
+        /// <summary>
+        /// 释放播放显示（允许自动锁屏）.
+        /// </summary>
+        void ReleaseDisplay();
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
@@ -87,6 +87,8 @@ namespace Bili.ViewModels.Uwp.Core
         /// </summary>
         private void ResetPlayer()
         {
+            ReleaseDisplay();
+
             if (_player != null)
             {
                 _player.MediaOpened -= OnMediaOpened;
@@ -102,14 +104,6 @@ namespace Bili.ViewModels.Uwp.Core
             _unitTimer?.Stop();
 
             Status = PlayerStatus.NotLoad;
-
-            try
-            {
-                _displayRequest.RequestRelease();
-            }
-            catch (Exception)
-            {
-            }
         }
 
         private void InitializeTimers()
@@ -133,13 +127,6 @@ namespace Bili.ViewModels.Uwp.Core
         {
             _progressTimer?.Start();
             _unitTimer?.Start();
-            try
-            {
-                _displayRequest.RequestActive();
-            }
-            catch (Exception)
-            {
-            }
         }
 
         private string GetVideoPreferCodecId()
@@ -291,6 +278,12 @@ namespace Bili.ViewModels.Uwp.Core
             Status = e.Status;
             IsMediaPause = e.Status != PlayerStatus.Playing;
             IsBuffering = e.Status == PlayerStatus.Buffering;
+
+            if (_systemMediaTransportControls == null)
+            {
+                return;
+            }
+
             if (e.Status == PlayerStatus.Failed)
             {
                 ErrorText = e.Message;
@@ -329,6 +322,15 @@ namespace Bili.ViewModels.Uwp.Core
             else
             {
                 _systemMediaTransportControls.PlaybackStatus = MediaPlaybackStatus.Paused;
+            }
+
+            if (e.Status == PlayerStatus.Playing)
+            {
+                ActiveDisplay();
+            }
+            else
+            {
+                ReleaseDisplay();
             }
         }
 

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Properties.cs
@@ -39,7 +39,6 @@ namespace Bili.ViewModels.Uwp.Core
         private readonly IAppViewModel _appViewModel;
         private readonly CoreDispatcher _dispatcher;
         private readonly ObservableAsPropertyHelper<bool> _isReloading;
-        private readonly DisplayRequest _displayRequest;
 
         private IPlayerViewModel _player;
         private VideoType _videoType;
@@ -55,6 +54,7 @@ namespace Bili.ViewModels.Uwp.Core
         private TimeSpan _initializeProgress;
         private Action _playNextAction;
         private SystemMediaTransportControls _systemMediaTransportControls;
+        private DisplayRequest _displayRequest;
 
         private DispatcherTimer _unitTimer;
         private DispatcherTimer _progressTimer;

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
@@ -46,8 +46,7 @@ namespace Bili.ViewModels.Uwp.Core
             IInteractionModuleViewModel interactionModuleViewModel,
             ICallerViewModel callerViewModel,
             IAppViewModel appViewModel,
-            CoreDispatcher dispatcher,
-            DisplayRequest displayRequest)
+            CoreDispatcher dispatcher)
         {
             _playerProvider = playerProvider;
             _liveProvider = liveProvider;
@@ -60,7 +59,6 @@ namespace Bili.ViewModels.Uwp.Core
             _appViewModel = appViewModel;
             _navigationViewModel = navigationViewModel;
             _dispatcher = dispatcher;
-            _displayRequest = displayRequest;
             SubtitleViewModel = subtitleModuleViewModel;
             DanmakuViewModel = danmakuModuleViewModel;
             InteractionViewModel = interactionModuleViewModel;
@@ -203,6 +201,36 @@ namespace Bili.ViewModels.Uwp.Core
             ReloadCommand.Execute().Subscribe();
         }
 
+        /// <inheritdoc/>
+        public async void ActiveDisplay()
+        {
+            if (_displayRequest != null)
+            {
+                return;
+            }
+
+            await _dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                _displayRequest = new DisplayRequest();
+                _displayRequest.RequestActive();
+            });
+        }
+
+        /// <inheritdoc/>
+        public async void ReleaseDisplay()
+        {
+            if (_displayRequest == null)
+            {
+                return;
+            }
+
+            await _dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                _displayRequest.RequestRelease();
+                _displayRequest = null;
+            });
+        }
+
         /// <summary>
         /// 设置播放下一个内容的动作.
         /// </summary>
@@ -232,10 +260,10 @@ namespace Bili.ViewModels.Uwp.Core
             }
 
             ResetMediaData();
-            ResetPlayer();
             ResetVideoData();
             ResetLiveData();
             InitializePlaybackRates();
+            ResetPlayer();
         }
 
         private async Task LoadAsync()


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1423 

修复退出视频后没有释放DisplayRequest的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

退出视频后，应用依然保持 DisplayRequest 的激活状态，这会导致系统不能自动锁屏

## 新的行为是什么？

仅在视频播放时激活 DisplayRequest，其他情况下都会释放

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

`DisplayRequest` 不能保持单例，释放后该对象就该弃用，并创建一个新的
