### PR TITLE
修复不能连续播放的问题

### DIFF
--- a/src/App/Pages/Desktop/Overlay/UserSpacePage.xaml
+++ b/src/App/Pages/Desktop/Overlay/UserSpacePage.xaml
@@ -233,8 +233,12 @@
                 Visibility="{x:Bind ViewModel.IsSearchMode, Mode=OneWay}" />
 
             <Grid VerticalAlignment="Center">
-                <controls:ErrorPanel Text="{loc:Locale Name=UserHaveNoVideos}" Visibility="{x:Bind ViewModel.IsSpaceVideoEmpty, Mode=OneWay}" />
-                <controls:ErrorPanel Text="{loc:Locale Name=NoUserVideoSearchResult}" Visibility="{x:Bind ViewModel.IsSearchVideoEmpty, Mode=OneWay}" />
+                <StackPanel Visibility="{x:Bind ViewModel.IsSearchMode, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
+                    <controls:ErrorPanel Text="{loc:Locale Name=UserHaveNoVideos}" Visibility="{x:Bind ViewModel.IsSpaceVideoEmpty, Mode=OneWay}" />
+                </StackPanel>
+                <StackPanel Visibility="{x:Bind ViewModel.IsSearchMode, Mode=OneWay}">
+                    <controls:ErrorPanel Text="{loc:Locale Name=NoUserVideoSearchResult}" Visibility="{x:Bind ViewModel.IsSearchVideoEmpty, Mode=OneWay}" />
+                </StackPanel>
             </Grid>
         </Grid>
     </Grid>

--- a/src/ViewModels/ViewModels.Interfaces/IPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Interfaces/IPlayerViewModel.cs
@@ -27,6 +27,11 @@ namespace Bili.ViewModels.Interfaces
         event EventHandler<MediaStateChangedEventArgs> StateChanged;
 
         /// <summary>
+        /// 媒体结束.
+        /// </summary>
+        event EventHandler MediaEnded;
+
+        /// <summary>
         /// 播放进度变化.
         /// </summary>
         event EventHandler<MediaPositionChangedEventArgs> PositionChanged;

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
@@ -63,11 +63,7 @@ namespace Bili.ViewModels.Uwp.Core
             await Task.WhenAll(tasks);
             _videoPlaybackItem = _videoFFSource.CreateMediaPlaybackItem();
 
-            if (_videoPlayer == null)
-            {
-                _videoPlayer = GetVideoPlayer();
-            }
-
+            _videoPlayer = GetVideoPlayer();
             _videoPlayer.Source = _videoPlaybackItem;
 
             if (hasAudio)
@@ -77,11 +73,7 @@ namespace Bili.ViewModels.Uwp.Core
                 _videoPlayer.CommandManager.IsEnabled = false;
                 _videoPlayer.TimelineController = _mediaTimelineController;
 
-                if (_audioPlayer == null)
-                {
-                    _audioPlayer = GetAudioPlayer();
-                }
-
+                _audioPlayer = GetAudioPlayer();
                 _audioPlayer.CommandManager.IsEnabled = false;
                 _audioPlayer.Source = _audioPlaybackItem;
                 _audioPlayer.TimelineController = _mediaTimelineController;
@@ -219,7 +211,7 @@ namespace Bili.ViewModels.Uwp.Core
                 }
 
                 Status = PlayerStatus.End;
-                StateChanged?.Invoke(this, new MediaStateChangedEventArgs(Status, string.Empty));
+                MediaEnded?.Invoke(this, EventArgs.Empty);
             });
         }
 
@@ -344,6 +336,7 @@ namespace Bili.ViewModels.Uwp.Core
             stream?.Dispose();
 
             mediaPlayer.Source = null;
+            mediaPlayer = null;
         }
 
         private void Clear()

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Properties.cs
@@ -48,6 +48,9 @@ namespace Bili.ViewModels.Uwp.Core
         public event EventHandler MediaOpened;
 
         /// <inheritdoc/>
+        public event EventHandler MediaEnded;
+
+        /// <inheritdoc/>
         public event EventHandler<MediaStateChangedEventArgs> StateChanged;
 
         /// <inheritdoc/>

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Controls.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Controls.cs
@@ -35,7 +35,11 @@ namespace Bili.ViewModels.Uwp.Core
                 }
                 else if (Status == PlayerStatus.End)
                 {
-                    _player.SeekTo(TimeSpan.Zero);
+                    if (Math.Abs(_player.Position.TotalSeconds - _player.Duration.TotalSeconds) < 1)
+                    {
+                        _player.SeekTo(TimeSpan.Zero);
+                    }
+
                     _player.Play();
                 }
             });

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
@@ -91,10 +91,6 @@ namespace Bili.ViewModels.Uwp.Core
 
             if (_player != null)
             {
-                _player.MediaOpened -= OnMediaOpened;
-                _player.MediaPlayerChanged -= OnMediaPlayerChanged;
-                _player.PositionChanged -= OnMediaPositionChanged;
-                _player.StateChanged -= OnMediaStateChanged;
                 _player.ClearCommand.Execute().Subscribe();
                 _player = null;
             }
@@ -298,27 +294,6 @@ namespace Bili.ViewModels.Uwp.Core
                     _initializeProgress = TimeSpan.Zero;
                 }
             }
-            else if (e.Status == PlayerStatus.End)
-            {
-                _systemMediaTransportControls.PlaybackStatus = MediaPlaybackStatus.Stopped;
-                if (IsInteractionVideo)
-                {
-                    if (InteractionViewModel.Choices.Count == 1 && string.IsNullOrEmpty(InteractionViewModel.Choices.First().Text))
-                    {
-                        // 这是默认选项，直接切换.
-                        SelectInteractionChoiceCommand.Execute(InteractionViewModel.Choices.First());
-                    }
-                    else
-                    {
-                        IsShowInteractionChoices = true;
-                    }
-                }
-
-                if (!IsLoop)
-                {
-                    MediaEnded?.Invoke(this, EventArgs.Empty);
-                }
-            }
             else
             {
                 _systemMediaTransportControls.PlaybackStatus = MediaPlaybackStatus.Paused;
@@ -375,6 +350,27 @@ namespace Bili.ViewModels.Uwp.Core
             if (autoPlay)
             {
                 _player.Play();
+            }
+        }
+
+        private void OnMediaEnded(object sender, EventArgs e)
+        {
+            if (IsInteractionVideo)
+            {
+                if (InteractionViewModel.Choices.Count == 1 && string.IsNullOrEmpty(InteractionViewModel.Choices.First().Text))
+                {
+                    // 这是默认选项，直接切换.
+                    SelectInteractionChoiceCommand.Execute(InteractionViewModel.Choices.First());
+                }
+                else
+                {
+                    IsShowInteractionChoices = true;
+                }
+            }
+
+            if (!IsLoop)
+            {
+                MediaEnded?.Invoke(this, EventArgs.Empty);
             }
         }
 

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
@@ -226,7 +226,7 @@ namespace Bili.ViewModels.Uwp.Core
 
             await _dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
-                _displayRequest.RequestRelease();
+                _displayRequest?.RequestRelease();
                 _displayRequest = null;
             });
         }
@@ -342,12 +342,13 @@ namespace Bili.ViewModels.Uwp.Core
                         PlayerType.FFmpeg => Locator.Current.GetService<IFFmpegPlayerViewModel>(),
                         _ => Locator.Current.GetService<INativePlayerViewModel>(),
                     };
-            }
 
-            _player.MediaOpened += OnMediaOpened;
-            _player.MediaPlayerChanged += OnMediaPlayerChanged;
-            _player.PositionChanged += OnMediaPositionChanged;
-            _player.StateChanged += OnMediaStateChanged;
+                _player.MediaOpened += OnMediaOpened;
+                _player.MediaEnded += OnMediaEnded;
+                _player.MediaPlayerChanged += OnMediaPlayerChanged;
+                _player.PositionChanged += OnMediaPositionChanged;
+                _player.StateChanged += OnMediaStateChanged;
+            }
         }
 
         private void InitializeSmtc()

--- a/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
@@ -77,11 +77,7 @@ namespace Bili.ViewModels.Uwp.Core
             _videoSource = MediaSource.CreateFromAdaptiveMediaSource(source.MediaSource);
             _videoPlaybackItem = new MediaPlaybackItem(_videoSource);
 
-            if (_videoPlayer == null)
-            {
-                _videoPlayer = GetVideoPlayer();
-            }
-
+            _videoPlayer = GetVideoPlayer();
             _videoPlayer.Source = _videoPlaybackItem;
             MediaPlayerChanged?.Invoke(this, _videoPlayer);
         }
@@ -144,7 +140,7 @@ namespace Bili.ViewModels.Uwp.Core
             await _dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
             {
                 Status = PlayerStatus.End;
-                StateChanged?.Invoke(this, new MediaStateChangedEventArgs(Status, string.Empty));
+                MediaEnded?.Invoke(this, EventArgs.Empty);
             });
         }
 
@@ -165,7 +161,7 @@ namespace Bili.ViewModels.Uwp.Core
                 }
                 catch (Exception)
                 {
-                    Status = PlayerStatus.NotLoad;
+                    Status = PlayerStatus.Failed;
                 }
 
                 StateChanged?.Invoke(this, new MediaStateChangedEventArgs(Status, string.Empty));
@@ -251,6 +247,7 @@ namespace Bili.ViewModels.Uwp.Core
             }
 
             _videoPlayer.Source = null;
+            _videoPlayer = null;
         }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Properties.cs
@@ -34,6 +34,9 @@ namespace Bili.ViewModels.Uwp.Core
         public event EventHandler MediaOpened;
 
         /// <inheritdoc/>
+        public event EventHandler MediaEnded;
+
+        /// <inheritdoc/>
         public event EventHandler<MediaStateChangedEventArgs> StateChanged;
 
         /// <inheritdoc/>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1412 

修复不能连续播放的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

对于有分集的视频，可能出现不能正常连续播放的情况

## 新的行为是什么？

分离事件，单独触发 MediaEnded 事件，以保证不会有事件队列的冲突

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
