### PR TITLE
修复收藏夹JSON解析失败的问题

### DIFF
--- a/src/Models/Models.BiliBili/Others/VideoFavoriteGalleryResponse.cs
+++ b/src/Models/Models.BiliBili/Others/VideoFavoriteGalleryResponse.cs
@@ -65,19 +65,19 @@ namespace Bili.Models.BiliBili
         /// 收藏夹完整ID.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "id", Required = Required.Default)]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// 收藏夹原始ID.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "fid", Required = Required.Default)]
-        public int OriginId { get; set; }
+        public long OriginId { get; set; }
 
         /// <summary>
         /// 用户ID.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "mid", Required = Required.Default)]
-        public int Mid { get; set; }
+        public long Mid { get; set; }
 
         /// <summary>
         /// 收藏夹标题.
@@ -144,7 +144,7 @@ namespace Bili.Models.BiliBili
         /// 媒体Id.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "id", Required = Required.Default)]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// 媒体类型，2-视频，12-音频，21-视频合集.
@@ -210,19 +210,19 @@ namespace Bili.Models.BiliBili
         /// 创建时间.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "ctime", Required = Required.Default)]
-        public int CreateTime { get; set; }
+        public long CreateTime { get; set; }
 
         /// <summary>
         /// 发布时间.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "pubtime", Required = Required.Default)]
-        public int PublishTime { get; set; }
+        public long PublishTime { get; set; }
 
         /// <summary>
         /// 收藏时间.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "fav_time", Required = Required.Default)]
-        public int FavoriteTime { get; set; }
+        public long FavoriteTime { get; set; }
 
         /// <summary>
         /// Bv Id.
@@ -285,7 +285,7 @@ namespace Bili.Models.BiliBili
         /// 收藏夹所属分类Id.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "id", Required = Required.Default)]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// 分类名.


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

修复收藏夹JSON解析失败的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复 -->
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

在进行反序列化的时候，有可能会出现由于媒体id过大导致无法解析的情况

## 新的行为是什么？

修复此问题

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
