### PR TITLE
直播页与历史记录页支持自动刷新

### DIFF
--- a/src/App/Pages/Desktop/LiveFeedPage.xaml.cs
+++ b/src/App/Pages/Desktop/LiveFeedPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
 using Bili.App.Pages.Base;
+using Windows.UI.Xaml.Navigation;
 
 namespace Bili.App.Pages.Desktop
 {
@@ -21,5 +22,9 @@ namespace Bili.App.Pages.Desktop
         /// <inheritdoc/>
         protected override void OnPageUnloaded()
             => Bindings.StopTracking();
+
+        /// <inheritdoc/>
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+            => ViewModel.ResetStateCommand.Execute(null);
     }
 }

--- a/src/App/Pages/Desktop/Overlay/HistoryPage.xaml.cs
+++ b/src/App/Pages/Desktop/Overlay/HistoryPage.xaml.cs
@@ -8,6 +8,7 @@ using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Account;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 namespace Bili.App.Pages.Desktop.Overlay
 {
@@ -28,6 +29,10 @@ namespace Bili.App.Pages.Desktop.Overlay
         /// <inheritdoc/>
         protected override void OnPageUnloaded()
             => Bindings.StopTracking();
+
+        /// <inheritdoc/>
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+            => ViewModel.ResetStateCommand.Execute(null);
 
         private async void OnClearButtonClickAsync(object sender, RoutedEventArgs e)
         {

--- a/src/ViewModels/ViewModels.Interfaces/IInformationFlowViewModel.cs
+++ b/src/ViewModels/ViewModels.Interfaces/IInformationFlowViewModel.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 namespace Bili.ViewModels.Interfaces
 {
@@ -15,5 +16,10 @@ namespace Bili.ViewModels.Interfaces
         /// 视频集合.
         /// </summary>
         ObservableCollection<T> Items { get; }
+
+        /// <summary>
+        /// 重置状态的命令.
+        /// </summary>
+        IRelayCommand ResetStateCommand { get; }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Base/InformationFlowViewModelBase/InformationFlowViewModelBase.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Base/InformationFlowViewModelBase/InformationFlowViewModelBase.Properties.cs
@@ -38,6 +38,9 @@ namespace Bili.ViewModels.Uwp.Base
         public IAsyncRelayCommand IncrementalCommand { get; }
 
         /// <inheritdoc/>
+        public IRelayCommand ResetStateCommand { get; }
+
+        /// <inheritdoc/>
         public ObservableCollection<T> Items { get; }
     }
 }

--- a/src/ViewModels/ViewModels.Uwp/Base/InformationFlowViewModelBase/InformationFlowViewModelBase.cs
+++ b/src/ViewModels/ViewModels.Uwp/Base/InformationFlowViewModelBase/InformationFlowViewModelBase.cs
@@ -22,6 +22,7 @@ namespace Bili.ViewModels.Uwp.Base
             _dispatcher = dispatcher;
             Items = new ObservableCollection<T>();
 
+            ResetStateCommand = new RelayCommand(ResetState);
             InitializeCommand = new AsyncRelayCommand(InitializeAsync);
             ReloadCommand = new AsyncRelayCommand(ReloadAsync);
             IncrementalCommand = new AsyncRelayCommand(IncrementalAsync);
@@ -83,11 +84,16 @@ namespace Bili.ViewModels.Uwp.Base
             await ReloadAsync();
         }
 
-        private async Task ReloadAsync()
+        private void ResetState()
         {
             BeforeReload();
             TryClear(Items);
             ClearException();
+        }
+
+        private async Task ReloadAsync()
+        {
+            ResetState();
 
             var task = _dispatcher.RunAsync(
                 CoreDispatcherPriority.Normal,


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1457 

用户在进入直播页面和历史记录页时将会自动刷新以保持最新

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

直播页和历史记录页将保持数据知道用户手动刷新

## 新的行为是什么？

这两个页面每次进入时都会自动刷新

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
