### PR TITLE
修复SMTC显示重复播放器的问题

### DIFF
--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
@@ -70,11 +70,9 @@ namespace Bili.ViewModels.Uwp.Core
             {
                 _audioPlaybackItem = _audioFFSource.CreateMediaPlaybackItem();
                 _mediaTimelineController = GetTimelineController();
-                _videoPlayer.CommandManager.IsEnabled = false;
                 _videoPlayer.TimelineController = _mediaTimelineController;
 
                 _audioPlayer = GetAudioPlayer();
-                _audioPlayer.CommandManager.IsEnabled = false;
                 _audioPlayer.Source = _audioPlaybackItem;
                 _audioPlayer.TimelineController = _mediaTimelineController;
             }
@@ -141,6 +139,7 @@ namespace Bili.ViewModels.Uwp.Core
             player.CurrentStateChanged += OnMediaPlayerCurrentStateChangedAsync;
             player.MediaEnded += OnMediaPlayerEndedAsync;
             player.MediaFailed += OnMediaPlayerFailedAsync;
+            player.CommandManager.IsEnabled = false;
             return player;
         }
 
@@ -148,6 +147,7 @@ namespace Bili.ViewModels.Uwp.Core
         {
             var player = new MediaPlayer();
             player.MediaFailed += OnMediaPlayerFailedAsync;
+            player.CommandManager.IsEnabled = false;
             return player;
         }
 

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.cs
@@ -69,6 +69,14 @@ namespace Bili.ViewModels.Uwp.Core
             }
             else
             {
+                if (_videoPlayer != null
+                    && _videoPlayer.TimelineController == null
+                    && _videoPlayer.PlaybackSession != null
+                    && _videoPlayer.PlaybackSession.CanPause)
+                {
+                    _videoPlayer.Pause();
+                }
+
                 if (_audioPlayer != null
                     && _audioPlayer.TimelineController == null
                     && _audioPlayer.PlaybackSession != null

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Live.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Live.cs
@@ -95,7 +95,7 @@ namespace Bili.ViewModels.Uwp.Core
         private async Task InitializeLivePlayerAsync(string url)
         {
             await _player.SetSourceAsync(url);
-            StartTimersAndDisplayRequest();
+            StartTimers();
         }
 
         private async Task ChangeLiveAudioOnlyAsync(bool isAudioOnly)

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Method.cs
@@ -49,6 +49,7 @@ namespace Bili.ViewModels.Uwp.Core
 
             if (_systemMediaTransportControls != null)
             {
+                _systemMediaTransportControls.DisplayUpdater.ClearAll();
                 _systemMediaTransportControls.IsEnabled = false;
                 _systemMediaTransportControls = null;
             }
@@ -118,7 +119,7 @@ namespace Bili.ViewModels.Uwp.Core
             }
         }
 
-        private void StartTimersAndDisplayRequest()
+        private void StartTimers()
         {
             _progressTimer?.Start();
             _unitTimer?.Start();
@@ -259,6 +260,7 @@ namespace Bili.ViewModels.Uwp.Core
             }
 
             var updater = _systemMediaTransportControls.DisplayUpdater;
+            updater.ClearAll();
             updater.Type = MediaPlaybackType.Video;
             updater.Thumbnail = Windows.Storage.Streams.RandomAccessStreamReference.CreateFromUri(new Uri(cover));
             updater.VideoProperties.Title = title;

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
@@ -29,7 +29,7 @@ namespace Bili.ViewModels.Uwp.Core
             ResetPlayer();
             ResetMediaData();
             await LoadVideoAsync();
-            StartTimersAndDisplayRequest();
+            StartTimers();
         }
 
         private async Task LoadVideoAsync()
@@ -143,7 +143,7 @@ namespace Bili.ViewModels.Uwp.Core
             try
             {
                 await _player.SetSourceAsync(_video, _audio);
-                StartTimersAndDisplayRequest();
+                StartTimers();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1445 

修复 SMTC 区域显示冗余播放器的问题，原因在于没有禁用 ffmpeg 的默认命令管理器，导致系统自动为 MediaPlayer 创建了一个控制器

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

观看直播或者使用ffmpeg播放视频时会在系统媒体传输区域出现双重控制

## 新的行为是什么？

修复这个问题

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
