### PR TITLE
修复部分PGC额外内容因标题重复导致解析失败的问题

### DIFF
--- a/src/Adapter/Adapter.Implementation/PgcAdapter.cs
+++ b/src/Adapter/Adapter.Implementation/PgcAdapter.cs
@@ -335,9 +335,17 @@ namespace Bili.Adapter
                     extras = new Dictionary<string, IEnumerable<EpisodeInformation>>();
                     foreach (var section in sectionModules)
                     {
-                        if (section.Data?.Episodes?.Any() ?? false)
+                        var title = section.Title;
+                        if (extras.ContainsKey(title))
                         {
-                            extras.Add(section.Title, section.Data.Episodes.Select(p => ConvertToEpisodeInformation(p)));
+                            var count = extras.Keys.Count(p => p.StartsWith(title)) + 1;
+                            title = title + count;
+                        }
+
+                        if (
+                            section.Data?.Episodes?.Any() ?? false)
+                        {
+                            extras.Add(title, section.Data.Episodes.Select(p => ConvertToEpisodeInformation(p)));
                         }
                     }
                 }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1495 

修复因区块标题重复导致运行时错误的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

在一些特别的PGC内容（比如求职高手第二季）中，额外内容的区块标题会重复，因字典不能添加同名元素，导致运行失败

## 新的行为是什么？

在添加区块内容时检查是否同名，如果同名，则在标题后追加序号

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
