### PR TITLE
修复在进入直播时没有应用默认播放模式的问题

### DIFF
--- a/src/ViewModels/ViewModels.Uwp/Live/LivePlayerPageViewModel/LivePlayerPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Live/LivePlayerPageViewModel/LivePlayerPageViewModel.cs
@@ -80,8 +80,15 @@ namespace Bili.ViewModels.Uwp.Live
         {
             _presetRoomId = snapshot.VideoId;
             var defaultPlayMode = _settingsToolkit.ReadLocalSetting(SettingNames.DefaultPlayerDisplayMode, PlayerDisplayMode.Default);
-            MediaPlayerViewModel.DisplayMode = snapshot.DisplayMode ?? defaultPlayMode;
-            ReloadCommand.ExecuteAsync(null);
+            ReloadCommand.ExecuteAsync(null)
+                .ContinueWith(async _ =>
+                {
+                    await _dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                    {
+                        MediaPlayerViewModel.DisplayMode = snapshot.DisplayMode ?? defaultPlayMode;
+                    });
+                });
+
             _liveProvider.MessageReceived += OnMessageReceivedAsync;
         }
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1474 

修复在进入直播时没有应用默认播放模式的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

进入直播间时，默认的播放模式并没有起作用（起了，但没完全起，比如标题栏没了）

## 新的行为是什么？

让直播间在加载完成后再尝试进入默认播放模式，避免线程冲突

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
