### PR TITLE
修复首页推荐列表鉴权失败问题

### DIFF
--- a/src/Lib/Lib.Implementation/HttpProvider/HttpProvider.cs
+++ b/src/Lib/Lib.Implementation/HttpProvider/HttpProvider.cs
@@ -83,6 +83,8 @@ namespace Bili.Lib
 
                 url += $"?{query}";
                 requestMessage = new HttpRequestMessage(method, url);
+                requestMessage.Headers.Add(Headers.BiliAuroraZone, Headers.BiliAuroraZoneValue);
+                requestMessage.Headers.Add(Headers.BiliAuroraEid, Headers.BiliAuroraEidValue);
             }
             else
             {

--- a/src/Models/Models.App/Constants/ServiceConstants.cs
+++ b/src/Models/Models.App/Constants/ServiceConstants.cs
@@ -229,6 +229,10 @@ namespace Bili.Models.App.Constants
             public const string BiliRestriction = "x-bili-restriction-bin";
             public const string BiliLocale = "x-bili-locale-bin";
             public const string BiliFawkes = "x-bili-fawkes-req-bin";
+            public const string BiliAuroraZone = "x-bili-aurora-zone";
+            public const string BiliAuroraZoneValue = "sh001";
+            public const string BiliAuroraEid = "x-bili-aurora-eid";
+            public const string BiliAuroraEidValue = "UlMFQVcABlAH";
             public const string GRPCAcceptEncodingKey = "grpc-accept-encoding";
             public const string GRPCAcceptEncodingValue = "identity,deflate,gzip";
             public const string GRPCTimeOutKey = "grpc-timeout";


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1615 

<!-- 在上面的 `Close` 标题后添加要修复的 Issue 编号，比如 “Close #1234”，这样在 PR 合并后可以直接关闭 Issue -->

<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

 - Bug 修复 
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

请求首页推荐列表时会频繁得到-663鉴权失败的响应

## 新的行为是什么？

参考这个issue： https://github.com/SocialSisterYi/bilibili-API-collect/issues/533

在请求的header中添加了x-bili-aurora-zone和x-bili-aurora-eid两个参数

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [X] 应用成功启动
- [ ] **不**包含破坏式更新

破坏式更新：直接修改GetRequestMessageAsync方法，其他没问题的请求也加了这两个header

## 备注

修复了请求首页推荐列表的问题，但是还有其他的请求会返回-663错误如#1612、#1609、#1606，暂时没发现还有什么其他的机制会导致这个错误


