### PR TITLE
移除视频/文章卡片上的用户头像

### DIFF
--- a/src/Adapter/Adapter.Implementation/UserAdapter.cs
+++ b/src/Adapter/Adapter.Implementation/UserAdapter.cs
@@ -154,7 +154,9 @@ namespace Bili.Adapter
         public UserProfile ConvertToUserProfile(long userId, string userName, string avatar, AvatarSize avatarSize)
         {
             var size = int.Parse(avatarSize.ToString().Replace("Size", string.Empty));
-            var image = _imageAdapter.ConvertToImage(avatar, size, size);
+            var image = string.IsNullOrEmpty(avatar)
+                ? default
+                : _imageAdapter.ConvertToImage(avatar, size, size);
             var profile = new UserProfile(userId.ToString(), userName, image);
             return profile;
         }

--- a/src/Adapter/Adapter.Implementation/VideoAdapter.cs
+++ b/src/Adapter/Adapter.Implementation/VideoAdapter.cs
@@ -198,6 +198,7 @@ namespace Bili.Adapter
             var communityInfo = _communityAdapter.ConvertToVideoCommunityInformation(hotVideo);
             var highlight = hotVideo.SmallCoverV5.RcmdReasonStyle?.Text ?? string.Empty;
             highlight = _textToolkit.ConvertToTraditionalChineseIfNeeded(highlight);
+            var publisher = _userAdapter.ConvertToUserProfile(shareInfo.AuthorId, shareInfo.Author, string.Empty, Models.Enums.App.AvatarSize.Size48);
 
             var identifier = new VideoIdentifier(id, title, duration, cover);
 

--- a/src/App/Controls/Article/ArticleItem/ArticleItem.xaml
+++ b/src/App/Controls/Article/ArticleItem/ArticleItem.xaml
@@ -9,6 +9,14 @@
 
     <MenuFlyout x:Key="DefaultArticleItemContextFlyout">
         <MenuFlyoutItem
+            Command="{Binding Publisher.ShowDetailCommand}"
+            IsEnabled="{Binding Publisher.User, Converter={StaticResource ObjectToBoolConverter}}"
+            Text="{loc:Locale Name=EnterUserSpace}">
+            <MenuFlyoutItem.Icon>
+                <icons:RegularFluentIcon Symbol="Person16" />
+            </MenuFlyoutItem.Icon>
+        </MenuFlyoutItem>
+        <MenuFlyoutItem
             x:Name="OpenInBroswerItem"
             AutomationProperties.Name="{loc:Locale Name=OpenInBroswer}"
             Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.OpenInBroswerCommand}"
@@ -36,6 +44,7 @@
                             AutomationProperties.Name="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Data.Identifier.Title}"
                             Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.ReadCommand}"
                             ContextFlyout="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ContextFlyout, TargetNullValue={StaticResource DefaultArticleItemContextFlyout}}"
+                            DataContext="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel}"
                             IsEnableCheck="False">
                             <Grid>
                                 <Grid.RowDefinitions>
@@ -53,25 +62,6 @@
                                         VerticalAlignment="Center"
                                         ImageUrl="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Data.Identifier.Cover.Uri}"
                                         Stretch="UniformToFill" />
-                                </Grid>
-
-                                <Grid
-                                    Margin="0,0,12,-18"
-                                    HorizontalAlignment="Right"
-                                    VerticalAlignment="Bottom"
-                                    Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Data.Publisher, Converter={StaticResource ObjectToVisibilityConverter}}">
-                                    <Ellipse
-                                        Width="40"
-                                        Height="40"
-                                        Fill="{ThemeResource ControlOnImageFillColorDefaultBrush}" />
-                                    <controls:UserAvatar
-                                        x:Name="VerticalAvatar"
-                                        Width="36"
-                                        Height="36"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center"
-                                        Avatar="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Data.Publisher.User.Avatar.Uri}"
-                                        UserName="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Data.Publisher.User.Name}" />
                                 </Grid>
 
                                 <Grid
@@ -235,8 +225,9 @@
                                             Height="24"
                                             Margin="0,0,8,0"
                                             VerticalAlignment="Center"
-                                            Avatar="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Data.Publisher.User.Avatar.Uri}"
-                                            UserName="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Data.Publisher.User.Name}" />
+                                            Avatar="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Publisher.User.Avatar.Uri}"
+                                            Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Publisher.ShowDetailCommand}"
+                                            UserName="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Publisher.User.Name}" />
                                         <TextBlock
                                             Style="{StaticResource CaptionTextBlockStyle}"
                                             VerticalAlignment="Center"

--- a/src/App/Controls/Videos/VideoItem/VideoItem.xaml
+++ b/src/App/Controls/Videos/VideoItem/VideoItem.xaml
@@ -8,6 +8,14 @@
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls">
 
     <MenuFlyout x:Key="DefaultVideoItemContextFlyout">
+        <MenuFlyoutItem
+            Command="{Binding Publisher.ShowDetailCommand}"
+            IsEnabled="{Binding Publisher.User, Converter={StaticResource ObjectToBoolConverter}}"
+            Text="{loc:Locale Name=EnterUserSpace}">
+            <MenuFlyoutItem.Icon>
+                <icons:RegularFluentIcon Symbol="Person16" />
+            </MenuFlyoutItem.Icon>
+        </MenuFlyoutItem>
         <MenuFlyoutItem Command="{Binding AddToViewLaterCommand}" Text="{loc:Locale Name=AddToViewLater}">
             <MenuFlyoutItem.Icon>
                 <icons:RegularFluentIcon Symbol="Add16" />
@@ -86,26 +94,6 @@
                                             Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
                                             Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Data.Highlight}" />
                                     </Grid>
-                                </Grid>
-
-                                <Grid
-                                    Margin="0,0,12,-18"
-                                    HorizontalAlignment="Right"
-                                    VerticalAlignment="Bottom"
-                                    Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Data.Publisher, Converter={StaticResource ObjectToVisibilityConverter}}">
-                                    <Ellipse
-                                        Width="40"
-                                        Height="40"
-                                        Fill="{ThemeResource ControlOnImageFillColorDefaultBrush}" />
-                                    <controls:UserAvatar
-                                        x:Name="VerticalAvatar"
-                                        Width="36"
-                                        Height="36"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center"
-                                        Avatar="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Publisher.User.Avatar.Uri}"
-                                        Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Publisher.ShowDetailCommand}"
-                                        UserName="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.Publisher.User.Name}" />
                                 </Grid>
 
                                 <Grid

--- a/src/App/Resources/Strings/zh-Hans/Resources.resw
+++ b/src/App/Resources/Strings/zh-Hans/Resources.resw
@@ -517,6 +517,9 @@ UGC优先级：分P &gt; 播放列表 &gt; 合集视频 &gt; 关联视频 (如�
   <data name="EnterToEffect" xml:space="preserve">
     <value>按下回车以生效</value>
   </data>
+  <data name="EnterUserSpace" xml:space="preserve">
+    <value>进入用户空间</value>
+  </data>
   <data name="Episodes" xml:space="preserve">
     <value>分集</value>
   </data>

--- a/src/App/Resources/Strings/zh-Hant/Resources.resw
+++ b/src/App/Resources/Strings/zh-Hant/Resources.resw
@@ -518,6 +518,9 @@ UGC優先級：分P &gt; 播放列表 &gt; 合集影片 &gt; 關聯影片 (如�
   <data name="EnterToEffect" xml:space="preserve">
     <value>按下Enter以套用</value>
   </data>
+  <data name="EnterUserSpace" xml:space="preserve">
+    <value>進入用戶空間</value>
+  </data>
   <data name="Episodes" xml:space="preserve">
     <value>分集</value>
   </data>

--- a/src/Models/Models.Enums/App/LanguageNames.cs
+++ b/src/Models/Models.Enums/App/LanguageNames.cs
@@ -539,6 +539,7 @@ namespace Bili.Models.Enums
         PlayerTypeDescription,
         HDFirst,
         PreferQuality,
+        EnterUserSpace,
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
 }

--- a/src/ViewModels/ViewModels.Interfaces/Article/IArticleItemViewModel.cs
+++ b/src/ViewModels/ViewModels.Interfaces/Article/IArticleItemViewModel.cs
@@ -3,6 +3,7 @@
 using System.Reactive;
 using System.Threading.Tasks;
 using Bili.Models.Data.Article;
+using Bili.ViewModels.Interfaces.Account;
 using ReactiveUI;
 
 namespace Bili.ViewModels.Interfaces.Article
@@ -46,6 +47,11 @@ namespace Bili.ViewModels.Interfaces.Article
         /// 是否显示社区信息.
         /// </summary>
         bool IsShowCommunity { get; }
+
+        /// <summary>
+        /// 发布者.
+        /// </summary>
+        IUserItemViewModel Publisher { get; }
 
         /// <summary>
         /// 获取文章详情内容.

--- a/src/ViewModels/ViewModels.Uwp/Article/ArticleItemViewModel/ArticleItemViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Article/ArticleItemViewModel/ArticleItemViewModel.Properties.cs
@@ -6,6 +6,7 @@ using System.Reactive;
 using Bili.Lib.Interfaces;
 using Bili.Models.Data.Article;
 using Bili.Toolkit.Interfaces;
+using Bili.ViewModels.Interfaces.Account;
 using Bili.ViewModels.Interfaces.Article;
 using Bili.ViewModels.Interfaces.Core;
 using ReactiveUI;
@@ -42,6 +43,10 @@ namespace Bili.ViewModels.Uwp.Article
         /// <inheritdoc/>
         [Reactive]
         public ArticleInformation Data { get; set; }
+
+        /// <inheritdoc/>
+        [Reactive]
+        public IUserItemViewModel Publisher { get; set; }
 
         /// <inheritdoc/>
         [Reactive]

--- a/src/ViewModels/ViewModels.Uwp/Article/ArticleItemViewModel/ArticleItemViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Article/ArticleItemViewModel/ArticleItemViewModel.cs
@@ -5,10 +5,12 @@ using System.Threading.Tasks;
 using Bili.Lib.Interfaces;
 using Bili.Models.Data.Article;
 using Bili.Toolkit.Interfaces;
+using Bili.ViewModels.Interfaces.Account;
 using Bili.ViewModels.Interfaces.Article;
 using Bili.ViewModels.Interfaces.Core;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
+using Splat;
 using Windows.System;
 
 namespace Bili.ViewModels.Uwp.Article
@@ -98,6 +100,9 @@ namespace Bili.ViewModels.Uwp.Article
         private void InitializeData()
         {
             IsShowCommunity = Data.CommunityInformation != null;
+            var userVM = Locator.Current.GetService<IUserItemViewModel>();
+            userVM.SetProfile(Data.Publisher);
+            Publisher = userVM;
             if (IsShowCommunity)
             {
                 ViewCountText = _numberToolkit.GetCountText(Data.CommunityInformation.ViewCount);


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

在纵向布局时，移除叠加在卡片上的圆形用户头像。将进入用户空间的功能入口移至右键菜单。

移除这个头像可以明显提高滚动性能

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

用户头像贴在视频封面上，尽管布局美观，但对于性能影响较大

## 新的行为是什么？

移除头像，将进入用户空间的功能入口移至右键菜单。

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
