### PR TITLE
修復跳轉分 P 後不再阻止系統休眠的問題

### DIFF
--- a/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
+++ b/src/ViewModels/ViewModels.Uwp/Core/MediaPlayerViewModel/MediaPlayerViewModel.Video.cs
@@ -30,6 +30,7 @@ namespace Bili.ViewModels.Uwp.Core
             ResetMediaData();
             await LoadVideoAsync();
             StartTimers();
+            InitializeSmtc();
         }
 
         private async Task LoadVideoAsync()


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #1473 

<!-- 在上面的 `Close` 标题后添加要修复的 Issue 编号，比如 “Close #1234”，这样在 PR 合并后可以直接关闭 Issue -->

<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

<!-- 请描述应用在你修复之前的行为，或者添加 Issue 链接 -->
https://github.com/Richasy/Bili.Uwp/issues/1473

`_systemMediaTransportControls` 在跳轉分 P 後會被重製為 null，因此阻止系統休眠/系統播放控件不再生效

## 新的行为是什么？

<!-- 描述你解决了什么问题，现在的行为是什么 -->
`_systemMediaTransportControls` 現在會被重新初始化，以此再次阻止系統休眠並正確設置系統播放控件

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
這個算是個臨時的解法，我覺得更好的是同一個影片的不同分段共用一個 `_systemMediaTransportControls`，set/reset 僅會發生在進入/離開播放頁時發生，可以稍微減少資源占用，不過代碼修改會稍大一些。
