### PR TITLE
fix: 修复扫码登录及部分常用接口663响应错误

### DIFF
--- a/src/Lib/Lib.Implementation/ArticleProvider/ArticleProvider.cs
+++ b/src/Lib/Lib.Implementation/ArticleProvider/ArticleProvider.cs
@@ -85,7 +85,7 @@ namespace Bili.Lib
             var uri = partitionId == "0"
                 ? ApiConstants.Article.Recommend
                 : ApiConstants.Article.ArticleList;
-            var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Get, uri, queryParameters);
+            var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Get, uri, queryParameters, RequestClientType.IOS);
             var response = await _httpProvider.SendAsync(request);
             ArticlePartitionView view;
             if (partitionId == "0")

--- a/src/Lib/Lib.Implementation/FavoriteProvider/FavoriteProvider.cs
+++ b/src/Lib/Lib.Implementation/FavoriteProvider/FavoriteProvider.cs
@@ -68,7 +68,7 @@ namespace Bili.Lib
                 { Query.UpId, userId.ToString() },
             };
 
-            var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Get, Account.VideoFavoriteGallery, queryParameters, needToken: true);
+            var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Get, Account.VideoFavoriteGallery, queryParameters, Models.Enums.RequestClientType.IOS, needToken: true);
             var response = await _httpProvider.SendAsync(request);
             var result = await _httpProvider.ParseAsync<ServerResponse<VideoFavoriteGalleryResponse>>(response);
             _videoCollectFolderPageNumber = 1;

--- a/src/Lib/Lib.Implementation/HttpProvider/HttpProvider.cs
+++ b/src/Lib/Lib.Implementation/HttpProvider/HttpProvider.cs
@@ -69,11 +69,30 @@ namespace Bili.Lib
             Dictionary<string, string> queryParams = null,
             RequestClientType clientType = RequestClientType.Android,
             bool needToken = true,
-            string additionalQuery = "")
+            string additionalQuery = "",
+            bool needCookie = false,
+            bool needAppKey = false)
         {
             HttpRequestMessage requestMessage;
 
-            if (method == HttpMethod.Get || method == HttpMethod.Delete)
+            if (method == HttpMethod.Get && needCookie)
+            {
+                if (needAppKey)
+                {
+                    var query = _authenticationProvider.GenerateAuthorizedQueryStringFirstSign(queryParams, clientType);
+                    url += $"?{query}";
+                }
+
+                if (!string.IsNullOrEmpty(additionalQuery))
+                {
+                    url += $"&{additionalQuery}";
+                }
+
+                requestMessage = new HttpRequestMessage(method, url);
+                var cookie = _authenticationProvider.GetCookieString();
+                requestMessage.Headers.Add("Cookie", cookie);
+            }
+            else if (method == HttpMethod.Get || method == HttpMethod.Delete)
             {
                 var query = await _authenticationProvider.GenerateAuthorizedQueryStringAsync(queryParams, clientType, needToken);
                 if (!string.IsNullOrEmpty(additionalQuery))

--- a/src/Lib/Lib.Implementation/LiveProvider/LiveProvider.cs
+++ b/src/Lib/Lib.Implementation/LiveProvider/LiveProvider.cs
@@ -77,7 +77,7 @@ namespace Bili.Lib
                 { Query.ActionKey, Query.AppKey },
             };
 
-            var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Post, Live.EnterRoom, queryParameters);
+            var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Post, Live.EnterRoom, queryParameters, RequestClientType.IOS);
             var response = await _httpProvider.SendAsync(request);
             var data = await _httpProvider.ParseAsync<ServerResponse>(response);
             if (data.IsSuccess())
@@ -218,7 +218,7 @@ namespace Bili.Lib
 
             try
             {
-                var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Post, Live.SendMessage, queryParameter, needToken: true);
+                var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Post, Live.SendMessage, queryParameter, RequestClientType.IOS, needToken: true);
                 var response = await _httpProvider.SendAsync(request);
                 var result = await _httpProvider.ParseAsync<ServerResponse>(response);
                 return result.IsSuccess();

--- a/src/Lib/Lib.Implementation/PlayerProvider/PlayerProvider.Extension.cs
+++ b/src/Lib/Lib.Implementation/PlayerProvider/PlayerProvider.Extension.cs
@@ -113,7 +113,7 @@ namespace Bili.Lib
                 otherQuery = $"area={area}";
             }
 
-            var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Get, url, queryParameters, Models.Enums.RequestClientType.Web, additionalQuery: otherQuery);
+            var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Get, url, queryParameters, Models.Enums.RequestClientType.IOS, additionalQuery: otherQuery);
             var response = await _httpProvider.SendAsync(request);
             var data = await _httpProvider.ParseAsync<ServerResponse<PlayerInformation>, ServerResponse2<PlayerInformation>>(response, (str) =>
             {

--- a/src/Lib/Lib.Implementation/PlayerProvider/PlayerProvider.cs
+++ b/src/Lib/Lib.Implementation/PlayerProvider/PlayerProvider.cs
@@ -292,7 +292,7 @@ namespace Bili.Lib
 
             try
             {
-                var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Post, Video.SendDanmaku, queryParameters, needToken: true);
+                var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Post, Video.SendDanmaku, queryParameters, RequestClientType.IOS, needToken: true);
                 var response = await _httpProvider.SendAsync(request);
                 var result = await _httpProvider.ParseAsync<ServerResponse>(response);
                 return result.IsSuccess();

--- a/src/Lib/Lib.Implementation/PlayerProvider/PlayerProvider.cs
+++ b/src/Lib/Lib.Implementation/PlayerProvider/PlayerProvider.cs
@@ -312,7 +312,7 @@ namespace Bili.Lib
                 { Query.Aid, videoId },
             };
 
-            var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Get, Video.Subtitle, queryParameters);
+            var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Get, Video.Subtitle, queryParameters, RequestClientType.IOS);
             var response = await _httpProvider.SendAsync(request);
             var text = await response.Content.ReadAsStringAsync();
             if (!string.IsNullOrEmpty(text) && text.Contains("subtitle"))

--- a/src/Lib/Lib.Interfaces/IAuthorizeProvider.cs
+++ b/src/Lib/Lib.Interfaces/IAuthorizeProvider.cs
@@ -47,6 +47,22 @@ namespace Bili.Lib.Interfaces
         Task<Dictionary<string, string>> GenerateAuthorizedQueryDictionaryAsync(Dictionary<string, string> queryParameters, RequestClientType clientType, bool needToken = true);
 
         /// <summary>
+        /// 获取包含授权码的查询字典，无token且先加盐.
+        /// </summary>
+        /// <param name="queryParameters">请求所需的查询参数.</param>
+        /// <param name="clientType">请求需要模拟的客户端类型.</param>
+        /// <returns>包含授权验证码的查询字典.</returns>
+        string GenerateAuthorizedQueryStringFirstSign(
+            Dictionary<string, string> queryParameters,
+            RequestClientType clientType);
+
+        /// <summary>
+        /// 获取Cookie字符串.
+        /// </summary>
+        /// <returns>Cookie字符串.</returns>
+        string GetCookieString();
+
+        /// <summary>
         /// 获取当前登录用户的访问令牌.
         /// </summary>
         /// <returns>账户授权的令牌.</returns>

--- a/src/Lib/Lib.Interfaces/IHttpProvider.cs
+++ b/src/Lib/Lib.Interfaces/IHttpProvider.cs
@@ -34,8 +34,10 @@ namespace Bili.Lib.Interfaces
         /// <param name="type">需要模拟的设备类型.</param>
         /// <param name="needToken">是否需要令牌.</param>
         /// <param name="additionalQuery">附加查询参数.</param>
+        /// <param name="needCookie">是否需要cookie.</param>
+        /// <param name="needAppKey">是否需要appKey.</param>
         /// <returns><see cref="HttpRequestMessage"/>.</returns>
-        Task<HttpRequestMessage> GetRequestMessageAsync(HttpMethod method, string url, Dictionary<string, string> queryParams = null, RequestClientType type = RequestClientType.Android, bool needToken = false, string additionalQuery = "");
+        Task<HttpRequestMessage> GetRequestMessageAsync(HttpMethod method, string url, Dictionary<string, string> queryParams = null, RequestClientType type = RequestClientType.Android, bool needToken = false, string additionalQuery = "", bool needCookie = false, bool needAppKey = false);
 
         /// <summary>
         /// 获取 <see cref="HttpRequestMessage"/>.

--- a/src/Models/Models.App/Constants/ApiConstants.cs
+++ b/src/Models/Models.App/Constants/ApiConstants.cs
@@ -17,6 +17,9 @@ namespace Bili.Models.App.Constants
         public const string _bangumiBase = "https://bangumi.bilibili.com";
         public const string _grpcBase = "https://grpc.biliapi.net";
 
+        public const string CookieGetDomain = "https://bilibili.com";
+        public const string CookieSetDomain = "bilibili.com";
+
         public static class Passport
         {
             /// <summary>
@@ -53,6 +56,16 @@ namespace Bili.Models.App.Constants
             /// 登录二维码轮询状态.
             /// </summary>
             public const string QRCodeCheck = _passBase + "/x/passport-tv-login/qrcode/poll";
+
+            /// <summary>
+            /// cookie转访问令牌.
+            /// </summary>
+            public const string LoginAppThird = _passBase + "/login/app/third";
+
+            /// <summary>
+            /// cookie转访问令牌.
+            /// </summary>
+            public const string LoginAppThirdApi = "http://link.acg.tv/forum.php";
         }
 
         public static class Account

--- a/src/Models/Models.App/Constants/ServiceConstants.cs
+++ b/src/Models/Models.App/Constants/ServiceConstants.cs
@@ -40,12 +40,12 @@ namespace Bili.Models.App.Constants
         {
             public const string AndroidKey = "4409e2ce8ffd12b8";
             public const string AndroidSecret = "59b43e04ad6965f34319062b478f83dd";
-            public const string IOSKey = "4ebafd7c4951b366";
-            public const string IOSSecret = "8cb98205e9b2ad3669aad0fce12a4c13";
+            public const string IOSKey = "27eb53fc9058f8c3";
+            public const string IOSSecret = "c2ed53a74eeefe3cf99fbd01d8c9c375";
             public const string WebKey = "84956560bc028eb7";
             public const string WebSecret = "94aba54af9065f71de72f5508f1cd42e";
-            public const string LoginKey = "783bbb7264451d82";
-            public const string LoginSecret = "2653583c8873dea268ab9386918b1d65";
+            public const string LoginKey = "4409e2ce8ffd12b8";
+            public const string LoginSecret = "59b43e04ad6965f34319062b478f83dd";
         }
 
         public static class Query

--- a/src/Models/Models.BiliBili/Authorize/Cookies.cs
+++ b/src/Models/Models.BiliBili/Authorize/Cookies.cs
@@ -34,6 +34,12 @@ namespace Bili.Models.BiliBili
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "expires", Required = Required.Default)]
         public int Expires { get; set; }
+
+        /// <summary>
+        /// 安全.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "secure", Required = Required.Default)]
+        public int Secure { get; set; }
     }
 
     /// <summary>

--- a/src/Models/Models.BiliBili/Authorize/LoginAppThird.cs
+++ b/src/Models/Models.BiliBili/Authorize/LoginAppThird.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Richasy. All rights reserved.
+
+using Newtonsoft.Json;
+
+namespace Bili.Models.BiliBili
+{
+    /// <summary>
+    /// 登录时请求appThird响应信息.
+    /// </summary>
+    public class LoginAppThird
+    {
+        /// <summary>
+        /// api域.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "api_host", Required = Required.Default)]
+        public string ApiHost { get; set; }
+
+        /// <summary>
+        /// 是否登录.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "has_login", Required = Required.Default)]
+        public int HasLogin { get; set; }
+
+        /// <summary>
+        /// 是否直接登录.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "direct_login", Required = Required.Default)]
+        public int DirectLogin { get; set; }
+
+        /// <summary>
+        /// 确认链接.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "confirm_uri", Required = Required.Default)]
+        public string ConfirmUri { get; set; }
+    }
+}

--- a/src/Models/Models.BiliBili/Authorize/TokenInfo.cs
+++ b/src/Models/Models.BiliBili/Authorize/TokenInfo.cs
@@ -33,5 +33,11 @@ namespace Bili.Models.BiliBili
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "expires_in", Required = Required.Default)]
         public int ExpiresIn { get; set; }
+
+        /// <summary>
+        /// Cookies.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "cookie_info", Required = Required.Default)]
+        public CookieInfo CookieInfo { get; set; }
     }
 }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1630

<!-- 在上面的 `Close` 标题后添加要修复的 Issue 编号，比如 “Close #1234”，这样在 PR 合并后可以直接关闭 Issue -->

<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

 - Bug 修复 
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

#1629 #1626 #1627 #1625 #1622 #1623 #1619 #1617 #1615 #1609 #1631
<!-- 请描述应用在你修复之前的行为，或者添加 Issue 链接 -->

## 新的行为是什么？

能够正常登录，正常播放视频
顺便更新了下appKey和appSecret
<!-- 描述你解决了什么问题，现在的行为是什么 -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [ ] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

破坏式更新：
  - 还有些功能涉及到的接口没有测试过是否仍然会响应663
  - 如果后续有其他663错误出现，只需要按如下方式修改发出该请求的GetRequestMessageAsync方法的appKey参数
  ```cs
// 修复前
// var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Get, url, needToken: true);
// 修复后 
var request = await _httpProvider.GetRequestMessageAsync(HttpMethod.Get, url, type: Models.Enums.RequestClientType.IOS, needToken: true);
  ```
<!-- 请添加任何你认为有帮助的信息 -->
