### PR TITLE
解析某些直播间描述中的html标签内容为纯文本

### DIFF
--- a/src/Models/Models.Data/Live/LiveInformation.cs
+++ b/src/Models/Models.Data/Live/LiveInformation.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Bili.Models.Data.User;
 using Bili.Models.Data.Video;
 using Bili.Models.Enums.Community;
+using HtmlAgilityPack;
 
 namespace Bili.Models.Data.Live
 {
@@ -34,7 +35,7 @@ namespace Bili.Models.Data.Live
             ViewerCount = viewerCount;
             Relation = relation;
             Subtitle = subtitle;
-            Description = description;
+            Description = ParseDescription(description);
         }
 
         /// <inheritdoc/>
@@ -70,5 +71,17 @@ namespace Bili.Models.Data.Live
 
         /// <inheritdoc/>
         public override int GetHashCode() => Identifier.GetHashCode();
+
+        private string ParseDescription(string description)
+        {
+            if (description == null)
+            {
+                return null;
+            }
+
+            var document = new HtmlDocument();
+            document.LoadHtml(description);
+            return document.DocumentNode.InnerText;
+        }
     }
 }

--- a/src/Models/Models.Data/Models.Data.csproj
+++ b/src/Models/Models.Data/Models.Data.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -6,6 +6,10 @@
     <AssemblyName>Bili.$(MSBuildProjectName)</AssemblyName>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Models.Enums\Models.Enums.csproj" />


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

<!-- 在上面的 `Close` 标题后添加要修复的 Issue 编号，比如 “Close #1234”，这样在 PR 合并后可以直接关闭 Issue -->

<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
功能 
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- -其他，请描述内容：-->

解析某些直播间的介绍文字中html标签内容为纯文本字符

## 当前行为是什么？

某些直播间的描述为html标签文本，比如key725的直播间。在直播间的介绍中会显示html标签，如<p>xxxx</p>

## 新的行为是什么？

解析html标签获取到纯文本。如原文本为<p>xxxx</p>，解析后为xxxx

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [ ] 新组件
  - [ ] 已经准备了关于新组件的说明文档，文档链接：[link]()
  - [ ] 对于控件，已将控件放在主项目的 Controls 文件夹内
- [ ] 主要的功能修改已经添加至 [Wiki](https://github.com/Richasy/Bili.Uwp/wiki)
- [ ] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->

**根据情况决定是否需要合并吧**

使用了html解析库[HtmlAgilityPack](https://html-agility-pack.net/)。

此功能解析后实际会造成某些直播间通过本app观看时，其描述和web端的有区别。比如我上面举例的key725的直播间描述，实际的web端展示的为
``` txt
<p>前Snake守望分部职业选手 担任射击C位 国内暴雪黄金联赛3强 亚洲Apac国际赛6强 </p> <p>直播通知群（禁言）：1076440489<br>yumi小姐姐的录播组账号：老Key直播录播組<br>每晚9点B站直播，偶尔会鸽，群内通知！</p> <p>主播配置：3080 12900kf 64g 鼠标g903 键盘G610 耳机800s 采集卡双机直播</p>
```
解析后变成了
```txt
前Snake守望分部职业选手 担任射击C位 国内暴雪黄金联赛3强 亚洲Apac国际赛6强 
直播通知群（禁言）：1076440489yumi小姐姐的录播组账号：老Key直播录播組每晚9点B站直播，偶尔会鸽，群内通知！
主播配置：3080 12900kf 64g 鼠标g903 键盘G610 耳机800s 采集卡双机直播
```
app上展示没有html标签，看起来更美观。当然，如果从是数据方面来看，实际上这个是破坏了原始数据。