### PR TITLE
修复因DI使用不当造成的多实例创建的问题

### DIFF
--- a/src/Adapter/Adapter.UnitTests/Adapter.UnitTests.csproj
+++ b/src/Adapter/Adapter.UnitTests/Adapter.UnitTests.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="FluentAssertions" Version="6.7.0" />
+      <PackageReference Update="FluentAssertions" Version="6.8.0" />
       <PackageReference Update="FluentAssertions.Analyzers" Version="0.17.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -1309,19 +1309,19 @@
       <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI">
-      <Version>7.1.2</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Animations">
-      <Version>7.1.2</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Behaviors">
-      <Version>7.1.2</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
-      <Version>7.1.2</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Media">
-      <Version>7.1.2</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.8.2-prerelease.220830001</Version>

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -76,7 +76,6 @@ namespace Bili.App
 
                 // Place the frame in the current Window
                 Window.Current.Content = rootFrame;
-                DIFactory.RegisterAppRequiredConstants();
             }
 
             if (e is LaunchActivatedEventArgs && (e as LaunchActivatedEventArgs).PrelaunchActivated == false)

--- a/src/App/Controls/App/XboxNavigationView.xaml.cs
+++ b/src/App/Controls/App/XboxNavigationView.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using System.Linq;
 using Bili.App.Controls.Base;
 using Bili.App.Pages.Xbox;

--- a/src/App/Controls/Community/CommentMainView/CommentMainView.cs
+++ b/src/App/Controls/Community/CommentMainView/CommentMainView.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.Models.App.Other;
 using Bili.ViewModels.Interfaces.Community;
 using Windows.UI.Xaml.Controls;

--- a/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Handlers.cs
+++ b/src/App/Controls/Player/BiliMediaPlayer/BiliMediaPlayer.Handlers.cs
@@ -75,7 +75,7 @@ namespace Bili.App.Controls.Player
 
         private async void OnMediaPlayerChangedAsync(object sender, object e)
         {
-            if(e is MediaPlayer mp)
+            if (e is MediaPlayer mp)
             {
                 _mediaPlayerElement.SetMediaPlayer(mp);
 

--- a/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.Handlers.cs
+++ b/src/App/Controls/Player/BiliMediaTransportControls/BiliMediaTransportControls.Handlers.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using System.ComponentModel;
 using Bili.Models.Data.Player;
 using Windows.UI.Xaml;

--- a/src/App/Controls/Player/InteractionChoicePanel.xaml.cs
+++ b/src/App/Controls/Player/InteractionChoicePanel.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.Models.Data.Player;
 using Bili.ViewModels.Interfaces.Core;
 using Windows.UI.Xaml;

--- a/src/App/Controls/Player/PlayerControls/PlayRateButton.xaml.cs
+++ b/src/App/Controls/Player/PlayerControls/PlayRateButton.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Windows.UI.Xaml;
 
 namespace Bili.App.Controls.Player.PlayerControls

--- a/src/App/Controls/Player/SubtitleConfigPanel.xaml.cs
+++ b/src/App/Controls/Player/SubtitleConfigPanel.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.Models.Data.Player;
 using Bili.ViewModels.Interfaces.Common;
 using Windows.UI.Xaml;

--- a/src/App/Pages/Desktop/ArticlePartitionPage.xaml.cs
+++ b/src/App/Pages/Desktop/ArticlePartitionPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.Models.Data.Community;
 using Bili.Models.Enums;
 using Bili.ViewModels.Interfaces.Article;

--- a/src/App/Pages/Desktop/DynamicPage.xaml.cs
+++ b/src/App/Pages/Desktop/DynamicPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.App.Pages.Base;
 using Bili.Models.App.Other;
 

--- a/src/App/Pages/Desktop/Overlay/FavoritePage.xaml.cs
+++ b/src/App/Pages/Desktop/Overlay/FavoritePage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using System.Linq;
 using Bili.App.Pages.Base;
 using Bili.Models.App.Other;

--- a/src/App/Pages/Desktop/Overlay/LivePartitionDetailPage.xaml.cs
+++ b/src/App/Pages/Desktop/Overlay/LivePartitionDetailPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.App.Pages.Base;
 using Bili.Models.Data.Community;
 using Bili.Models.Data.Live;

--- a/src/App/Pages/Desktop/Overlay/LivePartitionPage.xaml.cs
+++ b/src/App/Pages/Desktop/Overlay/LivePartitionPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.App.Pages.Base;
 using Bili.Models.Data.Community;
 

--- a/src/App/Pages/Desktop/Overlay/LivePlayerPage.xaml.cs
+++ b/src/App/Pages/Desktop/Overlay/LivePlayerPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.App.Pages.Base;
 using Bili.Models.Data.Local;
 using Windows.UI.Xaml.Navigation;

--- a/src/App/Pages/Desktop/Overlay/MessagePage.xaml.cs
+++ b/src/App/Pages/Desktop/Overlay/MessagePage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.ViewModels.Interfaces.Community;
 
 namespace Bili.App.Pages.Desktop.Overlay

--- a/src/App/Pages/Desktop/Overlay/MyFollowsPage.xaml.cs
+++ b/src/App/Pages/Desktop/Overlay/MyFollowsPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.Models.Data.Community;
 using Bili.ViewModels.Interfaces.Account;
 

--- a/src/App/Pages/Desktop/Overlay/PgcIndexPage.xaml.cs
+++ b/src/App/Pages/Desktop/Overlay/PgcIndexPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using System.Linq;
 using Bili.Models.Data.Appearance;
 using Bili.Models.Enums;

--- a/src/App/Pages/Desktop/Overlay/SearchPage.xaml.cs
+++ b/src/App/Pages/Desktop/Overlay/SearchPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.App.Pages.Base;
 using Bili.Models.Data.Appearance;
 using Bili.ViewModels.Interfaces.Search;

--- a/src/App/Pages/Desktop/Overlay/UserSpacePage.xaml.cs
+++ b/src/App/Pages/Desktop/Overlay/UserSpacePage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.App.Pages.Base;
 using Bili.Models.Data.User;
 using Windows.UI.Xaml.Navigation;

--- a/src/App/Pages/Desktop/Overlay/VideoPartitionDetailPage.xaml.cs
+++ b/src/App/Pages/Desktop/Overlay/VideoPartitionDetailPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.App.Pages.Base;
 using Bili.Models.Data.Community;
 using Bili.Models.Enums;

--- a/src/App/Pages/Desktop/RankPage.xaml.cs
+++ b/src/App/Pages/Desktop/RankPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.App.Pages.Base;
 using Bili.Models.Data.Community;
 

--- a/src/App/Pages/Xbox/Overlay/FavoritePage.xaml.cs
+++ b/src/App/Pages/Xbox/Overlay/FavoritePage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using System.Linq;
 using Bili.App.Pages.Base;
 using Bili.Models.App.Other;

--- a/src/App/Pages/Xbox/Overlay/LivePartitionDetailPage.xaml.cs
+++ b/src/App/Pages/Xbox/Overlay/LivePartitionDetailPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.App.Pages.Base;
 using Bili.Models.Data.Community;
 using Bili.Models.Data.Live;

--- a/src/App/Pages/Xbox/Overlay/LivePartitionPage.xaml.cs
+++ b/src/App/Pages/Xbox/Overlay/LivePartitionPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.App.Pages.Base;
 using Bili.Models.Data.Community;
 

--- a/src/App/Pages/Xbox/Overlay/SearchPage.xaml.cs
+++ b/src/App/Pages/Xbox/Overlay/SearchPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.App.Pages.Base;
 using Bili.Models.Data.Appearance;
 using Bili.ViewModels.Interfaces.Search;

--- a/src/App/Pages/Xbox/Overlay/UserSpacePage.xaml.cs
+++ b/src/App/Pages/Xbox/Overlay/UserSpacePage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.App.Pages.Base;
 using Bili.Models.Data.User;
 using Windows.UI.Xaml.Navigation;

--- a/src/App/Pages/Xbox/Overlay/VideoFavoriteDetailPage.xaml.cs
+++ b/src/App/Pages/Xbox/Overlay/VideoFavoriteDetailPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.App.Pages.Base;
 using Bili.Models.Data.Video;
 using Windows.UI.Xaml.Navigation;

--- a/src/App/Pages/Xbox/Overlay/VideoPartitionDetailPage.xaml.cs
+++ b/src/App/Pages/Xbox/Overlay/VideoPartitionDetailPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.App.Pages.Base;
 using Bili.Models.Data.Community;
 using Bili.Models.Enums;

--- a/src/App/Pages/Xbox/PreSearchPage.xaml.cs
+++ b/src/App/Pages/Xbox/PreSearchPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.Models.Data.Search;
 using Bili.ViewModels.Interfaces.Search;
 

--- a/src/App/Pages/Xbox/RankPage.xaml.cs
+++ b/src/App/Pages/Xbox/RankPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
-using System;
 using Bili.App.Pages.Base;
 using Bili.Models.Data.Community;
 

--- a/src/App/Resources/Converter/PreferQualityConverter.cs
+++ b/src/App/Resources/Converter/PreferQualityConverter.cs
@@ -15,7 +15,7 @@ namespace Bili.App.Resources.Converter
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {
-            if(value is PreferQuality quality)
+            if (value is PreferQuality quality)
             {
                 var resToolkit = Locator.Instance.GetService<IResourceToolkit>();
                 return quality switch

--- a/src/Lib/DI.App/DI.App.csproj
+++ b/src/Lib/DI.App/DI.App.csproj
@@ -129,7 +129,7 @@
       <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="NLog">
-      <Version>5.0.4</Version>
+      <Version>5.0.5</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Lib/DI.App/DIFactory.cs
+++ b/src/Lib/DI.App/DIFactory.cs
@@ -32,7 +32,6 @@ using Bili.ViewModels.Uwp.Search;
 using Bili.ViewModels.Uwp.Toolbox;
 using Bili.ViewModels.Uwp.Video;
 using Windows.Storage;
-using Windows.UI.Xaml;
 
 namespace Bili.DI.App
 {
@@ -52,7 +51,7 @@ namespace Bili.DI.App
             NLog.GlobalDiagnosticsContext.Set("LogPath", fullPath);
             var logger = NLog.LogManager.GetLogger("Richasy.Bili");
             Container.Locator.Instance
-                .RegisterSingleton<NLog.ILogger>(logger)
+                .RegisterConstant(logger)
                 .RegisterSingleton<IResourceToolkit, ResourceToolkit>()
                 .RegisterSingleton<INumberToolkit, NumberToolkit>()
                 .RegisterSingleton<ISettingsToolkit, SettingsToolkit>()
@@ -177,15 +176,6 @@ namespace Bili.DI.App
                 .RegisterSingleton<IVideoPlayerPageViewModel, VideoPlayerPageViewModel>()
                 .RegisterSingleton<IPgcPlayerPageViewModel, PgcPlayerPageViewModel>()
                 .RegisterSingleton<ILivePlayerPageViewModel, LivePlayerPageViewModel>()
-                .Build();
-        }
-
-        /// <summary>
-        /// 注册应用所需的常量.
-        /// </summary>
-        public static void RegisterAppRequiredConstants()
-        {
-            Container.Locator.Instance.RegisterSingleton(Window.Current.CoreWindow.Dispatcher)
                 .Build();
         }
     }

--- a/src/Lib/DI.Container/DI.Container.csproj
+++ b/src/Lib/DI.Container/DI.Container.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Autofac" Version="6.4.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Lib/Lib.Implementation/Lib.Implementation.csproj
+++ b/src/Lib/Lib.Implementation/Lib.Implementation.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.21.6" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.9" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="Websocket.Client" Version="4.4.43" />
   </ItemGroup>

--- a/src/Models/Models.gRPC/Models.gRPC.csproj
+++ b/src/Models/Models.gRPC/Models.gRPC.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.21.6" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.48.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.48.1">
+    <PackageReference Include="Google.Protobuf" Version="3.21.9" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.50.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Tasks/Tasks.csproj
+++ b/src/Tasks/Tasks.csproj
@@ -126,13 +126,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf">
-      <Version>3.21.6</Version>
+      <Version>3.21.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
-      <Version>7.1.2</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/ViewModels/ViewModels.Interfaces/Pgc/IPgcPlaylistViewModel.cs
+++ b/src/ViewModels/ViewModels.Interfaces/Pgc/IPgcPlaylistViewModel.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
 using System.Collections.ObjectModel;
-using System.Windows.Input;
 using Bili.Models.Data.Pgc;
 using CommunityToolkit.Mvvm.Input;
 

--- a/src/ViewModels/ViewModels.Uwp/Account/AccountViewModel/AccountViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Account/AccountViewModel/AccountViewModel.cs
@@ -12,7 +12,7 @@ using Bili.Models.Enums;
 using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Account;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
+using Windows.UI.Xaml;
 
 namespace Bili.ViewModels.Uwp.Account
 {
@@ -29,15 +29,14 @@ namespace Bili.ViewModels.Uwp.Account
             INumberToolkit numberToolkit,
             IFileToolkit fileToolkit,
             IAuthorizeProvider authorizeProvider,
-            IAccountProvider accountProvider,
-            CoreDispatcher dispatcher)
+            IAccountProvider accountProvider)
         {
             _resourceToolkit = resourceToolkit;
             _numberToolkit = numberToolkit;
             _fileToolkit = fileToolkit;
             _authorizeProvider = authorizeProvider;
             _accountProvider = accountProvider;
-            _dispatcher = dispatcher;
+            _dispatcher = Window.Current.CoreWindow.Dispatcher;
 
             TrySignInCommand = new AsyncRelayCommand<bool>(TrySignInAsync);
             SignOutCommand = new AsyncRelayCommand(SignOutAsync);

--- a/src/ViewModels/ViewModels.Uwp/Account/HistoryPageViewModel/HistoryPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Account/HistoryPageViewModel/HistoryPageViewModel.cs
@@ -8,7 +8,6 @@ using Bili.ViewModels.Interfaces.Account;
 using Bili.ViewModels.Interfaces.Video;
 using Bili.ViewModels.Uwp.Base;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Account
 {
@@ -22,9 +21,7 @@ namespace Bili.ViewModels.Uwp.Account
         /// </summary>
         public HistoryPageViewModel(
             IAccountProvider accountProvider,
-            IResourceToolkit resourceToolkit,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            IResourceToolkit resourceToolkit)
         {
             _accountProvider = accountProvider;
             _resourceToolkit = resourceToolkit;

--- a/src/ViewModels/ViewModels.Uwp/Account/MyFollowsPageViewModel/MyFollowsPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Account/MyFollowsPageViewModel/MyFollowsPageViewModel.cs
@@ -12,7 +12,6 @@ using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Account;
 using Bili.ViewModels.Uwp.Base;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Account
 {
@@ -27,9 +26,7 @@ namespace Bili.ViewModels.Uwp.Account
         public MyFollowsPageViewModel(
             IAccountProvider accountProvider,
             IResourceToolkit resourceToolkit,
-            IAccountViewModel accountViewModel,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            IAccountViewModel accountViewModel)
         {
             _accountProvider = accountProvider;
             _resourceToolkit = resourceToolkit;

--- a/src/ViewModels/ViewModels.Uwp/Account/UserItemViewModel/UserItemViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Account/UserItemViewModel/UserItemViewModel.cs
@@ -12,6 +12,7 @@ using Bili.ViewModels.Interfaces.Account;
 using Bili.ViewModels.Interfaces.Core;
 using CommunityToolkit.Mvvm.Input;
 using Windows.UI.Core;
+using Windows.UI.Xaml;
 
 namespace Bili.ViewModels.Uwp.Account
 {
@@ -29,8 +30,7 @@ namespace Bili.ViewModels.Uwp.Account
             IResourceToolkit resourceToolkit,
             ICallerViewModel callerViewModel,
             INavigationViewModel navigationViewModel,
-            IAccountViewModel accountViewModel,
-            CoreDispatcher dispatcher)
+            IAccountViewModel accountViewModel)
         {
             _numberToolkit = numberToolkit;
             _accountProvider = accountProvider;
@@ -38,7 +38,7 @@ namespace Bili.ViewModels.Uwp.Account
             _callerViewModel = callerViewModel;
             _navigationViewModel = navigationViewModel;
             _accountViewModel = accountViewModel;
-            _dispatcher = dispatcher;
+            _dispatcher = Window.Current.CoreWindow.Dispatcher;
 
             ToggleRelationCommand = new AsyncRelayCommand(ToggleRelationAsync);
             InitializeRelationCommand = new AsyncRelayCommand(InitializeRelationAsync);

--- a/src/ViewModels/ViewModels.Uwp/Account/UserSpaceViewModel/UserSpaceViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Account/UserSpaceViewModel/UserSpaceViewModel.cs
@@ -13,7 +13,6 @@ using Bili.ViewModels.Interfaces.Core;
 using Bili.ViewModels.Interfaces.Video;
 using Bili.ViewModels.Uwp.Base;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Account
 {
@@ -30,9 +29,7 @@ namespace Bili.ViewModels.Uwp.Account
             IResourceToolkit resourceToolkit,
             INavigationViewModel navigationViewModel,
             IAccountViewModel accountViewModel,
-            ICallerViewModel callerViewModel,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            ICallerViewModel callerViewModel)
         {
             _accountProvider = accountProvider;
             _resourceToolkit = resourceToolkit;

--- a/src/ViewModels/ViewModels.Uwp/Account/ViewLaterPageViewModel/ViewLaterPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Account/ViewLaterPageViewModel/ViewLaterPageViewModel.cs
@@ -11,7 +11,6 @@ using Bili.ViewModels.Interfaces.Core;
 using Bili.ViewModels.Interfaces.Video;
 using Bili.ViewModels.Uwp.Base;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Account
 {
@@ -26,9 +25,7 @@ namespace Bili.ViewModels.Uwp.Account
         public ViewLaterPageViewModel(
             IAccountProvider accountProvider,
             IResourceToolkit resourceToolkit,
-            INavigationViewModel navigationViewModel,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            INavigationViewModel navigationViewModel)
         {
             _accountProvider = accountProvider;
             _resourceToolkit = resourceToolkit;

--- a/src/ViewModels/ViewModels.Uwp/Article/ArticleFavoriteModuleViewModel/ArticleFavoriteModuleViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Article/ArticleFavoriteModuleViewModel/ArticleFavoriteModuleViewModel.cs
@@ -7,7 +7,6 @@ using Bili.Models.Enums;
 using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Article;
 using Bili.ViewModels.Uwp.Base;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Article
 {
@@ -21,9 +20,7 @@ namespace Bili.ViewModels.Uwp.Article
         /// </summary>
         public ArticleFavoriteModuleViewModel(
             IFavoriteProvider favoriteProvider,
-            IResourceToolkit resourceToolkit,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            IResourceToolkit resourceToolkit)
         {
             _favoriteProvider = favoriteProvider;
             _resourceToolkit = resourceToolkit;

--- a/src/ViewModels/ViewModels.Uwp/Article/ArticlePartitionPageViewModel/ArticlePartitionPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Article/ArticlePartitionPageViewModel/ArticlePartitionPageViewModel.cs
@@ -14,7 +14,6 @@ using Bili.ViewModels.Interfaces.Article;
 using Bili.ViewModels.Interfaces.Common;
 using Bili.ViewModels.Uwp.Base;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Article
 {
@@ -31,9 +30,7 @@ namespace Bili.ViewModels.Uwp.Article
         /// <param name="coreDispatcher">UI 调度器.</param>
         public ArticlePartitionPageViewModel(
             IResourceToolkit resourceToolkit,
-            IArticleProvider articleProvider,
-            CoreDispatcher coreDispatcher)
-            : base(coreDispatcher)
+            IArticleProvider articleProvider)
         {
             _resourceToolkit = resourceToolkit;
             _articleProvider = articleProvider;

--- a/src/ViewModels/ViewModels.Uwp/Base/DynamicModuleViewModelBase/DynamicModuleViewModelBase.cs
+++ b/src/ViewModels/ViewModels.Uwp/Base/DynamicModuleViewModelBase/DynamicModuleViewModelBase.cs
@@ -7,7 +7,6 @@ using Bili.Lib.Interfaces;
 using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Community;
 using Bili.ViewModels.Uwp.Community;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Base
 {
@@ -24,9 +23,7 @@ namespace Bili.ViewModels.Uwp.Base
             IResourceToolkit resourceToolkit,
             ISettingsToolkit settingsToolkit,
             IAuthorizeProvider authorizeProvider,
-            bool isOnlyVideo,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            bool isOnlyVideo)
         {
             _communityProvider = communityProvider;
             _resourceToolkit = resourceToolkit;

--- a/src/ViewModels/ViewModels.Uwp/Base/InformationFlowViewModelBase/InformationFlowViewModelBase.cs
+++ b/src/ViewModels/ViewModels.Uwp/Base/InformationFlowViewModelBase/InformationFlowViewModelBase.cs
@@ -7,6 +7,7 @@ using Bili.Models.App.Other;
 using Bili.ViewModels.Interfaces;
 using CommunityToolkit.Mvvm.Input;
 using Windows.UI.Core;
+using Windows.UI.Xaml;
 
 namespace Bili.ViewModels.Uwp.Base
 {
@@ -17,9 +18,9 @@ namespace Bili.ViewModels.Uwp.Base
     public abstract partial class InformationFlowViewModelBase<T> : ViewModelBase, IInformationFlowViewModel<T>
         where T : class
     {
-        internal InformationFlowViewModelBase(CoreDispatcher dispatcher)
+        internal InformationFlowViewModelBase()
         {
-            _dispatcher = dispatcher;
+            _dispatcher = Window.Current.CoreWindow.Dispatcher;
             Items = new ObservableCollection<T>();
 
             ResetStateCommand = new RelayCommand(ResetState);

--- a/src/ViewModels/ViewModels.Uwp/Base/PgcFavoriteModuleViewModelBase/PgcFavoriteModuleViewModelBase.cs
+++ b/src/ViewModels/ViewModels.Uwp/Base/PgcFavoriteModuleViewModelBase/PgcFavoriteModuleViewModelBase.cs
@@ -9,7 +9,6 @@ using Bili.Models.Enums.App;
 using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Pgc;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Base
 {
@@ -24,9 +23,7 @@ namespace Bili.ViewModels.Uwp.Base
         internal PgcFavoriteModuleViewModelBase(
             FavoriteType type,
             IFavoriteProvider favoriteProvider,
-            IResourceToolkit resourceToolkit,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            IResourceToolkit resourceToolkit)
         {
             _type = type;
             _favoriteProvider = favoriteProvider;

--- a/src/ViewModels/ViewModels.Uwp/Base/PgcPageViewModelBase/PgcPageViewModelBase.cs
+++ b/src/ViewModels/ViewModels.Uwp/Base/PgcPageViewModelBase/PgcPageViewModelBase.cs
@@ -12,7 +12,6 @@ using Bili.ViewModels.Interfaces.Common;
 using Bili.ViewModels.Interfaces.Core;
 using Bili.ViewModels.Interfaces.Pgc;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Base
 {
@@ -32,10 +31,8 @@ namespace Bili.ViewModels.Uwp.Base
         public PgcPageViewModelBase(
             IPgcProvider pgcProvider,
             IResourceToolkit resourceToolkit,
-            CoreDispatcher dispatcher,
             INavigationViewModel navigationViewModel,
             PgcType type)
-            : base(dispatcher)
         {
             _type = type;
             _pgcProvider = pgcProvider;

--- a/src/ViewModels/ViewModels.Uwp/Base/RelationPageViewModelBase/RelationPageViewModelBase.cs
+++ b/src/ViewModels/ViewModels.Uwp/Base/RelationPageViewModelBase/RelationPageViewModelBase.cs
@@ -7,7 +7,6 @@ using Bili.Models.Data.User;
 using Bili.Models.Enums.Bili;
 using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Account;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Base
 {
@@ -22,9 +21,7 @@ namespace Bili.ViewModels.Uwp.Base
         internal RelationPageViewModelBase(
             IAccountProvider accountProvider,
             IResourceToolkit resourceToolkit,
-            RelationType type,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            RelationType type)
         {
             _accountProvider = accountProvider;
             _resourceToolkit = resourceToolkit;

--- a/src/ViewModels/ViewModels.Uwp/Community/CommentDetailModuleViewModel/CommentDetailModuleViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Community/CommentDetailModuleViewModel/CommentDetailModuleViewModel.cs
@@ -11,7 +11,6 @@ using Bili.ViewModels.Interfaces.Community;
 using Bili.ViewModels.Interfaces.Core;
 using Bili.ViewModels.Uwp.Base;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Community
 {
@@ -26,9 +25,7 @@ namespace Bili.ViewModels.Uwp.Community
         public CommentDetailModuleViewModel(
             ICommunityProvider communityProvider,
             IResourceToolkit resourceToolkit,
-            ICallerViewModel callerViewModel,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            ICallerViewModel callerViewModel)
         {
             _communityProvider = communityProvider;
             _resourceToolkit = resourceToolkit;

--- a/src/ViewModels/ViewModels.Uwp/Community/CommentMainModuleViewModel/CommentMainModuleViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Community/CommentMainModuleViewModel/CommentMainModuleViewModel.cs
@@ -13,7 +13,6 @@ using Bili.ViewModels.Interfaces.Community;
 using Bili.ViewModels.Interfaces.Core;
 using Bili.ViewModels.Uwp.Base;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Community
 {
@@ -28,9 +27,7 @@ namespace Bili.ViewModels.Uwp.Community
         public CommentMainModuleViewModel(
             ICommunityProvider communityProvider,
             IResourceToolkit resourceToolkit,
-            ICallerViewModel callerViewModel,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            ICallerViewModel callerViewModel)
         {
             _communityProvider = communityProvider;
             _resourceToolkit = resourceToolkit;

--- a/src/ViewModels/ViewModels.Uwp/Community/DynamicAllModuleViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Community/DynamicAllModuleViewModel.cs
@@ -4,7 +4,6 @@ using Bili.Lib.Interfaces;
 using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Community;
 using Bili.ViewModels.Uwp.Base;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Community
 {
@@ -20,9 +19,8 @@ namespace Bili.ViewModels.Uwp.Community
             ICommunityProvider communityProvider,
             IResourceToolkit resourceToolkit,
             ISettingsToolkit settingsToolkit,
-            IAuthorizeProvider authorizeProvider,
-            CoreDispatcher dispatcher)
-            : base(communityProvider, resourceToolkit, settingsToolkit, authorizeProvider, false, dispatcher)
+            IAuthorizeProvider authorizeProvider)
+            : base(communityProvider, resourceToolkit, settingsToolkit, authorizeProvider, false)
         {
         }
     }

--- a/src/ViewModels/ViewModels.Uwp/Community/DynamicVideoModuleViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Community/DynamicVideoModuleViewModel.cs
@@ -4,7 +4,6 @@ using Bili.Lib.Interfaces;
 using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Community;
 using Bili.ViewModels.Uwp.Base;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Community
 {
@@ -20,9 +19,8 @@ namespace Bili.ViewModels.Uwp.Community
             ICommunityProvider communityProvider,
             IResourceToolkit resourceToolkit,
             ISettingsToolkit settingsToolkit,
-            IAuthorizeProvider authorizeProvider,
-            CoreDispatcher dispatcher)
-            : base(communityProvider, resourceToolkit, settingsToolkit, authorizeProvider, true, dispatcher)
+            IAuthorizeProvider authorizeProvider)
+            : base(communityProvider, resourceToolkit, settingsToolkit, authorizeProvider, true)
         {
         }
     }

--- a/src/ViewModels/ViewModels.Uwp/Community/FansPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Community/FansPageViewModel.cs
@@ -4,7 +4,6 @@ using Bili.Lib.Interfaces;
 using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Community;
 using Bili.ViewModels.Uwp.Base;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Community
 {
@@ -18,9 +17,8 @@ namespace Bili.ViewModels.Uwp.Community
         /// </summary>
         public FansPageViewModel(
             IAccountProvider accountProvider,
-            IResourceToolkit resourceToolkit,
-            CoreDispatcher dispatcher)
-            : base(accountProvider, resourceToolkit, Models.Enums.Bili.RelationType.Fans, dispatcher)
+            IResourceToolkit resourceToolkit)
+            : base(accountProvider, resourceToolkit, Models.Enums.Bili.RelationType.Fans)
         {
         }
     }

--- a/src/ViewModels/ViewModels.Uwp/Community/FollowsPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Community/FollowsPageViewModel.cs
@@ -4,7 +4,6 @@ using Bili.Lib.Interfaces;
 using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Community;
 using Bili.ViewModels.Uwp.Base;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Community
 {
@@ -18,9 +17,8 @@ namespace Bili.ViewModels.Uwp.Community
         /// </summary>
         public FollowsPageViewModel(
             IAccountProvider accountProvider,
-            IResourceToolkit resourceToolkit,
-            CoreDispatcher dispatcher)
-            : base(accountProvider, resourceToolkit, Models.Enums.Bili.RelationType.Follows, dispatcher)
+            IResourceToolkit resourceToolkit)
+            : base(accountProvider, resourceToolkit, Models.Enums.Bili.RelationType.Follows)
         {
         }
     }

--- a/src/ViewModels/ViewModels.Uwp/Community/MessagePageViewModel/MessagePageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Community/MessagePageViewModel/MessagePageViewModel.cs
@@ -15,7 +15,6 @@ using Bili.ViewModels.Interfaces.Account;
 using Bili.ViewModels.Interfaces.Community;
 using Bili.ViewModels.Uwp.Base;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Community
 {
@@ -30,9 +29,7 @@ namespace Bili.ViewModels.Uwp.Community
         public MessagePageViewModel(
             IAccountProvider accountProvider,
             IResourceToolkit resourceToolkit,
-            IAccountViewModel accountViewModel,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            IAccountViewModel accountViewModel)
         {
             _accountProvider = accountProvider;
             _resourceToolkit = resourceToolkit;

--- a/src/ViewModels/ViewModels.Uwp/Core/AppViewModel/AppViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/AppViewModel/AppViewModel.cs
@@ -9,7 +9,6 @@ using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Core;
 using CommunityToolkit.Mvvm.Input;
 using Windows.Globalization;
-using Windows.UI.Core;
 using Windows.UI.Xaml;
 
 namespace Bili.ViewModels.Uwp.Core
@@ -28,8 +27,7 @@ namespace Bili.ViewModels.Uwp.Core
             IAppToolkit appToolkit,
             IUpdateProvider updateProvider,
             ICallerViewModel callerViewModel,
-            INavigationViewModel navigationViewModel,
-            CoreDispatcher dispatcher)
+            INavigationViewModel navigationViewModel)
         {
             _callerViewModel = callerViewModel;
             _navigationViewModel = navigationViewModel;
@@ -38,7 +36,7 @@ namespace Bili.ViewModels.Uwp.Core
             _appToolkit = appToolkit;
             _updateProvider = updateProvider;
             _networkHelper = Microsoft.Toolkit.Uwp.Connectivity.NetworkHelper.Instance;
-            _dispatcher = dispatcher;
+            _dispatcher = Window.Current.CoreWindow.Dispatcher;
 
             IsXbox = Windows.System.Profile.AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Xbox";
             IsNavigatePaneOpen = true;

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Methods.cs
@@ -258,13 +258,6 @@ namespace Bili.ViewModels.Uwp.Core
 
         private async void OnPlayerPositionChangedAsync(MediaPlaybackSession sender, object args)
         {
-            if (_shouldPreventSkip && Position != TimeSpan.Zero)
-            {
-                _shouldPreventSkip = false;
-                SeekTo(TimeSpan.Zero);
-                return;
-            }
-
             await _dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
             {
                 if (_videoCurrentSession == null)

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.Properties.cs
@@ -41,7 +41,6 @@ namespace Bili.ViewModels.Uwp.Core
         private MediaPlaybackSession _videoCurrentSession;
         private int _liveRetryCount;
         private int _videoRetryCount;
-        private bool _shouldPreventSkip;
 
         /// <inheritdoc/>
         public event EventHandler MediaOpened;

--- a/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/FFmpegPlayerViewModel/FFmpegPlayerViewModel.cs
@@ -9,7 +9,7 @@ using Bili.ViewModels.Interfaces.Core;
 using CommunityToolkit.Mvvm.Input;
 using FFmpegInteropX;
 using Microsoft.Graphics.Canvas;
-using Windows.UI.Core;
+using Windows.UI.Xaml;
 
 namespace Bili.ViewModels.Uwp.Core
 {
@@ -23,12 +23,11 @@ namespace Bili.ViewModels.Uwp.Core
         /// </summary>
         public FFmpegPlayerViewModel(
             IResourceToolkit resourceToolkit,
-            ISettingsToolkit settingsToolkit,
-            CoreDispatcher dispatcher)
+            ISettingsToolkit settingsToolkit)
         {
             _resourceToolkit = resourceToolkit;
             _settingsToolkit = settingsToolkit;
-            _dispatcher = dispatcher;
+            _dispatcher = Window.Current.CoreWindow.Dispatcher;
 
             _liveConfig = new MediaSourceConfig();
             _liveConfig.FFmpegOptions.Add("rtsp_transport", "tcp");
@@ -45,7 +44,6 @@ namespace Bili.ViewModels.Uwp.Core
             _video = video;
             _audio = audio;
             _videoRetryCount = 0;
-            _shouldPreventSkip = true;
 
             await LoadDashVideoSourceAsync();
         }

--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.cs
@@ -20,6 +20,7 @@ using Windows.Media;
 using Windows.System.Display;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
+using Windows.UI.Xaml;
 
 namespace Bili.ViewModels.Uwp.Core
 {
@@ -44,8 +45,7 @@ namespace Bili.ViewModels.Uwp.Core
             IDanmakuModuleViewModel danmakuModuleViewModel,
             IInteractionModuleViewModel interactionModuleViewModel,
             ICallerViewModel callerViewModel,
-            IAppViewModel appViewModel,
-            CoreDispatcher dispatcher)
+            IAppViewModel appViewModel)
         {
             _playerProvider = playerProvider;
             _liveProvider = liveProvider;
@@ -57,7 +57,7 @@ namespace Bili.ViewModels.Uwp.Core
             _callerViewModel = callerViewModel;
             _appViewModel = appViewModel;
             _navigationViewModel = navigationViewModel;
-            _dispatcher = dispatcher;
+            _dispatcher = Window.Current.CoreWindow.Dispatcher;
             SubtitleViewModel = subtitleModuleViewModel;
             DanmakuViewModel = danmakuModuleViewModel;
             InteractionViewModel = interactionModuleViewModel;

--- a/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
@@ -186,13 +186,6 @@ namespace Bili.ViewModels.Uwp.Core
 
         private async void OnPlayerPositionChangedAsync(MediaPlaybackSession sender, object args)
         {
-            if (_shouldPreventSkip && Position != TimeSpan.Zero)
-            {
-                _shouldPreventSkip = false;
-                SeekTo(TimeSpan.Zero);
-                return;
-            }
-
             await _dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
             {
                 try

--- a/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.Properties.cs
@@ -27,7 +27,6 @@ namespace Bili.ViewModels.Uwp.Core
         private MediaSource _videoSource;
         private MediaPlaybackItem _videoPlaybackItem;
         private HttpRandomAccessStream _liveStream;
-        private bool _shouldPreventSkip;
 
         /// <inheritdoc/>
         public event EventHandler MediaOpened;

--- a/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NativePlayerViewModel/NativePlayerViewModel.cs
@@ -8,7 +8,7 @@ using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Core;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Graphics.Canvas;
-using Windows.UI.Core;
+using Windows.UI.Xaml;
 
 namespace Bili.ViewModels.Uwp.Core
 {
@@ -22,12 +22,11 @@ namespace Bili.ViewModels.Uwp.Core
         /// </summary>
         public NativePlayerViewModel(
             IFileToolkit fileToolkit,
-            IResourceToolkit resourceToolkit,
-            CoreDispatcher dispatcher)
+            IResourceToolkit resourceToolkit)
         {
             _fileToolkit = fileToolkit;
             _resourceToolkit = resourceToolkit;
-            _dispatcher = dispatcher;
+            _dispatcher = Window.Current.CoreWindow.Dispatcher;
 
             ClearCommand = new RelayCommand(Clear);
         }
@@ -37,7 +36,7 @@ namespace Bili.ViewModels.Uwp.Core
         {
             _video = video;
             _audio = audio;
-            _shouldPreventSkip = true;
+            Clear();
             await LoadDashVideoSourceAsync();
         }
 

--- a/src/ViewModels/ViewModels.Uwp/Core/NavigationViewModel/NavigationViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/NavigationViewModel/NavigationViewModel.cs
@@ -100,6 +100,7 @@ namespace Bili.ViewModels.Uwp.Core
             RemoveBackStack(BackBehavior.OpenPlayer);
             var pageId = GetPageIdFromPlaySnapshot(parameter);
             PlayViewId = pageId;
+            SecondaryViewId = PageIds.None;
             var args = new AppNavigationEventArgs(NavigationType.Player, pageId, parameter);
             AddBackStack(
                     BackBehavior.OpenPlayer,

--- a/src/ViewModels/ViewModels.Uwp/Home/PopularPageViewModel/PopularPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Home/PopularPageViewModel/PopularPageViewModel.cs
@@ -8,7 +8,6 @@ using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Home;
 using Bili.ViewModels.Interfaces.Video;
 using Bili.ViewModels.Uwp.Base;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Home
 {
@@ -22,9 +21,7 @@ namespace Bili.ViewModels.Uwp.Home
         /// </summary>
         public PopularPageViewModel(
             IResourceToolkit resourceToolkit,
-            IHomeProvider homeProvider,
-            CoreDispatcher coreDispatcher)
-            : base(coreDispatcher)
+            IHomeProvider homeProvider)
         {
             _resourceToolkit = resourceToolkit;
             _homeProvider = homeProvider;

--- a/src/ViewModels/ViewModels.Uwp/Home/RankPageViewModel/RankPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Home/RankPageViewModel/RankPageViewModel.cs
@@ -16,6 +16,7 @@ using Bili.ViewModels.Interfaces.Home;
 using Bili.ViewModels.Interfaces.Video;
 using CommunityToolkit.Mvvm.Input;
 using Windows.UI.Core;
+using Windows.UI.Xaml;
 
 namespace Bili.ViewModels.Uwp.Home
 {
@@ -29,15 +30,13 @@ namespace Bili.ViewModels.Uwp.Home
         /// </summary>
         /// <param name="resourceToolkit">本地资源工具.</param>
         /// <param name="homeProvider">分区服务提供工具.</param>
-        /// <param name="dispatcher">UI 调度器.</param>
         public RankPageViewModel(
             IResourceToolkit resourceToolkit,
-            IHomeProvider homeProvider,
-            CoreDispatcher dispatcher)
+            IHomeProvider homeProvider)
         {
             _resourceToolkit = resourceToolkit;
             _homeProvider = homeProvider;
-            _dispatcher = dispatcher;
+            _dispatcher = Window.Current.CoreWindow.Dispatcher;
             _caches = new Dictionary<Partition, IEnumerable<VideoInformation>>();
 
             Videos = new ObservableCollection<IVideoItemViewModel>();

--- a/src/ViewModels/ViewModels.Uwp/Home/RecommendPageViewModel/RecommendPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Home/RecommendPageViewModel/RecommendPageViewModel.cs
@@ -12,7 +12,6 @@ using Bili.ViewModels.Interfaces.Home;
 using Bili.ViewModels.Interfaces.Pgc;
 using Bili.ViewModels.Interfaces.Video;
 using Bili.ViewModels.Uwp.Base;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Home
 {
@@ -26,9 +25,7 @@ namespace Bili.ViewModels.Uwp.Home
         /// </summary>
         public RecommendPageViewModel(
             IResourceToolkit resourceToolkit,
-            IHomeProvider recommendProvider,
-            CoreDispatcher coreDispatcher)
-            : base(coreDispatcher)
+            IHomeProvider recommendProvider)
         {
             _resourceToolkit = resourceToolkit;
             _homeProvider = recommendProvider;

--- a/src/ViewModels/ViewModels.Uwp/Home/SettingsPageViewModel/SettingsPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Home/SettingsPageViewModel/SettingsPageViewModel.cs
@@ -241,7 +241,7 @@ namespace Bili.ViewModels.Uwp.Home
 
         private void PreferQualityInit()
         {
-            if(PreferQualities.Count == 0)
+            if (PreferQualities.Count == 0)
             {
                 PreferQualities.Add(PreferQuality.Auto);
                 PreferQualities.Add(PreferQuality.HDFirst);

--- a/src/ViewModels/ViewModels.Uwp/Live/LiveFeedPageViewModel/LiveFeedPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Live/LiveFeedPageViewModel/LiveFeedPageViewModel.cs
@@ -13,7 +13,6 @@ using Bili.ViewModels.Interfaces.Core;
 using Bili.ViewModels.Interfaces.Live;
 using Bili.ViewModels.Uwp.Base;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Live
 {
@@ -25,17 +24,14 @@ namespace Bili.ViewModels.Uwp.Live
         /// <summary>
         /// Initializes a new instance of the <see cref="LiveFeedPageViewModel"/> class.
         /// </summary>
-        /// <param name="dispatcher">UI调度器.</param>
         /// <param name="liveProvider">直播服务提供工具.</param>
         /// <param name="authorizeProvider">账户服务提供工具.</param>
         /// <param name="resourceToolkit">资源工具.</param>
         public LiveFeedPageViewModel(
-            CoreDispatcher dispatcher,
             ILiveProvider liveProvider,
             IAuthorizeProvider authorizeProvider,
             IResourceToolkit resourceToolkit,
             INavigationViewModel navigationViewModel)
-            : base(dispatcher)
         {
             _liveProvider = liveProvider;
             _authorizeProvider = authorizeProvider;

--- a/src/ViewModels/ViewModels.Uwp/Live/LivePartitionDetailPageViewModel/LivePartitionDetailPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Live/LivePartitionDetailPageViewModel/LivePartitionDetailPageViewModel.cs
@@ -14,7 +14,6 @@ using Bili.ViewModels.Interfaces.Core;
 using Bili.ViewModels.Interfaces.Live;
 using Bili.ViewModels.Uwp.Base;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Live
 {
@@ -33,9 +32,7 @@ namespace Bili.ViewModels.Uwp.Live
         public LivePartitionDetailPageViewModel(
             IResourceToolkit resourceToolkit,
             ILiveProvider liveProvider,
-            CoreDispatcher coreDispatcher,
             INavigationViewModel navigationViewModel)
-            : base(coreDispatcher)
         {
             _resourceToolkit = resourceToolkit;
             _liveProvider = liveProvider;

--- a/src/ViewModels/ViewModels.Uwp/Live/LivePartitionPageViewModel/LivePartitionPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Live/LivePartitionPageViewModel/LivePartitionPageViewModel.cs
@@ -11,6 +11,7 @@ using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Live;
 using CommunityToolkit.Mvvm.Input;
 using Windows.UI.Core;
+using Windows.UI.Xaml;
 
 namespace Bili.ViewModels.Uwp.Live
 {
@@ -24,12 +25,11 @@ namespace Bili.ViewModels.Uwp.Live
         /// </summary>
         public LivePartitionPageViewModel(
             IResourceToolkit resourceToolkit,
-            ILiveProvider liveProvider,
-            CoreDispatcher dispatcher)
+            ILiveProvider liveProvider)
         {
             _resourceToolkit = resourceToolkit;
             _liveProvider = liveProvider;
-            _dispatcher = dispatcher;
+            _dispatcher = Window.Current.CoreWindow.Dispatcher;
 
             ParentPartitions = new ObservableCollection<Partition>();
             DisplayPartitions = new ObservableCollection<Partition>();

--- a/src/ViewModels/ViewModels.Uwp/Live/LivePlayerPageViewModel/LivePlayerPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Live/LivePlayerPageViewModel/LivePlayerPageViewModel.cs
@@ -18,6 +18,7 @@ using Bili.ViewModels.Interfaces.Live;
 using Bili.ViewModels.Uwp.Base;
 using CommunityToolkit.Mvvm.Input;
 using Windows.UI.Core;
+using Windows.UI.Xaml;
 
 namespace Bili.ViewModels.Uwp.Live
 {
@@ -38,8 +39,7 @@ namespace Bili.ViewModels.Uwp.Live
             ICallerViewModel callerViewModel,
             IRecordViewModel recordViewModel,
             IAccountViewModel accountViewModel,
-            IMediaPlayerViewModel mediaPlayerViewModel,
-            CoreDispatcher dispatcher)
+            IMediaPlayerViewModel mediaPlayerViewModel)
         {
             _authorizeProvider = authorizeProvider;
             _liveProvider = liveProvider;
@@ -49,7 +49,7 @@ namespace Bili.ViewModels.Uwp.Live
             _callerViewModel = callerViewModel;
             _recordViewModel = recordViewModel;
             _accountViewModel = accountViewModel;
-            _dispatcher = dispatcher;
+            _dispatcher = Window.Current.CoreWindow.Dispatcher;
 
             Danmakus = new ObservableCollection<LiveDanmakuInformation>();
             Sections = new ObservableCollection<PlayerSectionHeader>

--- a/src/ViewModels/ViewModels.Uwp/Pgc/AnimeFavoriteModuleViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Pgc/AnimeFavoriteModuleViewModel.cs
@@ -4,7 +4,6 @@ using Bili.Lib.Interfaces;
 using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Pgc;
 using Bili.ViewModels.Uwp.Base;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Pgc
 {
@@ -18,9 +17,8 @@ namespace Bili.ViewModels.Uwp.Pgc
         /// </summary>
         public AnimeFavoriteModuleViewModel(
             IFavoriteProvider favoriteProvider,
-            IResourceToolkit resourceToolkit,
-            CoreDispatcher dispatcher)
-            : base(Models.Enums.App.FavoriteType.Anime, favoriteProvider, resourceToolkit, dispatcher)
+            IResourceToolkit resourceToolkit)
+            : base(Models.Enums.App.FavoriteType.Anime, favoriteProvider, resourceToolkit)
         {
         }
     }

--- a/src/ViewModels/ViewModels.Uwp/Pgc/CinemaFavoriteModuleViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Pgc/CinemaFavoriteModuleViewModel.cs
@@ -4,7 +4,6 @@ using Bili.Lib.Interfaces;
 using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Pgc;
 using Bili.ViewModels.Uwp.Base;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Pgc
 {
@@ -18,9 +17,8 @@ namespace Bili.ViewModels.Uwp.Pgc
         /// </summary>
         public CinemaFavoriteModuleViewModel(
             IFavoriteProvider favoriteProvider,
-            IResourceToolkit resourceToolkit,
-            CoreDispatcher dispatcher)
-            : base(Models.Enums.App.FavoriteType.Cinema, favoriteProvider, resourceToolkit, dispatcher)
+            IResourceToolkit resourceToolkit)
+            : base(Models.Enums.App.FavoriteType.Cinema, favoriteProvider, resourceToolkit)
         {
         }
     }

--- a/src/ViewModels/ViewModels.Uwp/Pgc/DocumentaryPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Pgc/DocumentaryPageViewModel.cs
@@ -6,7 +6,6 @@ using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Core;
 using Bili.ViewModels.Interfaces.Pgc;
 using Bili.ViewModels.Uwp.Base;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Pgc
 {
@@ -21,9 +20,8 @@ namespace Bili.ViewModels.Uwp.Pgc
         public DocumentaryPageViewModel(
              IPgcProvider pgcProvider,
              IResourceToolkit resourceToolkit,
-             CoreDispatcher dispatcher,
              INavigationViewModel navigationViewModel)
-             : base(pgcProvider, resourceToolkit, dispatcher, navigationViewModel, PgcType.Documentary)
+             : base(pgcProvider, resourceToolkit, navigationViewModel, PgcType.Documentary)
         {
         }
     }

--- a/src/ViewModels/ViewModels.Uwp/Pgc/IndexPageViewModel/IndexPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Pgc/IndexPageViewModel/IndexPageViewModel.cs
@@ -11,7 +11,6 @@ using Bili.Models.Enums;
 using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Pgc;
 using Bili.ViewModels.Uwp.Base;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Pgc
 {
@@ -25,12 +24,9 @@ namespace Bili.ViewModels.Uwp.Pgc
         /// </summary>
         /// <param name="pgcProvider">PGC 服务提供工具.</param>
         /// <param name="resourceToolkit">资源管理工具.</param>
-        /// <param name="dispatcher">UI 调度器.</param>
         public IndexPageViewModel(
             IPgcProvider pgcProvider,
-            IResourceToolkit resourceToolkit,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            IResourceToolkit resourceToolkit)
         {
             _pgcProvider = pgcProvider;
             _resourceToolkit = resourceToolkit;

--- a/src/ViewModels/ViewModels.Uwp/Pgc/MoviePageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Pgc/MoviePageViewModel.cs
@@ -6,7 +6,6 @@ using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Core;
 using Bili.ViewModels.Interfaces.Pgc;
 using Bili.ViewModels.Uwp.Base;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Pgc
 {
@@ -21,9 +20,8 @@ namespace Bili.ViewModels.Uwp.Pgc
         public MoviePageViewModel(
             IPgcProvider pgcProvider,
             IResourceToolkit resourceToolkit,
-            CoreDispatcher dispatcher,
             INavigationViewModel navigationViewModel)
-            : base(pgcProvider, resourceToolkit, dispatcher, navigationViewModel, PgcType.Movie)
+            : base(pgcProvider, resourceToolkit, navigationViewModel, PgcType.Movie)
         {
         }
     }

--- a/src/ViewModels/ViewModels.Uwp/Pgc/TvPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Pgc/TvPageViewModel.cs
@@ -6,7 +6,6 @@ using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Core;
 using Bili.ViewModels.Interfaces.Pgc;
 using Bili.ViewModels.Uwp.Base;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Pgc
 {
@@ -21,9 +20,8 @@ namespace Bili.ViewModels.Uwp.Pgc
         public TvPageViewModel(
             IPgcProvider pgcProvider,
             IResourceToolkit resourceToolkit,
-            CoreDispatcher dispatcher,
             INavigationViewModel navigationViewModel)
-            : base(pgcProvider, resourceToolkit, dispatcher, navigationViewModel, PgcType.TV)
+            : base(pgcProvider, resourceToolkit, navigationViewModel, PgcType.TV)
         {
         }
     }

--- a/src/ViewModels/ViewModels.Uwp/Search/SearchBoxViewModel/SearchBoxViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Search/SearchBoxViewModel/SearchBoxViewModel.cs
@@ -25,12 +25,11 @@ namespace Bili.ViewModels.Uwp.Search
         /// </summary>
         public SearchBoxViewModel(
             ISearchProvider searchProvider,
-            INavigationViewModel navigationViewModel,
-            CoreDispatcher dispatcher)
+            INavigationViewModel navigationViewModel)
         {
             _searchProvider = searchProvider;
             _navigationViewModel = navigationViewModel;
-            _dispatcher = dispatcher;
+            _dispatcher = Window.Current.CoreWindow.Dispatcher;
 
             HotSearchCollection = new ObservableCollection<SearchSuggest>();
             SearchSuggestion = new ObservableCollection<SearchSuggest>();

--- a/src/ViewModels/ViewModels.Uwp/Search/SearchPageViewModel/SearchPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Search/SearchPageViewModel/SearchPageViewModel.cs
@@ -17,7 +17,6 @@ using Bili.ViewModels.Interfaces.Search;
 using Bili.ViewModels.Interfaces.Video;
 using Bili.ViewModels.Uwp.Base;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Search
 {
@@ -35,9 +34,7 @@ namespace Bili.ViewModels.Uwp.Search
             IHomeProvider homeProvider,
             IArticleProvider articleProvider,
             ISettingsToolkit settingsToolkit,
-            IAppViewModel appViewModel,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            IAppViewModel appViewModel)
         {
             _searchProvider = searchProvider;
             _resourceToolkit = resourceToolkit;

--- a/src/ViewModels/ViewModels.Uwp/Toolbox/AvBvConverterViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Toolbox/AvBvConverterViewModel.cs
@@ -9,6 +9,7 @@ using Bili.ViewModels.Interfaces.Toolbox;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Windows.UI.Core;
+using Windows.UI.Xaml;
 
 namespace Bili.ViewModels.Uwp.Toolbox
 {
@@ -45,8 +46,7 @@ namespace Bili.ViewModels.Uwp.Toolbox
             IResourceToolkit resourceToolkit,
             IVideoToolkit videoToolkit,
             IPlayerProvider playerProvider,
-            IAppViewModel appViewModel,
-            CoreDispatcher dispatcher)
+            IAppViewModel appViewModel)
         {
             _resourceToolkit = resourceToolkit;
             _videoToolkit = videoToolkit;
@@ -56,7 +56,7 @@ namespace Bili.ViewModels.Uwp.Toolbox
 
             AttachIsRunningToAsyncCommand(p => IsConverting = p, ConvertCommand);
             AttachExceptionHandlerToAsyncCommand(DisplayExAsync, ConvertCommand);
-            _dispatcher = dispatcher;
+            _dispatcher = Window.Current.CoreWindow.Dispatcher;
         }
 
         /// <inheritdoc/>

--- a/src/ViewModels/ViewModels.Uwp/Toolbox/CoverDownloaderViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Toolbox/CoverDownloaderViewModel.cs
@@ -11,6 +11,7 @@ using CommunityToolkit.Mvvm.Input;
 using Windows.Storage;
 using Windows.System;
 using Windows.UI.Core;
+using Windows.UI.Xaml;
 
 namespace Bili.ViewModels.Uwp.Toolbox
 {
@@ -43,12 +44,11 @@ namespace Bili.ViewModels.Uwp.Toolbox
         /// </summary>
         public CoverDownloaderViewModel(
              IVideoToolkit videoToolkit,
-             IPlayerProvider playerProvider,
-             CoreDispatcher dispatcher)
+             IPlayerProvider playerProvider)
         {
             _videoToolkit = videoToolkit;
             _playerProvider = playerProvider;
-            _dispatcher = dispatcher;
+            _dispatcher = Window.Current.CoreWindow.Dispatcher;
 
             DownloadCommand = new AsyncRelayCommand(DownloadCoverAsync);
             LoadPreviewCommand = new AsyncRelayCommand(LoadPreviewAsync);

--- a/src/ViewModels/ViewModels.Uwp/Video/VideoFavoriteFolderDetailViewModel/VideoFavoriteFolderDetailViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Video/VideoFavoriteFolderDetailViewModel/VideoFavoriteFolderDetailViewModel.cs
@@ -8,7 +8,6 @@ using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Account;
 using Bili.ViewModels.Interfaces.Video;
 using Bili.ViewModels.Uwp.Base;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Video
 {
@@ -23,9 +22,7 @@ namespace Bili.ViewModels.Uwp.Video
         public VideoFavoriteFolderDetailViewModel(
             IFavoriteProvider favoriteProvider,
             IResourceToolkit resourceToolkit,
-            IAccountViewModel accountViewModel,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            IAccountViewModel accountViewModel)
         {
             _favoriteProvider = favoriteProvider;
             _resourceToolkit = resourceToolkit;

--- a/src/ViewModels/ViewModels.Uwp/Video/VideoFavoriteFolderGroupViewModel/VideoFavoriteFolderGroupViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Video/VideoFavoriteFolderGroupViewModel/VideoFavoriteFolderGroupViewModel.cs
@@ -7,7 +7,6 @@ using Bili.Models.Data.Video;
 using Bili.Toolkit.Interfaces;
 using Bili.ViewModels.Interfaces.Video;
 using Bili.ViewModels.Uwp.Base;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Video
 {
@@ -22,9 +21,7 @@ namespace Bili.ViewModels.Uwp.Video
         public VideoFavoriteFolderGroupViewModel(
             IFavoriteProvider favoriteProvider,
             IResourceToolkit resourceToolkit,
-            IAccountProvider accountProvider,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            IAccountProvider accountProvider)
         {
             _favoriteProvider = favoriteProvider;
             _resourceToolkit = resourceToolkit;

--- a/src/ViewModels/ViewModels.Uwp/Video/VideoFavoriteModuleViewModel/VideoFavoriteModuleViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Video/VideoFavoriteModuleViewModel/VideoFavoriteModuleViewModel.cs
@@ -7,7 +7,6 @@ using Bili.ViewModels.Interfaces.Core;
 using Bili.ViewModels.Interfaces.Video;
 using Bili.ViewModels.Uwp.Base;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Video
 {
@@ -22,9 +21,7 @@ namespace Bili.ViewModels.Uwp.Video
         public VideoFavoriteModuleViewModel(
             INavigationViewModel navigationViewModel,
             IAccountProvider accountProvider,
-            IFavoriteProvider favoriteProvider,
-            CoreDispatcher dispatcher)
-            : base(dispatcher)
+            IFavoriteProvider favoriteProvider)
         {
             _navigationViewModel = navigationViewModel;
             _accountProvider = accountProvider;

--- a/src/ViewModels/ViewModels.Uwp/Video/VideoPartitionDetailPageViewModel/VideoPartitionDetailPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Video/VideoPartitionDetailPageViewModel/VideoPartitionDetailPageViewModel.cs
@@ -14,7 +14,6 @@ using Bili.ViewModels.Interfaces.Common;
 using Bili.ViewModels.Interfaces.Video;
 using Bili.ViewModels.Uwp.Base;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
 
 namespace Bili.ViewModels.Uwp.Community
 {
@@ -28,9 +27,7 @@ namespace Bili.ViewModels.Uwp.Community
         /// </summary>
         public VideoPartitionDetailPageViewModel(
             IResourceToolkit resourceToolkit,
-            IHomeProvider homeProvider,
-            CoreDispatcher coreDispatcher)
-            : base(coreDispatcher)
+            IHomeProvider homeProvider)
         {
             _resourceToolkit = resourceToolkit;
             _homeProvider = homeProvider;

--- a/src/ViewModels/ViewModels.Uwp/Video/VideoPlayerPageViewModel/VideoPlayerPageViewModel.cs
+++ b/src/ViewModels/ViewModels.Uwp/Video/VideoPlayerPageViewModel/VideoPlayerPageViewModel.cs
@@ -18,7 +18,7 @@ using Bili.ViewModels.Interfaces.Core;
 using Bili.ViewModels.Interfaces.Video;
 using Bili.ViewModels.Uwp.Base;
 using CommunityToolkit.Mvvm.Input;
-using Windows.UI.Core;
+using Windows.UI.Xaml;
 
 namespace Bili.ViewModels.Uwp.Video
 {
@@ -42,8 +42,7 @@ namespace Bili.ViewModels.Uwp.Video
             INavigationViewModel navigationViewModel,
             IAccountViewModel accountViewModel,
             IDownloadModuleViewModel downloadViewModel,
-            ICommentPageViewModel commentPageViewModel,
-            CoreDispatcher dispatcher)
+            ICommentPageViewModel commentPageViewModel)
         {
             _playerProvider = playerProvider;
             _authorizeProvider = authorizeProvider;
@@ -56,7 +55,7 @@ namespace Bili.ViewModels.Uwp.Video
             _recordViewModel = recordViewModel;
             _commentPageViewModel = commentPageViewModel;
             _accountViewModel = accountViewModel;
-            _dispatcher = dispatcher;
+            _dispatcher = Window.Current.CoreWindow.Dispatcher;
 
             Collaborators = new ObservableCollection<IUserItemViewModel>();
             Tags = new ObservableCollection<Tag>();

--- a/src/ViewModels/ViewModels.Uwp/ViewModels.Uwp.csproj
+++ b/src/ViewModels/ViewModels.Uwp/ViewModels.Uwp.csproj
@@ -212,20 +212,17 @@
     <PackageReference Include="Humanizer.Core.zh-CN">
       <Version>2.14.1</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection">
-      <Version>6.0.0</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp">
-      <Version>7.1.2</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Connectivity">
-      <Version>7.1.2</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="NLog">
-      <Version>5.0.4</Version>
+      <Version>5.0.5</Version>
     </PackageReference>
     <PackageReference Include="QueryString.NET">
       <Version>1.0.0</Version>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

Microsoft提供的DI库在多次Build时会创建多个实例。这导致本应共享的状态变成多个不同的状态。这在之前造成了上一个视频的播放进度会延续到下一个视频的问题，以及增加内存占用。这次换用了Autofac，并且仅构建一次Composition root.

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
- 重构 （没有功能修改，没有 API 更新）
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

内部状态分叉

## 新的行为是什么？

保持依赖注入的单例

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
