### PR TITLE
减缓内存泄漏的程度

### DIFF
--- a/src/Adapter/Adapter.UnitTests/Adapter.UnitTests.csproj
+++ b/src/Adapter/Adapter.UnitTests/Adapter.UnitTests.csproj
@@ -19,7 +19,8 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-      <PackageReference Update="Moq" Version="4.18.1" />
+      <PackageReference Update="Moq" Version="4.18.2" />
+      <PackageReference Update="xunit" Version="2.4.2" />
       <PackageReference Update="xunit.runner.visualstudio" Version="2.4.5">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/App/Controls/Danmaku/DanmakuView/DanmakuView.cs
+++ b/src/App/Controls/Danmaku/DanmakuView/DanmakuView.cs
@@ -104,6 +104,8 @@ namespace Bili.App.Controls.Danmaku
         {
             Close();
             ViewModel.PropertyChanged -= OnViewModelProeprtyChangedAsync;
+            ViewModel.LiveDanmakuAdded -= OnLiveDanmakuAdded;
+            ViewModel.SendDanmakuSucceeded -= OnSendDanmakuSucceeded;
         }
 
         private async void OnViewModelProeprtyChangedAsync(object sender, PropertyChangedEventArgs e)

--- a/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Handlers.cs
+++ b/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Handlers.cs
@@ -89,7 +89,11 @@ namespace Bili.App.Controls.Player
             }
             else
             {
-                _mediaPlayerElement.SetMediaPlayer(null);
+                await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+                {
+                    _mediaPlayerElement.MediaPlayer?.Dispose();
+                    _mediaPlayerElement.SetMediaPlayer(null);
+                });
             }
         }
 

--- a/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Handlers.cs
+++ b/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Handlers.cs
@@ -49,6 +49,17 @@ namespace Bili.App.Controls.Player
             ViewModel.MediaPlayerChanged -= OnMediaPlayerChangedAsync;
             ViewModel.RequestShowTempMessage -= OnRequestShowTempMessage;
             ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+
+            _interactionControl.Tapped -= OnInteractionControlTapped;
+            _interactionControl.DoubleTapped -= OnInteractionControlDoubleTapped;
+            _interactionControl.ManipulationStarted -= OnInteractionControlManipulationStarted;
+            _interactionControl.ManipulationDelta -= OnInteractionControlManipulationDelta;
+            _interactionControl.ManipulationCompleted -= OnInteractionControlManipulationCompleted;
+            _interactionControl.PointerPressed -= OnInteractionControlPointerPressed;
+            _interactionControl.PointerMoved -= OnInteractionControlPointerMoved;
+            _interactionControl.PointerReleased -= OnInteractionControlPointerReleased;
+            _interactionControl.PointerCanceled -= OnInteractionControlPointerCanceled;
+            _gestureRecognizer.Holding -= OnGestureRecognizerHolding;
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)
@@ -69,10 +80,17 @@ namespace Bili.App.Controls.Player
 
         private async void OnMediaPlayerChangedAsync(object sender, object e)
         {
-            _mediaPlayerElement.SetMediaPlayer(e as MediaPlayer);
+            if(e is MediaPlayer mp)
+            {
+                _mediaPlayerElement.SetMediaPlayer(mp);
 
-            await Task.Delay(200);
-            await _danmakuView?.RedrawAsync();
+                await Task.Delay(200);
+                await _danmakuView?.RedrawAsync();
+            }
+            else
+            {
+                _mediaPlayerElement.SetMediaPlayer(null);
+            }
         }
 
         private void OnInteractionControlTapped(object sender, TappedRoutedEventArgs e)

--- a/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.Fields.cs
+++ b/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.Fields.cs
@@ -14,10 +14,12 @@ namespace Bili.App.Controls.Player
         private const string FormatListViewName = "FormatListView";
         private const string PlayPauseButtonName = "PlayPauseButton";
         private const string DanmakuBoxName = "DanmakuBox";
+        private const string RootGridName = "RootGrid";
 
         private Slider _volumeSlider;
         private ListView _formatListView;
         private Button _playPauseButton;
         private DanmakuBox _danmakuBox;
+        private Grid _rootGrid;
     }
 }

--- a/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.Handlers.cs
+++ b/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.Handlers.cs
@@ -54,7 +54,7 @@ namespace Bili.App.Controls.Player
             _volumeSlider = null;
             _playPauseButton = null;
             _danmakuBox = null;
-            _rootGrid.Children.Clear();
+            _rootGrid?.Children?.Clear();
             _rootGrid = null;
         }
 

--- a/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.Handlers.cs
+++ b/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.Handlers.cs
@@ -38,7 +38,25 @@ namespace Bili.App.Controls.Player
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
-            => ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+        {
+            ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            if (_formatListView != null)
+            {
+                _formatListView.SelectionChanged -= OnFormatListViewSelectionChanged;
+            }
+
+            if (_volumeSlider != null)
+            {
+                _volumeSlider.ValueChanged -= OnVolumeSliderValueChanged;
+            }
+
+            _formatListView = null;
+            _volumeSlider = null;
+            _playPauseButton = null;
+            _danmakuBox = null;
+            _rootGrid.Children.Clear();
+            _rootGrid = null;
+        }
 
         private void OnViewModelPropertyChanged(object sender, PropertyChangedEventArgs e)
         {

--- a/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.cs
+++ b/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.cs
@@ -41,6 +41,7 @@ namespace Bili.App.Controls.Player
             _formatListView = GetTemplateChild(FormatListViewName) as ListView;
             _playPauseButton = GetTemplateChild(PlayPauseButtonName) as Button;
             _danmakuBox = GetTemplateChild(DanmakuBoxName) as DanmakuBox;
+            _rootGrid = GetTemplateChild(RootGridName) as Grid;
 
             if (_formatListView != null)
             {

--- a/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.xaml
+++ b/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.xaml
@@ -54,7 +54,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:BiliMediaTransportControls">
-                    <Grid>
+                    <Grid x:Name="RootGird">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="PlayPauseStateGroup">
                                 <VisualState x:Name="PlayingState">
@@ -529,7 +529,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:BiliMediaTransportControls">
-                    <Grid>
+                    <Grid x:Name="RootGrid">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="PlayPauseStateGroup">
                                 <VisualState x:Name="PlayingState">
@@ -860,7 +860,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:BiliMediaTransportControls">
-                    <Grid>
+                    <Grid x:Name="RootGrid">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="PlayPauseStateGroup">
                                 <VisualState x:Name="PlayingState">
@@ -1167,7 +1167,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:BiliMediaTransportControls">
-                    <Grid>
+                    <Grid x:Name="RootGrid">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="PlayPauseStateGroup">
                                 <VisualState x:Name="PlayingState">

--- a/src/App/Pages/Desktop/Overlay/VideoPlayerPage.xaml
+++ b/src/App/Pages/Desktop/Overlay/VideoPlayerPage.xaml
@@ -134,7 +134,7 @@
         </Flyout>
     </base:VideoPlayerPageBase.Resources>
 
-    <Grid>
+    <Grid x:Name="RootGrid">
         <player:PlayerPagePanel
             IsEnabled="{x:Bind ViewModel.IsError, Mode=OneWay, Converter={StaticResource ObjectToBoolReverseConverter}}"
             IsTabStop="{x:Bind ViewModel.IsError, Mode=OneWay, Converter={StaticResource ObjectToBoolReverseConverter}}"

--- a/src/App/Pages/Desktop/Overlay/VideoPlayerPage.xaml.cs
+++ b/src/App/Pages/Desktop/Overlay/VideoPlayerPage.xaml.cs
@@ -44,6 +44,7 @@ namespace Bili.App.Pages.Desktop.Overlay
         /// <inheritdoc/>
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
+            RootGrid.Children.Clear();
             ViewModel.ClearCommand.Execute().Subscribe();
             ViewModel.ClearPlaylistCommand.Execute().Subscribe();
         }

--- a/src/Lib/Lib.Implementation/Lib.Implementation.csproj
+++ b/src/Lib/Lib.Implementation/Lib.Implementation.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.21.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.4" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.43" />
     <PackageReference Include="Websocket.Client" Version="4.4.43" />
   </ItemGroup>

--- a/src/Models/Models.gRPC/Models.gRPC.csproj
+++ b/src/Models/Models.gRPC/Models.gRPC.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.21.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.4" />
     <PackageReference Include="Grpc.Net.Client" Version="2.47.0" />
     <PackageReference Include="Grpc.Tools" Version="2.47.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tasks/Tasks.csproj
+++ b/src/Tasks/Tasks.csproj
@@ -126,7 +126,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf">
-      <Version>3.21.2</Version>
+      <Version>3.21.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
@@ -313,7 +313,7 @@ namespace Bili.ViewModels.Uwp.Core
             return controller;
         }
 
-        private void ClearMediaPlayerData(MediaPlayer mediaPlayer, MediaPlaybackItem playback, FFmpegMediaSource source, HttpRandomAccessStream stream)
+        private void ClearMediaPlayerData(ref MediaPlayer mediaPlayer, ref MediaPlaybackItem playback, ref FFmpegMediaSource source, ref HttpRandomAccessStream stream)
         {
             if (mediaPlayer == null)
             {
@@ -332,10 +332,14 @@ namespace Bili.ViewModels.Uwp.Core
             }
 
             playback?.Source?.Dispose();
+            playback = null;
             source?.Dispose();
+            source = null;
             stream?.Dispose();
+            stream = null;
 
             mediaPlayer.Source = null;
+            mediaPlayer?.Dispose();
             mediaPlayer = null;
         }
 
@@ -354,10 +358,17 @@ namespace Bili.ViewModels.Uwp.Core
             }
 
             _videoCurrentSession = null;
-            ClearMediaPlayerData(_videoPlayer, _videoPlaybackItem, _videoFFSource, _videoStream);
-            ClearMediaPlayerData(_audioPlayer, _audioPlaybackItem, _audioFFSource, _audioStream);
+
+            _videoPlayer.MediaOpened -= OnMediaPlayerOpened;
+            _videoPlayer.CurrentStateChanged -= OnMediaPlayerCurrentStateChangedAsync;
+            _videoPlayer.MediaEnded -= OnMediaPlayerEndedAsync;
+            _videoPlayer.MediaFailed -= OnMediaPlayerFailedAsync;
+
+            ClearMediaPlayerData(ref _videoPlayer, ref _videoPlaybackItem, ref _videoFFSource, ref _videoStream);
+            ClearMediaPlayerData(ref _audioPlayer, ref _audioPlaybackItem, ref _audioFFSource, ref _audioStream);
 
             Status = PlayerStatus.NotLoad;
+            MediaPlayerChanged?.Invoke(this, null);
         }
 
         private void TryReconnectPlayer(MediaPlayer player)

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
@@ -320,11 +320,6 @@ namespace Bili.ViewModels.Uwp.Core
                 return;
             }
 
-            _videoHttpClient?.Dispose();
-            _videoHttpClient = null;
-            _audioHttpClient?.Dispose();
-            _audioHttpClient = null;
-
             if (mediaPlayer.TimelineController != null)
             {
                 mediaPlayer.TimelineController = null;
@@ -339,8 +334,6 @@ namespace Bili.ViewModels.Uwp.Core
             stream = null;
 
             mediaPlayer.Source = null;
-            mediaPlayer?.Dispose();
-            mediaPlayer = null;
         }
 
         private void Clear()
@@ -363,11 +356,20 @@ namespace Bili.ViewModels.Uwp.Core
             _videoPlayer.CurrentStateChanged -= OnMediaPlayerCurrentStateChangedAsync;
             _videoPlayer.MediaEnded -= OnMediaPlayerEndedAsync;
             _videoPlayer.MediaFailed -= OnMediaPlayerFailedAsync;
+            _audioPlayer.MediaFailed -= OnMediaPlayerFailedAsync;
+
+            _videoHttpClient?.Dispose();
+            _videoHttpClient = null;
+            _audioHttpClient?.Dispose();
+            _audioHttpClient = null;
 
             ClearMediaPlayerData(ref _videoPlayer, ref _videoPlaybackItem, ref _videoFFSource, ref _videoStream);
             ClearMediaPlayerData(ref _audioPlayer, ref _audioPlaybackItem, ref _audioFFSource, ref _audioStream);
 
             Status = PlayerStatus.NotLoad;
+            _audioPlayer?.Dispose();
+            _audioPlayer = null;
+            _videoPlayer = null;
             MediaPlayerChanged?.Invoke(this, null);
         }
 

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
@@ -333,12 +333,7 @@ namespace Bili.ViewModels.Uwp.Core
         }
 
         private void OnMediaPlayerChanged(object sender, object e)
-        {
-            if (e is MediaPlayer mp)
-            {
-                MediaPlayerChanged?.Invoke(this, mp);
-            }
-        }
+            => MediaPlayerChanged?.Invoke(this, e);
 
         private void OnMediaOpened(object sender, EventArgs e)
         {

--- a/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
@@ -252,7 +252,6 @@ namespace Bili.ViewModels.Uwp.Core
             _videoPlayer.MediaFailed -= OnMediaPlayerFailedAsync;
 
             _videoPlayer.Source = null;
-            _videoPlayer.Dispose();
             _videoPlayer = null;
             MediaPlayerChanged?.Invoke(this, null);
         }

--- a/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
@@ -246,8 +246,15 @@ namespace Bili.ViewModels.Uwp.Core
                 _liveStream = null;
             }
 
+            _videoPlayer.MediaOpened -= OnMediaPlayerOpened;
+            _videoPlayer.CurrentStateChanged -= OnMediaPlayerCurrentStateChangedAsync;
+            _videoPlayer.MediaEnded -= OnMediaPlayerEndedAsync;
+            _videoPlayer.MediaFailed -= OnMediaPlayerFailedAsync;
+
             _videoPlayer.Source = null;
+            _videoPlayer.Dispose();
             _videoPlayer = null;
+            MediaPlayerChanged?.Invoke(this, null);
         }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Video/VideoPlayerPageViewModel/VideoPlayerPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Video/VideoPlayerPageViewModel/VideoPlayerPageViewModel.cs
@@ -171,6 +171,7 @@ namespace Bili.ViewModels.Uwp.Video
                 MediaPlayerViewModel.MediaEnded -= OnMediaEnded;
                 MediaPlayerViewModel.InternalPartChanged -= OnInternalPartChanged;
                 MediaPlayerViewModel.ClearCommand.Execute().Subscribe();
+                MediaPlayerViewModel = null;
             }
         }
 

--- a/src/ViewModels/ViewModels.Uwp/Video/VideoPlayerPageViewModel/VideoPlayerPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Video/VideoPlayerPageViewModel/VideoPlayerPageViewModel.cs
@@ -72,7 +72,6 @@ namespace Bili.ViewModels.Uwp.Video
 
             DownloadViewModel = downloadViewModel;
 
-            ReloadMediaPlayer();
             IsSignedIn = _authorizeProvider.State == AuthorizeState.SignedIn;
             _authorizeProvider.StateChanged += OnAuthorizeStateChanged;
 
@@ -111,6 +110,7 @@ namespace Bili.ViewModels.Uwp.Video
         /// <inheritdoc/>
         public void SetSnapshot(PlaySnapshot snapshot)
         {
+            ReloadMediaPlayer();
             _presetVideoId = snapshot.VideoId;
             var defaultPlayMode = _settingsToolkit.ReadLocalSetting(SettingNames.DefaultPlayerDisplayMode, PlayerDisplayMode.Default);
             MediaPlayerViewModel.DisplayMode = snapshot.DisplayMode ?? defaultPlayMode;
@@ -120,6 +120,7 @@ namespace Bili.ViewModels.Uwp.Video
         /// <inheritdoc/>
         public void SetPlaylist(IEnumerable<VideoInformation> videos, int playIndex = 0)
         {
+            ReloadMediaPlayer();
             TryClear(VideoPlaylist);
             foreach (var item in videos)
             {

--- a/src/ViewModels/ViewModels.Uwp/ViewModels.Uwp.csproj
+++ b/src/ViewModels/ViewModels.Uwp/ViewModels.Uwp.csproj
@@ -209,7 +209,7 @@
       <Version>2.9.1</Version>
     </PackageReference>
     <PackageReference Include="FFmpegInteropX">
-      <Version>1.0.0</Version>
+      <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Humanizer.Core.zh-CN">
       <Version>2.14.1</Version>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

哔哩在播放视频的过程中存在严重的内存泄露问题。播放视频越多，内存占用越高，达到限值应用就会崩溃。

这个 PR 只能说减缓内存泄漏，目前推断的原因可能与播放组件和ReactiveUI有关，但目前还没有找到根源（或者说问题遍地都是）

修复主要对原生播放有作用，FFMpeg效果不甚明显

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
<!-- - 功能 -->
<!-- - 代码样式更新 -->
- 重构 （没有功能修改，没有 API 更新）
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

呵，要变成内存怪兽了

## 新的行为是什么？

尽量释放播放所占用的内存

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

脑壳痛，写个鬼呀(ノ｀Д)ノ
